### PR TITLE
fix the buffer at the beginning of the struct

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Fixed size buffer for block processing of data"

--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -11,8 +11,10 @@ use generic_array::{GenericArray, ArrayLength};
 use core::slice;
 
 /// Buffer for block processing of data
+#[repr(C)]
 #[derive(Clone, Default)]
 pub struct BlockBuffer<BlockSize: ArrayLength<u8>>  {
+    // important: buffer must be the first field for predictable alignment
     buffer: GenericArray<u8, BlockSize>,
     pos: usize,
 }


### PR DESCRIPTION
This allows the owner of a BlockBuffer to control the alignment of its
data, e.g. to use `movaps` instead of `movups`.