### PR TITLE
Fix MSRV tests

### DIFF
--- a/.github/workflows/blobby.yml
+++ b/.github/workflows/blobby.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.36.0 # MSRV
+          - 1.39.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/cpuid-bool.yml
+++ b/.github/workflows/cpuid-bool.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.32.0 # MSRV
+          - 1.39.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
+checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
 dependencies = [
  "typenum",
  "version_check",

--- a/blobby/examples/convert.rs
+++ b/blobby/examples/convert.rs
@@ -71,7 +71,7 @@ fn encode(reader: impl BufRead, mut writer: impl Write) -> io::Result<usize> {
 
     for blob in blobs.iter() {
         if let Some(dup_pos) = rev_idx.get(blob.as_slice()) {
-            let n = (dup_pos << 1) + 1;
+            let n = (dup_pos << 1) + 1usize;
             writer.write_all(encode_vlq(n, &mut buf))?;
         } else {
             let n = blob.len() << 1;


### PR DESCRIPTION
Only Rust 1.39 will be tested, even though `blobby` and `cpuid-bool` should work on earlier versions (1.36 and 1.32 respectively).

Closes #71.