### PR TITLE
const-oid validation

### DIFF
--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.39.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.39.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41.0
+        toolchain: 1.46.0
         components: clippy
     - run: cargo clippy --all --all-features -- -D warnings
   rustfmt:

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -5,6 +5,18 @@
 //!
 //! It has full `no_std` support with no dependencies on a heap/liballoc and
 //! stores OID values as static data.
+//!
+//! # About OIDs
+//!
+//! Object Identifiers, a.k.a. OIDs, are an International Telecommunications Union (ITU) and
+//! ISO/IEC standard for naming any object, concept, or "thing" with a globally unambiguous
+//! persistent name.
+//!
+//! See also: https://en.wikipedia.org/wiki/Object_identifier
+//!
+//! # Minimum Supported Rust Version
+//!
+//! This crate requires **Rust 1.46** at a minimum.
 
 #![no_std]
 #![doc(
@@ -27,7 +39,25 @@ pub struct ObjectIdentifier {
 
 impl ObjectIdentifier {
     /// Create a new OID
+    #[allow(clippy::no_effect)]
     pub const fn new(nodes: &'static [u32]) -> Self {
+        // TODO(tarcieri): replace this with const panic when OIDs are invalid
+        // See: https://github.com/rust-lang/rust/issues/51999
+        let mut is_invalid = nodes.len() <= 2;
+
+        match nodes[0] {
+            0..=2 => (),
+            _ => is_invalid = true,
+        }
+
+        match nodes[1] {
+            0..=39 => {}
+            _ => is_invalid = true,
+        }
+
+        // TODO(tarcieri): better error message
+        ["invalid OID"][is_invalid as usize];
+
         Self { nodes }
     }
 }
@@ -63,5 +93,23 @@ mod tests {
     fn display_test() {
         let oid = EXAMPLE_OID.to_string();
         assert_eq!(oid, "1.2.840.10045.3.1.7");
+    }
+
+    #[test]
+    #[should_panic]
+    fn truncated_oid_test() {
+        ObjectIdentifier::new(&[1, 2]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_first_node_test() {
+        ObjectIdentifier::new(&[3, 2, 840, 10045, 3, 1, 7]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_second_node_test() {
+        ObjectIdentifier::new(&[1, 40, 840, 10045, 3, 1, 7]);
     }
 }


### PR DESCRIPTION
~~Attempting to use the new `const fn` features set to ship in 1.46, however it seems this may not be a good idea until const panic support ships and malformed OIDs can panic at compile time~~

Uses a workaround proposed by @rodrimati1992 below to allow a limited degree of compile-time const OID validation when used in a `const` context (which is what this crate is designed for, after all).