### PR TITLE
Bump generic array

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 byteorder = { version = "1.1", default-features = false }
 byte-tools = "0.3"
 block-padding = "0.1"
-generic-array = "0.12"
+generic-array = "0.13"
 
 [badges]
 travis-ci = { repository = "RustCrypto/utils" }

--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -8,7 +8,6 @@ use byteorder::{ByteOrder, BE};
 use byte_tools::zero;
 use block_padding::{Padding, PadError};
 use generic_array::{GenericArray, ArrayLength};
-use core::slice;
 
 /// Buffer for block processing of data
 #[derive(Clone, Default)]


### PR DESCRIPTION
One of my projects has a bunch of duplicate versions of generic-array, through block-buffer (from sha-2), crypto-mac (through hmac) and digest (through hmac and sha2) -- all of them through usage in postgres-protocol. Here's a start at fixing this up.