### PR TITLE
Remove unsafe{} code from the byte-tools crate

### DIFF
--- a/byte-tools/src/lib.rs
+++ b/byte-tools/src/lib.rs
@@ -6,7 +6,8 @@
 #[inline(always)]
 pub fn copy(src: &[u8], dst: &mut [u8]) {
     assert!(dst.len() >= src.len());
-    dst[..src.len()].copy_from_slice(src);
+    let dst = &mut dst[..src.len()]; // make sure that dst is the same length as src
+    dst.copy_from_slice(src);        // as it is required by copy_from_slice
 }
 
 /// Zero all bytes in `dst`

--- a/byte-tools/src/lib.rs
+++ b/byte-tools/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-use core::ptr;
 
 /// Copy bytes from `src` to `dst`
 ///
@@ -7,23 +6,19 @@ use core::ptr;
 #[inline(always)]
 pub fn copy(src: &[u8], dst: &mut [u8]) {
     assert!(dst.len() >= src.len());
-    unsafe {
-        ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), src.len());
-    }
+    dst[..src.len()].copy_from_slice(src);
 }
 
 /// Zero all bytes in `dst`
 #[inline(always)]
 pub fn zero(dst: &mut [u8]) {
-    unsafe {
-        ptr::write_bytes(dst.as_mut_ptr(), 0, dst.len());
-    }
+    set(dst, 0);
 }
 
 /// Sets all bytes in `dst` equal to `value`
 #[inline(always)]
 pub fn set(dst: &mut [u8], value: u8) {
-    unsafe {
-        ptr::write_bytes(dst.as_mut_ptr(), value, dst.len());
+    for elem in dst.iter_mut() {
+        *elem = value;
     }
 }


### PR DESCRIPTION
While the current unsafe code is sound, it is possible to express `byte-tools`'s functions without using unsafe blocks.

This change should not have a significant performance impact in release mode, but the `zero` and `set` functions will be slower in debug mode.