### PR TITLE
Don't depend on user crate's std feature

### DIFF
--- a/opaque-debug/src/lib.rs
+++ b/opaque-debug/src/lib.rs
@@ -1,6 +1,9 @@
 //! Macro for opaque `Debug` trait implementation.
 #![no_std]
 
+#[doc(hidden)]
+pub extern crate core as __core;
+
 /// Macro for defining opaque `Debug` implementation.
 ///
 /// It will use the following format: "StructName { ... }". While it's
@@ -10,19 +13,9 @@
 #[macro_export]
 macro_rules! impl_opaque_debug {
     ($struct:ty) => {
-        #[cfg(feature = "std")]
-        impl ::std::fmt::Debug for $struct {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter)
-                -> Result<(), ::std::fmt::Error>
-            {
-                write!(f, concat!(stringify!($struct), " {{ ... }}"))
-            }
-        }
-
-        #[cfg(not(feature = "std"))]
-        impl ::core::fmt::Debug for $struct {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter)
-                -> Result<(), ::core::fmt::Error>
+        impl $crate::__core::fmt::Debug for $struct {
+            fn fmt(&self, f: &mut $crate::__core::fmt::Formatter)
+                -> Result<(), $crate::__core::fmt::Error>
             {
                 write!(f, concat!(stringify!($struct), " {{ ... }}"))
             }


### PR DESCRIPTION
This avoids a compiler error when used with edition 2015 std crates that don't have an std feature.