### PR TITLE
pkcs8: add helper methods to load keys from the local filesystem

### DIFF
--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -5,12 +5,15 @@ use crate::{PrivateKeyInfo, Result, SubjectPublicKeyInfo};
 #[cfg(feature = "pem")]
 use crate::{PrivateKeyDocument, PublicKeyDocument};
 
+#[cfg(feature = "std")]
+use {crate::Error, std::vec::Vec, zeroize::Zeroizing};
+
 /// Parse a private key object from a PKCS#8 encoded document.
 pub trait FromPrivateKey: Sized {
     /// Parse the `PrivateKeyInfo` from a PKCS#8-encoded document.
     fn from_pkcs8_private_key_info(private_key_info: PrivateKeyInfo<'_>) -> Result<Self>;
 
-    /// Deserialize PKCS#8-encoded private key from ASN.1 DER
+    /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data
     /// (binary format).
     fn from_pkcs8_der(bytes: &[u8]) -> Result<Self> {
         Self::from_pkcs8_private_key_info(PrivateKeyInfo::from_der(bytes)?)
@@ -27,6 +30,25 @@ pub trait FromPrivateKey: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_pkcs8_pem(s: &str) -> Result<Self> {
         Self::from_pkcs8_der(PrivateKeyDocument::from_pem(s)?.as_ref())
+    }
+
+    /// Load PKCS#8 private key from an ASN.1 DER-encoded file on the local
+    /// filesystem (binary format).
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn load_pkcs8_der(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        load_file(path).and_then(|bytes| Self::from_pkcs8_der(&*bytes))
+    }
+
+    /// Load PKCS#8 private key from a PEM-encoded file on the local filesystem.
+    #[cfg(all(feature = "pem", feature = "std"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn load_pkcs8_pem(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        load_file(path).and_then(|bytes| {
+            let pem = std::str::from_utf8(&*bytes).map_err(|_| Error)?;
+            Self::from_pkcs8_pem(pem)
+        })
     }
 }
 
@@ -53,4 +75,29 @@ pub trait FromPublicKey: Sized {
     fn from_public_key_pem(s: &str) -> Result<Self> {
         Self::from_public_key_der(PublicKeyDocument::from_pem(s)?.as_ref())
     }
+
+    /// Load public key object from an ASN.1 DER-encoded file on the local
+    /// filesystem (binary format).
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn load_public_key_der(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        load_file(path).and_then(|bytes| Self::from_public_key_der(&*bytes))
+    }
+
+    /// Load public key object from a PEM-encoded file on the local filesystem.
+    #[cfg(all(feature = "pem", feature = "std"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn load_public_key_pem(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        load_file(path).and_then(|bytes| {
+            let pem = std::str::from_utf8(&*bytes).map_err(|_| Error)?;
+            Self::from_public_key_pem(pem)
+        })
+    }
+}
+
+/// Load data from a file into a self-zeroizing buffer
+#[cfg(feature = "std")]
+fn load_file(path: impl AsRef<std::path::Path>) -> Result<Zeroizing<Vec<u8>>> {
+    std::fs::read(path).map(Zeroizing::new).map_err(|_| Error)
 }


### PR DESCRIPTION
Adds the following methods gated on the `std` feature:

- `pkcs8::FromPrivateKey::{load_pkcs8_der, load_pkcs8_pem}`
- `pkcs8::FromPublicKey::{load_public_key_der, load_public_key_pem}`