### PR TITLE
opaque-debug v0.3.0

### DIFF
--- a/opaque-debug/Cargo.toml
+++ b/opaque-debug/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "opaque-debug"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Macro for opaque Debug trait implementation"
 documentation = "https://docs.rs/opaque-debug"
 repository = "https://github.com/RustCrypto/utils"
-
-[dependencies]
+edition = "2018"

--- a/opaque-debug/src/lib.rs
+++ b/opaque-debug/src/lib.rs
@@ -11,7 +11,7 @@ pub extern crate core as __core;
 /// undesirable to leak internal state, which can happen for example through
 /// uncareful logging.
 #[macro_export]
-macro_rules! impl_opaque_debug {
+macro_rules! implement {
     ($struct:ty) => {
         impl $crate::__core::fmt::Debug for $struct {
             fn fmt(&self, f: &mut $crate::__core::fmt::Formatter)

--- a/opaque-debug/tests/mod.rs
+++ b/opaque-debug/tests/mod.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+struct Foo {
+    secret: u64,
+}
+
+opaque_debug::implement!(Foo);
+
+#[test]
+fn debug_formatting() {
+    let s = format!("{:?}", Foo { secret: 42 });
+    assert_eq!(s, "Foo { ... }");
+}


### PR DESCRIPTION
The macro is renamed to `implement`, which allows to use `opaque_debug::implement!(Foo);`. Additionally the crate is migrated to 2018 edition and a simple test is added.