### PR TITLE
collectable: borrow iterators rather than consume them

### DIFF
--- a/collectable/src/lib.rs
+++ b/collectable/src/lib.rs
@@ -41,16 +41,16 @@ pub trait TryExtend<A> {
     type Error;
 
     /// Try to extend the collection from the given iterator.
-    fn try_extend<T>(&mut self, iter: T) -> Result<(), Self::Error>
+    fn try_extend<T>(&mut self, iter: &mut T) -> Result<(), Self::Error>
     where
-        T: IntoIterator<Item = A>;
+        T: Iterator<Item = A>;
 
     /// Try to extend the collection from the given slice.
     fn try_extend_from_slice(&mut self, slice: &[A]) -> Result<(), Self::Error>
     where
-        A: Clone
+        A: Clone,
     {
-        self.try_extend(slice.into_iter().cloned())
+        self.try_extend(&mut slice.iter().cloned())
     }
 }
 
@@ -64,17 +64,17 @@ pub trait TryFromIterator<A>: Sized {
 
     /// Try to create a new collection from the given iterator, potentially
     /// returning an error if the underlying collection's capacity is exceeded.
-    fn try_from_iter<T>(iter: T) -> Result<Self, Self::Error>
+    fn try_from_iter<T>(iter: &mut T) -> Result<Self, Self::Error>
     where
-        T: IntoIterator<Item = A>;
+        T: Iterator<Item = A>;
 }
 
 impl<A, C: Default + TryExtend<A>> TryFromIterator<A> for C {
     type Error = <Self as TryExtend<A>>::Error;
 
-    fn try_from_iter<T>(iter: T) -> Result<Self, Self::Error>
+    fn try_from_iter<T>(iter: &mut T) -> Result<Self, Self::Error>
     where
-        T: IntoIterator<Item = A>,
+        T: Iterator<Item = A>,
     {
         let mut collection = Self::default();
         collection.try_extend(iter)?;
@@ -92,13 +92,13 @@ pub trait TryCollect<A> {
 
 impl<A, T> TryCollect<A> for T
 where
-    T: Iterator<Item = A>
+    T: Iterator<Item = A>,
 {
-    fn try_collect<B>(self) -> Result<B, B::Error>
+    fn try_collect<B>(mut self) -> Result<B, B::Error>
     where
-        B: TryFromIterator<A>
+        B: TryFromIterator<A>,
     {
-        B::try_from_iter(self)
+        B::try_from_iter(&mut self)
     }
 }
 


### PR DESCRIPTION
The previous APIs consumed the underlying iterators even in the event there was insufficient capacity in the collection.

By borrowing them rather than consuming them, we can leave the unconsumed elements in the iterator rather than losing them.