### PR TITLE
crypto-tests: support trailing newlines in the new_tests! macro

### DIFF
--- a/crypto-tests/src/hash.rs
+++ b/crypto-tests/src/hash.rs
@@ -17,6 +17,7 @@ macro_rules! new_tests {
             },
         )*]
     };
+    ( $( $name:expr ),+, ) => (new_tests!($($name),+))
 }
 
 pub fn main_test<D: Digest + Default>(tests: &[Test]) {


### PR DESCRIPTION
The `new_tests!` macro can now be used with a trailing new line, i.e.:
```
new_tests!(
    "test1",
    "test2",
);
```