### PR TITLE
pkcs8 v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "0.3.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "const-oid",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2020-12-06)
+### Added
+- Helper methods to load keys from the local filesystem ([#115])
+
+[#115]: https://github.com/RustCrypto/utils/pull/115
+
 ## 0.1.0 (2020-12-05)
 - Initial release

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -23,7 +23,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/pkcs8/0.1.0"
+    html_root_url = "https://docs.rs/pkcs8/0.1.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Helper methods to load keys from the local filesystem ([#115])

[#115]: https://github.com/RustCrypto/utils/pull/115