### PR TITLE
const-oid: add `ObjectIdentifier::{write_ber, to_ber}` methods

### DIFF
--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -35,7 +35,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --release --target ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release
+      - run: cargo build --target ${{ matrix.target }} --release --features alloc
 
   test:
     runs-on: ubuntu-latest
@@ -52,4 +53,5 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
+      - run: cargo test --release --features alloc
       - run: cargo test --release --all-features

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -15,4 +15,9 @@ keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"
 
 [features]
-std = []
+alloc = []
+std = ["alloc"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Support for serializing OIDs as ASN.1 BER