### PR TITLE
Make block-buffer minimal-versions correct

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["block", "buffer"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-byteorder = { version = "1", default-features = false }
+byteorder = { version = "1.1", default-features = false }
 byte-tools = "0.3"
 block-padding = "0.1"
 generic-array = "0.12"


### PR DESCRIPTION
byteorder:1.0.0 does not export byteorder::BE.
It was added in byteorder:1.1.0.

Noticed in https://github.com/pest-parser/pest/pull/390.