### PR TITLE
block-padding: derive Copy, Clone, and Debug traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "collectable"

--- a/block-padding/CHANGELOG.md
+++ b/block-padding/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.1 (2020-08-14)
+### Added
+- `Copy`, `Clone`, and `Debug` trait implementations for padding types ([#76])
+
+[#76]: https://github.com/RustCrypto/utils/pull/76
+
+## 0.2.0 (2020-07-10)

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Padding and unpadding of messages divided into blocks."

--- a/block-padding/src/lib.rs
+++ b/block-padding/src/lib.rs
@@ -71,6 +71,7 @@ pub trait Padding {
 ///
 /// Note that zero padding may not be reversible if the original message ends
 /// with one or more zero bytes.
+#[derive(Clone, Copy, Debug)]
 pub enum ZeroPadding {}
 
 impl Padding for ZeroPadding {
@@ -147,6 +148,7 @@ impl Padding for ZeroPadding {
 /// In addition to conditions stated in the `Padding` trait documentation,
 /// `pad_block` will return `PadError` if `block.len() > 255`, and in case of
 /// `pad` if `block_size > 255`.
+#[derive(Clone, Copy, Debug)]
 pub enum Pkcs7 {}
 
 impl Padding for Pkcs7 {
@@ -213,6 +215,7 @@ impl Padding for Pkcs7 {
 /// In addition to conditions stated in the `Padding` trait documentation,
 /// `pad_block` will return `PadError` if `block.len() > 255`, and in case of
 /// `pad` if `block_size > 255`.
+#[derive(Clone, Copy, Debug)]
 pub enum AnsiX923 {}
 
 impl Padding for AnsiX923 {
@@ -270,6 +273,7 @@ impl Padding for AnsiX923 {
 /// assert_eq!(padded_msg, b"test\x80\x00");
 /// assert_eq!(Iso7816::unpad(&padded_msg).unwrap(), msg);
 /// ```
+#[derive(Clone, Copy, Debug)]
 pub enum Iso7816 {}
 
 impl Padding for Iso7816 {
@@ -324,6 +328,7 @@ impl Padding for Iso7816 {
 /// assert_eq!(padded_msg, b"test");
 /// assert_eq!(NoPadding::unpad(&padded_msg).unwrap(), msg);
 /// ```
+#[derive(Clone, Copy, Debug)]
 pub enum NoPadding {}
 
 impl Padding for NoPadding {


### PR DESCRIPTION
This primarily needed for correct deriving of `Clone` for block modes.