### PR TITLE
blobby v0.2

### DIFF
--- a/blobby/CHANGELOG.md
+++ b/blobby/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.2.0 (2020-06-13)
-### Changed
-- Added `Blob5Iterator`.
+### Added
+- `Blob5Iterator`
 
 ### Changed
 - Bumped MSRV to 1.34.

--- a/blobby/CHANGELOG.md
+++ b/blobby/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 (2020-06-13)
+### Changed
+- Added `Blob5Iterator`.
+
+### Changed
+- Bumped MSRV to 1.34.
+- Removed `byteorder` from non-dev dependencies.
+
+## 0.1.2 (2019-01-28)
+
+## 0.1.1 (2018-09-26)
+
+## 0.1.0 (2018-09-26)
+- Initial release

--- a/blobby/Cargo.toml
+++ b/blobby/Cargo.toml
@@ -1,19 +1,14 @@
 [package]
 name = "blobby"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Iterator over simple binary blob storage"
 documentation = "https://docs.rs/blobby"
 repository = "https://github.com/RustCrypto/utils"
 categories = ["no-std"]
-
-[dependencies]
-byteorder = { version = "1", default-features = false }
+edition = "2018"
 
 [dev-dependencies]
 hex = "0.3"
 byteorder = { version = "1", features = ["std"] }
-
-[badges]
-travis-ci = { repository = "RustCrypto/utils" }

--- a/blobby/examples/convert.rs
+++ b/blobby/examples/convert.rs
@@ -1,19 +1,12 @@
-//! Convert
-extern crate hex;
-extern crate blobby;
-extern crate byteorder;
-
-use std::env;
-use std::error::Error;
-use std::fs::File;
-use std::io;
-use std::io::{Write, BufRead, BufReader, BufWriter};
+//! Convert utility
+use std::{env, error::Error, fs::File};
+use std::io::{self, Write, BufRead, BufReader, BufWriter};
 use std::{u8, u16, u32};
 
-use byteorder::{LE, WriteBytesExt};
+use byteorder::{WriteBytesExt, LE};
 use blobby::BlobIterator;
 
-fn encode<R: BufRead, W: Write>(reader: R, mut writer: W)
+fn encode(reader: impl BufRead, mut writer: impl Write)
     -> io::Result<usize>
 {
     let mut res = Vec::new();
@@ -62,7 +55,7 @@ fn decode<R: BufRead, W: Write>(mut reader: R, mut writer: W)
     Ok(res.len())
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().skip(1).collect();
     let is_encode = match args[0].as_str() {
         "encode" => true,
@@ -80,7 +73,7 @@ fn main() -> Result<(), Box<Error>> {
         decode(in_file, out_file)?
     };
 
-    println!("Processed {} record(s)", n);;
+    println!("Processed {} record(s)", n);
 
     Ok(())
 }


### PR DESCRIPTION
Added `Blob5Iterator` (I plan to use it for AEAD), removed `byteroder` from non-dev dependencies, bumped to 2018 edition.

Apart from the MSRV bump v0.2 is fully compatible with v0.1.