### PR TITLE
pkcs8: add `FromPublicKey` trait

### DIFF
--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -39,6 +39,7 @@ mod asn1;
 mod error;
 mod private_key_info;
 mod spki;
+mod traits;
 
 #[cfg(feature = "alloc")]
 mod document;
@@ -51,34 +52,9 @@ pub use crate::{
     error::{Error, Result},
     private_key_info::PrivateKeyInfo,
     spki::SubjectPublicKeyInfo,
+    traits::FromPrivateKey,
 };
 pub use const_oid::ObjectIdentifier;
 
 #[cfg(feature = "alloc")]
 pub use crate::document::{PrivateKeyDocument, PublicKeyDocument};
-
-/// Parse an object from a PKCS#8 encoded document.
-pub trait FromPkcs8: Sized {
-    /// Parse the `private_key` field of a PKCS#8-encoded private key's
-    /// `PrivateKeyInfo`.
-    fn from_pkcs8_private_key_info(private_key_info: PrivateKeyInfo<'_>) -> Result<Self>;
-
-    /// Deserialize PKCS#8-encoded private key from ASN.1 DER
-    /// (binary format).
-    fn from_pkcs8_der(bytes: &[u8]) -> Result<Self> {
-        Self::from_pkcs8_private_key_info(PrivateKeyInfo::from_der(bytes)?)
-    }
-
-    /// Deserialize PKCS#8-encoded private key from PEM.
-    ///
-    /// Keys in this format begin with the following delimiter:
-    ///
-    /// ```text
-    /// -----BEGIN PRIVATE KEY-----
-    /// ```
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn from_pkcs8_pem(s: &str) -> Result<Self> {
-        Self::from_pkcs8_der(PrivateKeyDocument::from_pem(s)?.as_ref())
-    }
-}

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -1,0 +1,56 @@
+//! Traits for parsing objects from PKCS#8 encoded documents
+
+use crate::{PrivateKeyInfo, Result, SubjectPublicKeyInfo};
+
+#[cfg(feature = "pem")]
+use crate::{PrivateKeyDocument, PublicKeyDocument};
+
+/// Parse a private key object from a PKCS#8 encoded document.
+pub trait FromPrivateKey: Sized {
+    /// Parse the `PrivateKeyInfo` from a PKCS#8-encoded document.
+    fn from_pkcs8_private_key_info(private_key_info: PrivateKeyInfo<'_>) -> Result<Self>;
+
+    /// Deserialize PKCS#8-encoded private key from ASN.1 DER
+    /// (binary format).
+    fn from_pkcs8_der(bytes: &[u8]) -> Result<Self> {
+        Self::from_pkcs8_private_key_info(PrivateKeyInfo::from_der(bytes)?)
+    }
+
+    /// Deserialize PKCS#8-encoded private key from PEM.
+    ///
+    /// Keys in this format begin with the following delimiter:
+    ///
+    /// ```text
+    /// -----BEGIN PRIVATE KEY-----
+    /// ```
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn from_pkcs8_pem(s: &str) -> Result<Self> {
+        Self::from_pkcs8_der(PrivateKeyDocument::from_pem(s)?.as_ref())
+    }
+}
+
+/// Parse a public key object from an encoded SPKI document.
+pub trait FromPublicKey: Sized {
+    /// Parse [`SubjectPublicKeyInfo`] into a public key object.
+    fn from_spki(spki: SubjectPublicKeyInfo<'_>) -> Result<Self>;
+
+    /// Deserialize object from ASN.1 DER-encoded [`SubjectPublicKeyInfo`]
+    /// (binary format).
+    fn from_public_key_der(bytes: &[u8]) -> Result<Self> {
+        Self::from_spki(SubjectPublicKeyInfo::from_der(bytes)?)
+    }
+
+    /// Deserialize PEM-encoded [`SubjectPublicKeyInfo`].
+    ///
+    /// Keys in this format begin with the following delimiter:
+    ///
+    /// ```text
+    /// -----BEGIN PUBLIC KEY-----
+    /// ```
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn from_public_key_pem(s: &str) -> Result<Self> {
+        Self::from_public_key_der(PublicKeyDocument::from_pem(s)?.as_ref())
+    }
+}


### PR DESCRIPTION
Also renames the former `FromPkcs8` trait to `FromPrivateKey`.