### PR TITLE
allow control of buffer alignment

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Fixed size buffer for block processing of data"

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -14,6 +14,7 @@ byteorder = { version = "1", default-features = false }
 byte-tools = "0.3"
 block-padding = "0.1"
 generic-array = "0.12"
+alignas = "0.2"
 
 [badges]
 travis-ci = { repository = "RustCrypto/utils" }


### PR DESCRIPTION
Create a new API, AlignedBuffer, that is parameterized by a type used only for its alignment requirement. The BlockBuffer type becomes an alias for a u8-aligned AlignedBuffer.

I think it would be better to pass an &AlignAs<GenericArray> to the user callback to document the guarantees offered, but that would either be a breaking change or require a wrapper, and i'm not sure either is worth it: as it is, this PR adds alignment guarantees while remaining a drop-in replacement for the u8-aligned original.