### PR TITLE
pkcs8: PEM support for decoding SubjectPublicKeyInfo

### DIFF
--- a/pkcs8/src/document.rs
+++ b/pkcs8/src/document.rs
@@ -1,7 +1,7 @@
-//! PKCS#8 documents: serialized PKCS#8 private keys
+//! PKCS#8 documents: serialized PKCS#8 private keys and SPKI public keys
 // TODO(tarcieri): heapless support?
 
-use crate::{Error, PrivateKeyInfo, Result};
+use crate::{Error, PrivateKeyInfo, Result, SubjectPublicKeyInfo};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::{convert::TryFrom, fmt};
 use zeroize::Zeroizing;
@@ -11,26 +11,26 @@ use crate::pem;
 #[cfg(feature = "pem")]
 use core::str::FromStr;
 
-/// PKCS#8 document
+/// PKCS#8 private key document
 ///
-/// This type provides heapless storage for a PKCS#8 encoded private key with
-/// the invariant that the contained-document is "well-formed", i.e. it will
-/// parse successfully according to this crate's parsing rules.
+/// This type provides storage for a PKCS#8 private key encoded as ASN.1 DER
+/// with the invariant that the contained-document is "well-formed", i.e. it
+/// will parse successfully according to this crate's parsing rules.
 #[derive(Clone)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub struct Document(Zeroizing<Vec<u8>>);
+pub struct PrivateKeyDocument(Zeroizing<Vec<u8>>);
 
