### PR TITLE
const-oid v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.3.0-pre"
+version = "0.3.0"
 
 [[package]]
 name = "cpuid-bool"

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-12-05)
+### Added
+- Byte and string parsers ([#89])
+
+[#89]: https://github.com/RustCrypto/utils/pull/89
+
 ## 0.2.0 (2020-09-05)
 ### Changed
 - Validate OIDs are well-formed; MSRV 1.46+ ([#76])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -25,7 +25,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/const-oid/0.3.0-pre"
+    html_root_url = "https://docs.rs/const-oid/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["crypto", "key", "private"]
 readme = "README.md"
 
 [dependencies.const-oid]
-version = "=0.3.0-pre"
+version = "0.3"
 path = "../const-oid"
 
 [dependencies.subtle-encoding]


### PR DESCRIPTION
### Added
- Byte and string parsers ([#89])

[#89]: https://github.com/RustCrypto/utils/pull/89