### PR TITLE
const-oid v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.3.4"
+version = "0.3.5"
 
 [[package]]
 name = "cpuid-bool"

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.5 (2020-12-12)
+### Added
+- `ObjectIdentifier::{write_ber, to_ber}` methods ([#118])
+
+[#118]: https://github.com/RustCrypto/utils/pull/118
+
 ## 0.3.4 (2020-12-06)
 ### Changed
 - Documentation improvements ([#112])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -27,7 +27,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/const-oid/0.3.4"
+    html_root_url = "https://docs.rs/const-oid/0.3.5"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- `ObjectIdentifier::{write_ber, to_ber}` methods ([#118])

[#118]: https://github.com/RustCrypto/utils/pull/118