### PR TITLE
Removes unnecessary backtick from hex-literal doc

### DIFF
--- a/hex-literal/src/lib.rs
+++ b/hex-literal/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! - `'0'...'9'`, `'a'...'f'`, `'A'...'F'` — hex characters which will be used
 //!     in construction of the output byte array
-//! - `' '`, `'\r'`, `'\n'`, `'\t'`` — formatting characters which will be
+//! - `' '`, `'\r'`, `'\n'`, `'\t'` — formatting characters which will be
 //!     ignored
 //!
 //! # Examples


### PR DESCRIPTION
The extra backtick breaks formatting in docs.rs