### PR TITLE
pkcs8: rename AlgorithmIdentifier `algorithm` field => `oid`

### DIFF
--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -16,7 +16,9 @@ use core::convert::TryFrom;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct AlgorithmIdentifier {
     /// Algorithm OID.
-    pub algorithm: ObjectIdentifier,
+    ///
+    /// This is the `algorithm` field in the `AlgorithmIdentifier` ASN.1 schema.
+    pub oid: ObjectIdentifier,
 
     /// Algorithm parameters.
     ///

--- a/pkcs8/src/asn1.rs
+++ b/pkcs8/src/asn1.rs
@@ -124,7 +124,7 @@ pub(crate) fn parse_algorithm_identifier(input: &mut &[u8]) -> Result<AlgorithmI
     };
 
     Ok(AlgorithmIdentifier {
-        algorithm,
+        oid: algorithm,
         parameters,
     })
 }

--- a/pkcs8/tests/lib.rs
+++ b/pkcs8/tests/lib.rs
@@ -21,10 +21,7 @@ const RSA_2048_PEM_EXAMPLE: &str = include_str!("examples/rsa2048.pem");
 fn parse_ec_p256_der() {
     let pk_info = PrivateKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
 
-    assert_eq!(
-        pk_info.algorithm.algorithm,
-        "1.2.840.10045.2.1".parse().unwrap()
-    );
+    assert_eq!(pk_info.algorithm.oid, "1.2.840.10045.2.1".parse().unwrap());
 
     assert_eq!(
         pk_info.algorithm.parameters.unwrap(),
@@ -41,7 +38,7 @@ fn parse_rsa_2048_der() {
     let pk_info = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
 
     assert_eq!(
-        pk_info.algorithm.algorithm,
+        pk_info.algorithm.oid,
         "1.2.840.113549.1.1.1".parse().unwrap()
     );
 


### PR DESCRIPTION
Otherwise it's referenced as `private_key_info.algorithm.algorithm` which feels redundant.

This doesn't technically match the name in the ASN.1 schema, however the documentation addresses that.