### PR TITLE
const-oid v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "cpuid-bool"

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2020-12-05)
+## 0.3.1 (2020-12-05)
+### Added
+- Impl `TryFrom<&[u32]>` for ObjectIdentifier ([#105])
+
+[#105]: https://github.com/RustCrypto/utils/pull/105
+
+## 0.3.0 (2020-12-05) [YANKED]
 ### Added
 - Byte and string parsers ([#89])
 

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -25,7 +25,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/const-oid/0.3.0"
+    html_root_url = "https://docs.rs/const-oid/0.3.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Impl `TryFrom<&[u32]>` for ObjectIdentifier ([#105])

[#105]: https://github.com/RustCrypto/utils/pull/105