### PR TITLE
add no_std to hex-literal

### DIFF
--- a/hex-literal/src/lib.rs
+++ b/hex-literal/src/lib.rs
@@ -27,6 +27,7 @@
 //! ```
 #![doc(html_logo_url =
     "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![no_std]
 
 use proc_macro_hack::proc_macro_hack;
 #[doc(hidden)]


### PR DESCRIPTION
When including this library in a crate with `#![no_std]` forces the std library to be included. Thanks!