### PR TITLE
block-buffer: bump generic array to v0.14

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 byteorder = { version = "1.1", default-features = false }
 byte-tools = "0.3"
 block-padding = "0.1"
-generic-array = "0.13"
+generic-array = "0.14"
 
 [badges]
 travis-ci = { repository = "RustCrypto/utils" }


### PR DESCRIPTION
The `RustCrypto/traits` and `RustCrypto/block-ciphers` repos are both bumped to this version already.