### PR TITLE
block-buffer and block-padding improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -17,7 +17,10 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.2.1"
+version = "0.3.0"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "collectable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.0-pre"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.0"
+version = "0.3.0-pre"
 dependencies = [
  "generic-array",
 ]

--- a/block-buffer/CHANGELOG.md
+++ b/block-buffer/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.10.0 (2020-12-08)
+### Changed
+- Rename `input_block(s)` methods to `digest_block(s)`. ([#113])
+- Upgrade the `block-padding` dependency to v0.3. ([#113])
+
+### Added
+- The `xor_data` method. ([#113])
+
+### Removed
+- The `input_lazy` method. ([#113])
+
+[#113]: https://github.com/RustCrypto/utils/pull/113

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Fixed size buffer for block processing of data"
@@ -11,5 +11,5 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-block-padding = { version = "0.2.0", path = "../block-padding", optional = true }
+block-padding = { version = "0.3.0", path = "../block-padding", optional = true }
 generic-array = "0.14"

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Fixed size buffer for block processing of data"
@@ -11,5 +11,5 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-block-padding = { version = "0.3.0", path = "../block-padding", optional = true }
+block-padding = { version = "0.3.0-pre", path = "../block-padding", optional = true }
 generic-array = "0.14"

--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -15,7 +15,9 @@ use block_padding::Padding;
 use core::{convert::TryInto, slice};
 use generic_array::{typenum::U1, ArrayLength, GenericArray};
 
+/// Block on which a `BlockBuffer` operates.
 pub type Block<BlockSize> = GenericArray<u8, BlockSize>;
+/// Blocks being acted over in parallel.
 pub type ParBlock<BlockSize, ParBlocks> = GenericArray<Block<BlockSize>, ParBlocks>;
 
 /// Buffer for block processing of data.

--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -1,14 +1,21 @@
+//! Fixed size buffer for block processing of data.
 #![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[cfg(feature = "block-padding")]
 pub use block_padding;
 pub use generic_array;
 
 #[cfg(feature = "block-padding")]
-use block_padding::{PadError, Padding};
+use block_padding::Padding;
 use core::{convert::TryInto, slice};
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::{typenum::U1, ArrayLength, GenericArray};
 
-/// Buffer for block processing of data
+/// Buffer for block processing of data.
 #[derive(Clone, Default)]
 pub struct BlockBuffer<BlockSize: ArrayLength<u8>> {
     buffer: GenericArray<u8, BlockSize>,
@@ -16,226 +23,340 @@ pub struct BlockBuffer<BlockSize: ArrayLength<u8>> {
 }
 
 impl<BlockSize: ArrayLength<u8>> BlockBuffer<BlockSize> {
-    /// Process data in `input` in blocks of size `BlockSize` using function `f`.
+    /// Digest data in `input` in blocks of size `BlockSize` using
+    /// the `compress` function, which accepts a block reference.
     #[inline]
-    pub fn input_block(
+    pub fn digest_block(
         &mut self,
         mut input: &[u8],
-        mut f: impl FnMut(&GenericArray<u8, BlockSize>),
+        mut compress: impl FnMut(&GenericArray<u8, BlockSize>),
     ) {
+        let pos = self.get_pos();
         let r = self.remaining();
-        if input.len() < r {
-            let n = input.len();
-            self.buffer[self.pos..self.pos + n].copy_from_slice(input);
-            self.pos += n;
+        let n = input.len();
+        if n < r {
+            // double slicing allows to remove panic branches
+            self.buffer[pos..][..n].copy_from_slice(input);
+            self.set_pos_unchecked(pos + n);
             return;
         }
-        if self.pos != 0 && input.len() >= r {
-            let (l, r) = input.split_at(r);
-            input = r;
-            self.buffer[self.pos..].copy_from_slice(l);
-            f(&self.buffer);
+        if pos != 0 {
+            let (left, right) = input.split_at(r);
+            input = right;
+            self.buffer[pos..].copy_from_slice(left);
+            compress(&self.buffer);
         }
 
         let mut chunks_iter = input.chunks_exact(self.size());
         for chunk in &mut chunks_iter {
-            f(chunk.try_into().unwrap());
+            compress(chunk.try_into().unwrap());
         }
         let rem = chunks_iter.remainder();
 
         // Copy any remaining data into the buffer.
         self.buffer[..rem.len()].copy_from_slice(rem);
-        self.pos = rem.len();
+        self.set_pos_unchecked(rem.len());
     }
 
-    /// Process data in `input` in blocks of size `BlockSize` using function `f`, which accepts
-    /// slice of blocks.
+    /// Digest data in `input` in blocks of size `BlockSize` using
+    /// the `compress` function, which accepts slice of blocks.
     #[inline]
-    pub fn input_blocks(
+    pub fn digest_blocks(
         &mut self,
         mut input: &[u8],
-        mut f: impl FnMut(&[GenericArray<u8, BlockSize>]),
+        mut compress: impl FnMut(&[GenericArray<u8, BlockSize>]),
     ) {
+        let pos = self.get_pos();
         let r = self.remaining();
-        if input.len() < r {
-            let n = input.len();
-            self.buffer[self.pos..self.pos + n].copy_from_slice(input);
-            self.pos += n;
+        let n = input.len();
+        if n < r {
+            // double slicing allows to remove panic branches
+            self.buffer[pos..][..n].copy_from_slice(input);
+            self.set_pos_unchecked(pos + n);
             return;
         }
-        if self.pos != 0 && input.len() >= r {
-            let (l, r) = input.split_at(r);
-            input = r;
-            self.buffer[self.pos..].copy_from_slice(l);
-            self.pos = 0;
-            f(slice::from_ref(&self.buffer));
+        if pos != 0 {
+            let (left, right) = input.split_at(r);
+            input = right;
+            self.buffer[pos..].copy_from_slice(left);
+            compress(slice::from_ref(&self.buffer));
         }
 
-        // While we have at least a full buffer size chunks's worth of data,
-        // process its data without copying into the buffer
-        let n_blocks = input.len() / self.size();
-        let (left, right) = input.split_at(n_blocks * self.size());
-        // SAFETY: we guarantee that `blocks` does not point outside of `input`
-        let blocks = unsafe {
-            slice::from_raw_parts(
-                left.as_ptr() as *const GenericArray<u8, BlockSize>,
-                n_blocks,
-            )
-        };
-        f(blocks);
+        let (blocks, leftover) = to_blocks(input);
+        compress(blocks);
 
-        // Copy remaining data into the buffer.
-        let n = right.len();
-        self.buffer[..n].copy_from_slice(right);
-        self.pos = n;
+        let n = leftover.len();
+        self.buffer[..n].copy_from_slice(leftover);
+        self.set_pos_unchecked(n);
     }
 
-    /// Variant that doesn't flush the buffer until there's additional
-    /// data to be processed. Suitable for tweakable block ciphers
-    /// like Threefish that need to know whether a block is the *last*
-    /// data block before processing it.
-    #[inline]
-    pub fn input_lazy(
+    /// Core method for `xor_data` and `set_data` methods.
+    ///
+    /// If `N` is equal to 1, the `gen_blocks` function is not used.
+    fn process_data<S, N: ArrayLength<GenericArray<u8, BlockSize>>>(
         &mut self,
-        mut input: &[u8],
-        mut f: impl FnMut(&GenericArray<u8, BlockSize>),
+        mut data: &mut [u8],
+        state: &mut S,
+        mut process: impl FnMut(&mut [u8], &[u8]),
+        mut gen_block: impl FnMut(&mut S) -> GenericArray<u8, BlockSize>,
+        mut gen_blocks: impl FnMut(&mut S) -> GenericArray<GenericArray<u8, BlockSize>, N>,
     ) {
+        let pos = self.get_pos();
         let r = self.remaining();
-        if input.len() <= r {
-            let n = input.len();
-            self.buffer[self.pos..self.pos + n].copy_from_slice(input);
-            self.pos += n;
-            return;
-        }
-        if self.pos != 0 && input.len() > r {
-            let (l, r) = input.split_at(r);
-            input = r;
-            self.buffer[self.pos..].copy_from_slice(l);
-            f(&self.buffer);
-        }
-
-        while input.len() > self.size() {
-            let (block, r) = input.split_at(self.size());
-            input = r;
-            f(block.try_into().unwrap());
+        let n = data.len();
+        if pos != 0 {
+            if n < r {
+                // double slicing allows to remove panic branches
+                process(data, &self.buffer[pos..][..n]);
+                self.set_pos_unchecked(pos + n);
+                return;
+            }
+            let (left, right) = data.split_at_mut(r);
+            data = right;
+            process(left, &self.buffer[pos..]);
         }
 
-        self.buffer[..input.len()].copy_from_slice(input);
-        self.pos = input.len();
+        let (par_blocks, blocks, leftover) = to_blocks_mut::<BlockSize, N>(data);
+        for pb in par_blocks {
+            let blocks = gen_blocks(state);
+            for i in 0..N::USIZE {
+                process(&mut pb[i], &blocks[i]);
+            }
+        }
+
+        for block in blocks {
+            process(block, &gen_block(state));
+        }
+
+        let n = leftover.len();
+        if n != 0 {
+            let block = gen_block(state);
+            process(leftover, &block[..n]);
+            self.buffer = block;
+        }
+        self.set_pos_unchecked(n);
     }
 
-    /// Pad buffer with `prefix` and make sure that internall buffer
-    /// has at least `up_to` free bytes. All remaining bytes get
-    /// zeroed-out.
+    /// XORs `data` using the provided state and block generation functions.
+    ///
+    /// This method is intended for stream cipher implementations. If `N` is
+    /// equal to 1, the `gen_blocks` function is not used.
     #[inline]
-    fn digest_pad(&mut self, up_to: usize, mut f: impl FnMut(&GenericArray<u8, BlockSize>)) {
-        if self.pos == self.size() {
-            f(&self.buffer);
-            self.pos = 0;
-        }
-        self.buffer[self.pos] = 0x80;
-        self.pos += 1;
-
-        set_zero(&mut self.buffer[self.pos..]);
-
-        if self.remaining() < up_to {
-            f(&self.buffer);
-            set_zero(&mut self.buffer[..self.pos]);
-        }
+    pub fn par_xor_data<S, N: ArrayLength<GenericArray<u8, BlockSize>>>(
+        &mut self,
+        data: &mut [u8],
+        state: &mut S,
+        gen_block: impl FnMut(&mut S) -> GenericArray<u8, BlockSize>,
+        gen_blocks: impl FnMut(&mut S) -> GenericArray<GenericArray<u8, BlockSize>, N>,
+    ) {
+        self.process_data(data, state, xor, gen_block, gen_blocks);
     }
 
-    /// Pad message with 0x80, zeros and 64-bit message length
-    /// using big-endian byte order
+    /// Simplified version of the [`par_xor_data`] method, with `N = 1`.
+    #[inline]
+    pub fn xor_data(
+        &mut self,
+        data: &mut [u8],
+        mut gen_block: impl FnMut() -> GenericArray<u8, BlockSize>,
+    ) {
+        // note: the unrachable panic should be removed by compiler since
+        // with `N = 1` the second closure is not used
+        self.process_data(
+            data,
+            &mut gen_block,
+            xor,
+            |f| f(),
+            |_| -> GenericArray<GenericArray<u8, BlockSize>, U1> { unreachable!() },
+        );
+    }
+
+    /// Set `data` to generated blocks.
+    #[inline]
+    pub fn set_data(
+        &mut self,
+        data: &mut [u8],
+        mut gen_block: impl FnMut() -> GenericArray<u8, BlockSize>,
+    ) {
+        // note: the unrachable panic should be removed by compiler since
+        // with `N = 1` the second closure is not used
+        self.process_data(
+            data,
+            &mut gen_block,
+            set,
+            |f| f(),
+            |_| -> GenericArray<GenericArray<u8, BlockSize>, U1> { unreachable!() },
+        );
+    }
+
+    /// Compress remaining data after padding it with `0x80`, zeros and
+    /// the `suffix` bytes. If there is not enough unused space, `compress`
+    /// will be called twice.
+    #[inline(always)]
+    fn digest_pad(
+        &mut self,
+        suffix: &[u8],
+        mut compress: impl FnMut(&GenericArray<u8, BlockSize>),
+    ) {
+        let pos = self.get_pos();
+        self.buffer[pos] = 0x80;
+        for b in &mut self.buffer[pos + 1..] {
+            *b = 0;
+        }
+
+        let n = self.size() - suffix.len();
+        if self.size() - pos - 1 < suffix.len() {
+            compress(&self.buffer);
+            let mut block: GenericArray<u8, BlockSize> = Default::default();
+            block[n..].copy_from_slice(suffix);
+            compress(&block);
+        } else {
+            self.buffer[n..].copy_from_slice(suffix);
+            compress(&self.buffer);
+        }
+        self.set_pos_unchecked(0)
+    }
+
+    /// Pad message with 0x80, zeros and 64-bit message length using
+    /// big-endian byte order.
     #[inline]
     pub fn len64_padding_be(
         &mut self,
         data_len: u64,
-        mut f: impl FnMut(&GenericArray<u8, BlockSize>),
+        compress: impl FnMut(&GenericArray<u8, BlockSize>),
     ) {
-        self.digest_pad(8, &mut f);
-        let b = data_len.to_be_bytes();
-        let n = self.buffer.len() - b.len();
-        self.buffer[n..].copy_from_slice(&b);
-        f(&self.buffer);
-        self.pos = 0;
+        self.digest_pad(&data_len.to_be_bytes(), compress);
     }
 
-    /// Pad message with 0x80, zeros and 64-bit message length
-    /// using little-endian byte order
+    /// Pad message with 0x80, zeros and 64-bit message length using
+    /// little-endian byte order.
     #[inline]
     pub fn len64_padding_le(
         &mut self,
         data_len: u64,
-        mut f: impl FnMut(&GenericArray<u8, BlockSize>),
+        compress: impl FnMut(&GenericArray<u8, BlockSize>),
     ) {
-        self.digest_pad(8, &mut f);
-        let b = data_len.to_le_bytes();
-        let n = self.buffer.len() - b.len();
-        self.buffer[n..].copy_from_slice(&b);
-        f(&self.buffer);
-        self.pos = 0;
+        self.digest_pad(&data_len.to_le_bytes(), compress);
     }
 
-    /// Pad message with 0x80, zeros and 128-bit message length
-    /// using big-endian byte order
+    /// Pad message with 0x80, zeros and 128-bit message length using
+    /// big-endian byte order.
     #[inline]
     pub fn len128_padding_be(
         &mut self,
         data_len: u128,
-        mut f: impl FnMut(&GenericArray<u8, BlockSize>),
+        compress: impl FnMut(&GenericArray<u8, BlockSize>),
     ) {
-        self.digest_pad(16, &mut f);
-        let b = data_len.to_be_bytes();
-        let n = self.buffer.len() - b.len();
-        self.buffer[n..].copy_from_slice(&b);
-        f(&self.buffer);
-        self.pos = 0;
+        self.digest_pad(&data_len.to_be_bytes(), compress);
     }
 
-    /// Pad message with a given padding `P`
-    ///
-    /// Returns `PadError` if internall buffer is full, which can only happen if
-    /// `input_lazy` was used.
+    /// Pad message with a given padding `P`.
     #[cfg(feature = "block-padding")]
     #[inline]
-    pub fn pad_with<P: Padding>(&mut self) -> Result<&mut GenericArray<u8, BlockSize>, PadError> {
-        P::pad_block(&mut self.buffer[..], self.pos)?;
-        self.pos = 0;
-        Ok(&mut self.buffer)
+    pub fn pad_with<P: Padding<BlockSize>>(&mut self) -> &mut GenericArray<u8, BlockSize> {
+        let pos = self.get_pos();
+        P::pad(&mut self.buffer, pos);
+        self.set_pos_unchecked(0);
+        &mut self.buffer
     }
 
-    /// Return size of the internall buffer in bytes
+    /// Return size of the internall buffer in bytes.
     #[inline]
     pub fn size(&self) -> usize {
-        BlockSize::to_usize()
+        BlockSize::USIZE
     }
 
-    /// Return current cursor position
-    #[inline]
-    pub fn position(&self) -> usize {
-        self.pos
-    }
-
-    /// Return number of remaining bytes in the internall buffer
+    /// Return number of remaining bytes in the internall buffer.
     #[inline]
     pub fn remaining(&self) -> usize {
-        self.size() - self.pos
+        self.size() - self.get_pos()
     }
 
-    /// Reset buffer by setting cursor position to zero
+    /// Reset buffer by setting cursor position to zero.
     #[inline]
     pub fn reset(&mut self) {
         self.pos = 0
     }
+
+    /// Return current cursor position.
+    #[inline]
+    pub fn get_pos(&self) -> usize {
+        debug_assert!(self.pos < BlockSize::USIZE);
+        if self.pos >= BlockSize::USIZE {
+            // SAFETY: `pos` is set only to values smaller than block size
+            unsafe { core::hint::unreachable_unchecked() }
+        }
+        self.pos
+    }
+
+    /// Set buffer content and cursor position.
+    ///
+    /// # Panics
+    /// If `pos` is bigger or equal to block size.
+    pub fn set(&mut self, buf: GenericArray<u8, BlockSize>, pos: usize) {
+        assert!(pos < BlockSize::USIZE);
+        self.buffer = buf;
+        self.pos = pos;
+    }
+
+    #[inline]
+    fn set_pos_unchecked(&mut self, pos: usize) {
+        debug_assert!(pos < BlockSize::USIZE);
+        self.pos = pos;
+    }
 }
 
-/// Sets all bytes in `dst` to zero
 #[inline(always)]
-fn set_zero(dst: &mut [u8]) {
-    // SAFETY: we overwrite valid memory behind `dst`
-    // note: loop is not used here because it produces
-    // unnecessary branch which tests for zero-length slices
+fn xor(a: &mut [u8], b: &[u8]) {
+    debug_assert_eq!(a.len(), b.len());
+    a.iter_mut().zip(b.iter()).for_each(|(a, &b)| *a ^= b);
+}
+
+#[inline(always)]
+fn set(a: &mut [u8], b: &[u8]) {
+    a.copy_from_slice(b);
+}
+
+#[inline(always)]
+fn to_blocks<N: ArrayLength<u8>>(data: &[u8]) -> (&[GenericArray<u8, N>], &[u8]) {
+    let nb = data.len() / N::USIZE;
+    let (left, right) = data.split_at(nb * N::USIZE);
+    let p = left.as_ptr() as *const GenericArray<u8, N>;
+    // SAFETY: we guarantee that `blocks` does not point outside of `data`
+    let blocks = unsafe { slice::from_raw_parts(p, nb) };
+    (blocks, right)
+}
+
+#[allow(clippy::type_complexity)]
+#[inline(always)]
+fn to_blocks_mut<N, M>(
+    data: &mut [u8],
+) -> (
+    &mut [GenericArray<GenericArray<u8, N>, M>],
+    &mut [GenericArray<u8, N>],
+    &mut [u8],
+)
+where
+    N: ArrayLength<u8>,
+    M: ArrayLength<GenericArray<u8, N>>,
+{
+    let b_size = N::USIZE;
+    let pb_size = N::USIZE * M::USIZE;
+    let npb = match M::USIZE {
+        1 => 0,
+        _ => data.len() / pb_size,
+    };
+    let (pb_slice, data) = data.split_at_mut(npb * pb_size);
+    let nb = data.len() / b_size;
+    let (b_slice, data) = data.split_at_mut(nb * b_size);
+    let pb_ptr = pb_slice.as_mut_ptr() as *mut GenericArray<GenericArray<u8, N>, M>;
+    let b_ptr = b_slice.as_mut_ptr() as *mut GenericArray<u8, N>;
+    // SAFETY: we guarantee that the resulting values do not overlap and do not
+    // point outside of the input slice
     unsafe {
-        core::ptr::write_bytes(dst.as_mut_ptr(), 0, dst.len());
+        (
+            slice::from_raw_parts_mut(pb_ptr, npb),
+            slice::from_raw_parts_mut(b_ptr, nb),
+            data,
+        )
     }
 }

--- a/block-padding/CHANGELOG.md
+++ b/block-padding/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-12-08)
+### Changed
+- The `Padding` trait methods now work with blocks instead of byte slices. ([#113])
+
+[#113]: https://github.com/RustCrypto/utils/pull/113
+
 ## 0.2.1 (2020-08-14)
 ### Added
-- `Copy`, `Clone`, and `Debug` trait implementations for padding types ([#78])
+- `Copy`, `Clone`, and `Debug` trait implementations for padding types. ([#78])
 
 [#78]: https://github.com/RustCrypto/utils/pull/78
 

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Padding and unpadding of messages divided into blocks."
@@ -9,3 +9,9 @@ repository = "https://github.com/RustCrypto/utils"
 keywords = ["padding", "pkcs7", "ansix923", "iso7816"]
 categories = ["cryptography", "no-std"]
 edition = "2018"
+
+[dependencies]
+generic-array = "0.14"
+
+[features]
+std = []

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.3.0"
+version = "0.3.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Padding and unpadding of messages divided into blocks."


### PR DESCRIPTION
This PR modifies `block-buffer` and `block-padding` APIs to reduce their surface and to make them mostly panic-free. Lack of panics in `block-buffer` was checked using godbolt. The relevant `unsafe` code line relies on the following invariant: `pos` is always strictly smaller than block size.

Because of this invariant I had to remove the `input_lazy` method, which was initially added for Skein. I think it will be better to later introduce a separate "lazy" buffer type. As a consequence it means that Skein will not be compatible with the core API introduced in RustCrypto/traits#380 (I think it could be eventually fixed with specialization). For most users it will be a barely noticeable implementation detail (i.e. Skein will simply implement the mid-level traits directly, without relying on the core wrapper), so considering relative unpopularity of hashes reliant on "lazy" buffers, I think it's a reasonable sacrifice.

Ideally we would use an Ada-like range type for `pos` (both the `block-buffer` field and the `block-padding` method argument), but without const generics such type probably will be quite unergonomic.

Closes #79 