### PR TITLE
pkcs8: extract `Document` type

### DIFF
--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --release --target ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }} --features alloc
       - run: cargo build --release --target ${{ matrix.target }} --features pem
 
   test:
@@ -53,5 +54,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
+      - run: cargo test --release --features alloc
       - run: cargo test --release --features pem
       - run: cargo test --release --all-features

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -34,8 +34,8 @@ features = ["alloc"]
 hex-literal = "0.3"
 
 [features]
-alloc = []
-pem = ["alloc", "subtle-encoding", "zeroize"]
+alloc = ["zeroize"]
+pem = ["alloc", "subtle-encoding"]
 std = ["alloc", "const-oid/std"]
 
 [package.metadata.docs.rs]

--- a/pkcs8/src/document.rs
+++ b/pkcs8/src/document.rs
@@ -1,0 +1,78 @@
+//! PKCS#8 documents: serialized PKCS#8 private keys
+// TODO(tarcieri): heapless support?
+
+use crate::{Error, PrivateKeyInfo, Result};
+use alloc::{borrow::ToOwned, vec::Vec};
+use core::{convert::TryFrom, fmt};
+use zeroize::Zeroizing;
+
+#[cfg(feature = "pem")]
+use crate::pem;
+#[cfg(feature = "pem")]
+use core::str::FromStr;
+
+/// PKCS#8 document
+///
+/// This type provides heapless storage for a PKCS#8 encoded private key with
+/// the invariant that the contained-document is "well-formed", i.e. it will
+/// parse successfully according to this crate's parsing rules.
+#[derive(Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub struct Document(Zeroizing<Vec<u8>>);
+
+impl Document {
+    /// Parse [`Document`] from ASN.1 DER-encoded PKCS#8
+    pub fn from_der(bytes: &[u8]) -> Result<Self> {
+        // Ensure document is well-formed
+        PrivateKeyInfo::from_der(bytes)?;
+        Ok(Self(Zeroizing::new(bytes.to_owned())))
+    }
+
+    /// Parse [`Document`] from PEM-encoded PKCS#8.
+    ///
+    /// PEM-encoded can be identified by the leading delimiter:
+    ///
+    /// ```text
+    /// -----BEGIN PRIVATE KEY-----
+    /// ```
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn from_pem(s: &str) -> Result<Self> {
+        pem::parse(s)
+    }
+
+    /// Parse the [`PrivateKeyInfo`] contained in this [`Document`]
+    pub fn private_key_info(&self) -> PrivateKeyInfo<'_> {
+        PrivateKeyInfo::from_der(self.0.as_ref()).expect("constructor failed to validate document")
+    }
+}
+
+impl AsRef<[u8]> for Document {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl TryFrom<&[u8]> for Document {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_der(bytes)
+    }
+}
+
+impl fmt::Debug for Document {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Document(...)")
+    }
+}
+
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl FromStr for Document {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::from_pem(s)
+    }
+}

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -39,9 +39,11 @@ mod asn1;
 mod error;
 mod private_key_info;
 
