### PR TITLE
Fix minimal version of byteorder.

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["block", "buffer"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-byteorder = { version = "1", default-features = false }
+byteorder = { version = "1.1", default-features = false }
 byte-tools = "0.3"
 block-padding = "0.1"
 generic-array = "0.12"


### PR DESCRIPTION
block-buffer fails to build with cargo -Z minimal-versions since it's relying
on an [alias] from byteorder that was made available only in 1.1.

[alias]: https://github.com/RustCrypto/utils/blob/master/block-buffer/src/lib.rs#L7