-impl Document {
-    /// Parse [`Document`] from ASN.1 DER-encoded PKCS#8
+impl PrivateKeyDocument {
+    /// Parse [`PrivateKeyDocument`] from ASN.1 DER-encoded PKCS#8
     pub fn from_der(bytes: &[u8]) -> Result<Self> {
         // Ensure document is well-formed
         PrivateKeyInfo::from_der(bytes)?;
         Ok(Self(Zeroizing::new(bytes.to_owned())))
     }
 
-    /// Parse [`Document`] from PEM-encoded PKCS#8.
+    /// Parse [`PrivateKeyDocument`] from PEM-encoded PKCS#8.
     ///
-    /// PEM-encoding can be identified by the leading delimiter:
+    /// PEM-encoded private keys can be identified by the leading delimiter:
     ///
     /// ```text
     /// -----BEGIN PRIVATE KEY-----
@@ -38,22 +38,23 @@ impl Document {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn from_pem(s: &str) -> Result<Self> {
-        pem::parse(s)
+        let der_bytes = pem::parse(s, pem::BEGIN_PRIVATE_KEY, pem::END_PRIVATE_KEY)?;
+        Self::from_der(&*der_bytes)
     }
 
-    /// Parse the [`PrivateKeyInfo`] contained in this [`Document`]
+    /// Parse the [`PrivateKeyInfo`] contained in this [`PrivateKeyDocument`]
     pub fn private_key_info(&self) -> PrivateKeyInfo<'_> {
         PrivateKeyInfo::from_der(self.0.as_ref()).expect("constructor failed to validate document")
     }
 }
 
-impl AsRef<[u8]> for Document {
+impl AsRef<[u8]> for PrivateKeyDocument {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-impl TryFrom<&[u8]> for Document {
+impl TryFrom<&[u8]> for PrivateKeyDocument {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
@@ -61,15 +62,87 @@ impl TryFrom<&[u8]> for Document {
     }
 }
 
-impl fmt::Debug for Document {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Document(...)")
+impl fmt::Debug for PrivateKeyDocument {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_tuple("PrivateKeyDocument")
+            .field(&self.private_key_info())
+            .finish()
     }
 }
 
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-impl FromStr for Document {
+impl FromStr for PrivateKeyDocument {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::from_pem(s)
+    }
+}
+
+/// SPKI public key document
+///
+/// This type provides storage for a SPKI public key encoded as ASN.1 DER with
+/// the invariant that the contained-document is "well-formed", i.e. it will
+/// parse successfully according to this crate's parsing rules.
+#[derive(Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub struct PublicKeyDocument(Vec<u8>);
+
+impl PublicKeyDocument {
+    /// Parse [`PublicKeyDocument`] from ASN.1 DER
+    pub fn from_der(bytes: &[u8]) -> Result<Self> {
+        // Ensure document is well-formed
+        SubjectPublicKeyInfo::from_der(bytes)?;
+        Ok(Self(bytes.to_owned()))
+    }
+
+    /// Parse [`PublicKeyDocument`] from PEM
+    ///
+    /// PEM-encoded public keys can be identified by the leading delimiter:
+    ///
+    /// ```text
+    /// -----BEGIN PUBLIC KEY-----
+    /// ```
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn from_pem(s: &str) -> Result<Self> {
+        let der_bytes = pem::parse(s, pem::BEGIN_PUBLIC_KEY, pem::END_PUBLIC_KEY)?;
+        Self::from_der(&*der_bytes)
+    }
+
+    /// Parse the [`SubjectPublicKeyInfo`] contained in this [`PublicKeyDocument`]
+    pub fn spki(&self) -> SubjectPublicKeyInfo<'_> {
+        SubjectPublicKeyInfo::from_der(self.0.as_ref())
+            .expect("constructor failed to validate document")
+    }
+}
+
+impl AsRef<[u8]> for PublicKeyDocument {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKeyDocument {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_der(bytes)
+    }
+}
+
+impl fmt::Debug for PublicKeyDocument {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_tuple("PublicKeyDocument")
+            .field(&self.spki())
+            .finish()
+    }
+}
+
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl FromStr for PublicKeyDocument {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::{
 pub use const_oid::ObjectIdentifier;
 
 #[cfg(feature = "alloc")]
-pub use crate::document::Document;
+pub use crate::document::{PrivateKeyDocument, PublicKeyDocument};
 
 /// Parse an object from a PKCS#8 encoded document.
 pub trait FromPkcs8: Sized {
@@ -79,6 +79,6 @@ pub trait FromPkcs8: Sized {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_pkcs8_pem(s: &str) -> Result<Self> {
-        Self::from_pkcs8_der(Document::from_pem(s)?.as_ref())
+        Self::from_pkcs8_der(PrivateKeyDocument::from_pem(s)?.as_ref())
     }
 }

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -21,8 +21,7 @@ pub struct SubjectPublicKeyInfo<'a> {
     /// X.509 [`AlgorithmIdentifier`]
     pub algorithm: AlgorithmIdentifier,
 
-    /// Public key data. This is technically an ASN.1 `BIT STRING`, but this
-    /// implementation constrains its contents to an octet granularity
+    /// Public key data
     pub subject_public_key: &'a [u8],
 }
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -48,10 +48,10 @@ fn parse_rsa_2048_der() {
 #[test]
 #[cfg(feature = "pem")]
 fn parse_ec_p256_pem() {
-    let pkcs8_doc: pkcs8::Document = EC_P256_PEM_EXAMPLE.parse().unwrap();
+    let pkcs8_doc: pkcs8::PrivateKeyDocument = EC_P256_PEM_EXAMPLE.parse().unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 
-    // Ensure `pkcs8::Document` parses successfully
+    // Ensure `pkcs8::PrivateKeyDocument` parses successfully
     let pk_info = PrivateKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
     assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
 }
@@ -59,10 +59,10 @@ fn parse_ec_p256_pem() {
 #[test]
 #[cfg(feature = "pem")]
 fn parse_rsa_2048_pem() {
-    let pkcs8_doc: pkcs8::Document = RSA_2048_PEM_EXAMPLE.parse().unwrap();
+    let pkcs8_doc: pkcs8::PrivateKeyDocument = RSA_2048_PEM_EXAMPLE.parse().unwrap();
     assert_eq!(pkcs8_doc.as_ref(), RSA_2048_DER_EXAMPLE);
 
-    // Ensure `pkcs8::Document` parses successfully
+    // Ensure `pkcs8::PrivateKeyDocument` parses successfully
     let pk_info = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
 }

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -6,8 +6,16 @@ use pkcs8::SubjectPublicKeyInfo;
 /// Elliptic Curve (P-256) `SubjectPublicKeyInfo` encoded as ASN.1 DER
 const EC_P256_DER_EXAMPLE: &[u8] = include_bytes!("examples/p256-pub.der");
 
-/// RSA-2048 PKCS#8 private key encoded as ASN.1 DER
+/// RSA-2048 `SubjectPublicKeyInfo` encoded as ASN.1 DER
 const RSA_2048_DER_EXAMPLE: &[u8] = include_bytes!("examples/rsa2048-pub.der");
+
+/// Elliptic Curve (P-256) public key encoded as PEM
+#[cfg(feature = "pem")]
+const EC_P256_PEM_EXAMPLE: &str = include_str!("examples/p256-pub.pem");
+
+/// RSA-2048 PKCS#8 public key encoded as PEM
+#[cfg(feature = "pem")]
+const RSA_2048_PEM_EXAMPLE: &str = include_str!("examples/rsa2048-pub.pem");
 
 #[test]
 fn parse_ec_p256_der() {
@@ -30,4 +38,26 @@ fn parse_rsa_2048_der() {
     assert_eq!(spki.algorithm.oid, "1.2.840.113549.1.1.1".parse().unwrap());
     assert_eq!(spki.algorithm.parameters, None);
     assert_eq!(spki.subject_public_key, &hex!("003082010A0282010100B6C42C515F10A6AAF282C63EDBE24243A170F3FA2633BD4833637F47CA4F6F36E03A5D29EFC3191AC80F390D874B39E30F414FCEC1FCA0ED81E547EDC2CD382C76F61C9018973DB9FA537972A7C701F6B77E0982DFC15FC01927EE5E7CD94B4F599FF07013A7C8281BDF22DCBC9AD7CABB7C4311C982F58EDB7213AD4558B332266D743AED8192D1884CADB8B14739A8DADA66DC970806D9C7AC450CB13D0D7C575FB198534FC61BC41BC0F0574E0E0130C7BBBFBDFDC9F6A6E2E3E2AFF1CBEAC89BA57884528D55CFB08327A1E8C89F4E003CF2888E933241D9D695BCBBACDC90B44E3E095FA37058EA25B13F5E295CBEAC6DE838AB8C50AF61E298975B872F0203010001")[..]);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn parse_ec_p256_pem() {
+    let doc: pkcs8::PublicKeyDocument = EC_P256_PEM_EXAMPLE.parse().unwrap();
+    assert_eq!(doc.as_ref(), EC_P256_DER_EXAMPLE);
+
+    // Ensure `pkcs8::PublicKeyDocument` parses successfully
+    let spki = SubjectPublicKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
+    assert_eq!(doc.spki(), spki);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn parse_rsa_2048_pem() {
+    let doc: pkcs8::PublicKeyDocument = RSA_2048_PEM_EXAMPLE.parse().unwrap();
+    assert_eq!(doc.as_ref(), RSA_2048_DER_EXAMPLE);
+
+    // Ensure `pkcs8::PublicKeyDocument` parses successfully
+    let spki = SubjectPublicKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
+    assert_eq!(doc.spki(), spki);
 }


### PR DESCRIPTION
Generalizes PEM support so it can support both public and private keys, splitting `pkcs8::Document` into `pkcs8::PublicKeyDocument` and `pkcs8::PrivateKeyDocument`.