+#[cfg(feature = "alloc")]
+mod document;
+
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-pub mod pem;
+mod pem;
 
 pub use crate::{
     algorithm::AlgorithmIdentifier,
@@ -49,3 +51,6 @@ pub use crate::{
     private_key_info::PrivateKeyInfo,
 };
 pub use const_oid::ObjectIdentifier;
+
+#[cfg(feature = "alloc")]
+pub use crate::document::Document;

--- a/pkcs8/src/pem.rs
+++ b/pkcs8/src/pem.rs
@@ -1,8 +1,7 @@
 //! PEM encoding support (RFC 7468)
 
-use crate::{Error, Result};
-use alloc::{borrow::ToOwned, vec::Vec};
-use core::str::FromStr;
+use crate::{Document, Error, Result};
+use alloc::borrow::ToOwned;
 use subtle_encoding::base64;
 use zeroize::Zeroizing;
 
@@ -12,45 +11,25 @@ const PRE_ENCAPSULATION_BOUNDARY: &str = "-----BEGIN PRIVATE KEY-----\n";
 /// Post-encapsulation boundary
 const POST_ENCAPSULATION_BOUNDARY: &str = "\n-----END PRIVATE KEY-----";
 
-/// PKCS#8 document decoded from PEM.
+/// Parse "PEM encoding" as described in RFC 7468:
+/// <https://tools.ietf.org/html/rfc7468>
 ///
-/// Note for embedded users: enabling the `pem` feature requires linking
-/// with liballoc (i.e. this type is presently heap-backed).
-// TODO(tarcieri): heapless support?
-#[derive(Clone)]
-pub struct Document(Zeroizing<Vec<u8>>);
+/// Note that this decoder supports only a subset of the original
+/// "Privacy Enhanced Mail" encoding as this parser specifically
+/// implements a dialect intended for textual encodings of PKIX,
+/// PKCS, and CMS structures.
+// TODO(tarcieri): better harden for fully constant-time operation
+pub(crate) fn parse(s: &str) -> Result<Document> {
+    let s = s.trim_end();
 
-impl AsRef<[u8]> for Document {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
+    // TODO(tarcieri): handle missing newlines
+    let s = s.strip_prefix(PRE_ENCAPSULATION_BOUNDARY).ok_or(Error)?;
+    let s = s.strip_suffix(POST_ENCAPSULATION_BOUNDARY).ok_or(Error)?;
 
-impl FromStr for Document {
-    type Err = Error;
+    // TODO(tarcieri): fix subtle-encoding to tolerate whitespace
+    let mut s = Zeroizing::new(s.to_owned());
+    s.retain(|c| !c.is_whitespace());
 
-    /// Parse "PEM encoding" as described in RFC 7468:
-    /// <https://tools.ietf.org/html/rfc7468>
-    ///
-    /// Note that this decoder supports only a subset of the original
-    /// "Privacy Enhanced Mail" encoding as this parser specifically
-    /// implements a dialect intended for textual encodings of PKIX,
-    /// PKCS, and CMS structures.
-    // TODO(tarcieri): better harden for fully constant-time operation
-    fn from_str(s: &str) -> Result<Self> {
-        let s = s.trim_end();
-
-        // TODO(tarcieri): handle missing newlines
-        let s = s.strip_prefix(PRE_ENCAPSULATION_BOUNDARY).ok_or(Error)?;
-        let s = s.strip_suffix(POST_ENCAPSULATION_BOUNDARY).ok_or(Error)?;
-
-        // TODO(tarcieri): fix subtle-encoding to tolerate whitespace
-        let mut s = Zeroizing::new(s.to_owned());
-        s.retain(|c| !c.is_whitespace());
-
-        base64::decode(&*s)
-            .map(Zeroizing::new)
-            .map(Document)
-            .map_err(|_| Error)
-    }
+    let pkcs8_der = base64::decode(&*s).map_err(|_| Error).map(Zeroizing::new)?;
+    Document::from_der(&*pkcs8_der)
 }

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -3,7 +3,7 @@
 use crate::{asn1, AlgorithmIdentifier, Error, Result};
 use core::{convert::TryFrom, fmt};
 
-/// PKCS#8 `PrivateKeyInfo`.
+/// PKCS#8 `PrivateKeyInfo`
 ///
 /// ASN.1 structure containing an [`AlgorithmIdentifier`] and private key
 /// data in an algorithm specific format.

--- a/pkcs8/tests/lib.rs
+++ b/pkcs8/tests/lib.rs
@@ -52,13 +52,21 @@ fn parse_rsa_2048_der() {
 #[test]
 #[cfg(feature = "pem")]
 fn parse_ec_p256_pem() {
-    let pkcs8_doc: pkcs8::pem::Document = EC_P256_PEM_EXAMPLE.parse().unwrap();
+    let pkcs8_doc: pkcs8::Document = EC_P256_PEM_EXAMPLE.parse().unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
+
+    // Ensure `pkcs8::Document` parses successfully
+    let pk_info = PrivateKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
+    assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
 }
 
 #[test]
 #[cfg(feature = "pem")]
 fn parse_rsa_2048_pem() {
-    let pkcs8_doc: pkcs8::pem::Document = RSA_2048_PEM_EXAMPLE.parse().unwrap();
+    let pkcs8_doc: pkcs8::Document = RSA_2048_PEM_EXAMPLE.parse().unwrap();
     assert_eq!(pkcs8_doc.as_ref(), RSA_2048_DER_EXAMPLE);
+
+    // Ensure `pkcs8::Document` parses successfully
+    let pk_info = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
+    assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
 }


### PR DESCRIPTION
Refactors the previous `pkcs::pem::Document` type into a more general-purpose heap-backed `pkcs8::Document` type.

This type's invariant is to ensure it contains a valid PKCS#8 document which will always parse successfully as `PrivateKeyInfo`.