### PR TITLE
collectable: have TryCollect borrow iterator

### DIFF
--- a/collectable/src/lib.rs
+++ b/collectable/src/lib.rs
@@ -96,7 +96,7 @@ pub trait TryPush<T> {
 /// [`TryCollect`] is an extension to [`Iterator`] which allows for performing
 /// a fallible collection into a collection type.
 pub trait TryCollect<A> {
-    fn try_collect<B>(self) -> Result<B, B::Error>
+    fn try_collect<B>(&mut self) -> Result<B, B::Error>
     where
         B: TryFromIterator<A>;
 }
@@ -105,11 +105,11 @@ impl<A, T> TryCollect<A> for T
 where
     T: Iterator<Item = A>,
 {
-    fn try_collect<B>(mut self) -> Result<B, B::Error>
+    fn try_collect<B>(&mut self) -> Result<B, B::Error>
     where
         B: TryFromIterator<A>,
     {
-        B::try_from_iter(&mut self)
+        B::try_from_iter(self)
     }
 }
 


### PR DESCRIPTION
This finishes out the changes from #44 by borrowing the iterator when `try_collect()`ing it.

This allows potentially recovering the values within an iterator if the `try_collect()` operation fails.