### PR TITLE
block-buffer v0.9.0 and block-padding v0.2.0

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.9.0-pre"
+version = "0.9.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Fixed size buffer for block processing of data"

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.2.0-pre"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Padding and unpadding of messages divided into blocks."


### PR DESCRIPTION
The crates have been tested as part of RustCrypto/hashes#164.