### PR TITLE
collectable v0.0.2

### DIFF
--- a/collectable/CHANGELOG.md
+++ b/collectable/CHANGELOG.md
@@ -4,5 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.2 (2020-05-24)
+### Added
+- `TryPush` trait ([#45])
+
+### Changed
+- Borrow iterators rather than consume them ([#44], [#46])
+
+[#46]: https://github.com/RustCrypto/utils/pull/46
+[#45]: https://github.com/RustCrypto/utils/pull/45
+[#44]: https://github.com/RustCrypto/utils/pull/44
+
 ## 0.0.1 (2020-05-24)
 - Initial release

--- a/collectable/Cargo.toml
+++ b/collectable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "collectable"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"


### PR DESCRIPTION
### Added
- `TryPush` trait ([#45])

### Changed
- Borrow iterators rather than consume them ([#44], [#46])

[#46]: https://github.com/RustCrypto/utils/pull/46
[#45]: https://github.com/RustCrypto/utils/pull/45
[#44]: https://github.com/RustCrypto/utils/pull/44