### PR TITLE
pkcs8: DER encoding support

### DIFF
--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["crypto", "key", "private"]
 readme = "README.md"
 
 [dependencies.const-oid]
-version = "0.3"
+version = "0.3.5"
 path = "../const-oid"
 
 [dependencies.subtle-encoding]

--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -31,13 +31,30 @@ pub struct AlgorithmIdentifier {
 impl AlgorithmIdentifier {
     /// Parse [`AlgorithmIdentifier`] encoded as ASN.1 DER
     pub fn from_der(mut bytes: &[u8]) -> Result<Self> {
-        let algorithm = asn1::parse_algorithm_identifier(&mut bytes)?;
+        let algorithm = asn1::decoder::decode_algorithm_identifier(&mut bytes)?;
 
         if bytes.is_empty() {
             Ok(algorithm)
         } else {
             Err(Error)
         }
+    }
+
+    /// Write an ASN.1 DER-encoded [`AlgorithmIdentifier`] to the provided
+    /// buffer, returning a slice containing the encoded data.
+    pub fn write_der<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a [u8]> {
+        let offset = asn1::encoder::encode_algorithm_identifier(buffer, self)?;
+        Ok(&buffer[..offset])
+    }
+
+    /// Encode this [`AlgorithmIdentifier`] as ASN.1 DER
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn to_der(&self) -> alloc::vec::Vec<u8> {
+        let len = asn1::encoder::algorithm_identifier_len(self).unwrap();
+        let mut buffer = vec![0u8; len];
+        self.write_der(&mut buffer).unwrap();
+        buffer
     }
 }
 

--- a/pkcs8/src/asn1.rs
+++ b/pkcs8/src/asn1.rs
@@ -1,217 +1,26 @@
-//! PKCS#8 parser: supports the subset of ASN.1 DER needed to parse PKCS#8.
-//!
-//! Note: per RFC 5208, PKCS#8 is technically BER encoded (despite what
-//! things like the OpenSSL's `-outform DER` would lead you to believe).
-//!
-//! Despite that, this implementation presently attempts to reject BER-encoded
-//! PKCS#8 keys that are not valid DER. This is because PKCS#8 keys are
-//! typically described as "DER", and if it actually turns out to be a
-//! legitimate practical problem the parsing rules can be relaxed.
+//! ASN.1 decoder and encoder
 
-use crate::{
-    AlgorithmIdentifier, Error, ObjectIdentifier, PrivateKeyInfo, Result, SubjectPublicKeyInfo,
-};
+pub(crate) mod decoder;
+pub(crate) mod encoder;
 
-/// ASN.1 `INTEGER` tag
-const INTEGER_TAG: u8 = 0x02;
+/// ASN.1 tags
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Tag {
+    /// ASN.1 `INTEGER` tag
+    Integer = 0x02,
 
-/// ASN.1 `BIT STRING` tag
-const BIT_STRING_TAG: u8 = 0x03;
+    /// ASN.1 `BIT STRING` tag
+    BitString = 0x03,
 
-/// ASN.1 `OCTET STRING` tag
-const OCTET_STRING_TAG: u8 = 0x04;
+    /// ASN.1 `OCTET STRING` tag
+    OctetString = 0x04,
 
-/// ASN.1 `NULL` tag
-const NULL_TAG: u8 = 0x05;
+    /// ASN.1 `NULL` tag
+    Null = 0x05,
 
-/// ASN.1 `OBJECT IDENTIFIER` tag
-const OBJECT_IDENTIFIER_TAG: u8 = 0x06;
+    /// ASN.1 `OBJECT IDENTIFIER` tag
+    ObjectIdentifier = 0x06,
 
-/// ASN.1 `SEQUENCE` tag
-const SEQUENCE_TAG: u8 = 0x30;
-
-/// Parse a single byte from a slice
-fn parse_byte(bytes: &mut &[u8]) -> Result<u8> {
-    let byte = *bytes.get(0).ok_or(Error)?;
-    *bytes = &bytes[1..];
-    Ok(byte)
-}
-
-/// Parse DER-encoded length
-fn parse_len(bytes: &mut &[u8]) -> Result<usize> {
-    match parse_byte(bytes)? {
-        // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite
-        // lengths, which are not allowed in DER
-        len if len < 0x80 => Ok(len as usize),
-        0x81 => {
-            let len = parse_byte(bytes)? as usize;
-
-            // X.690 Section 10.1: DER lengths must be encoded with a minimum
-            // number of octets
-            if len >= 0x80 {
-                Ok(len)
-            } else {
-                Err(Error)
-            }
-        }
-        0x82 => {
-            let len_hi = parse_byte(bytes)? as usize;
-            let len = (len_hi << 8) | (parse_byte(bytes)? as usize);
-
-            // X.690 Section 10.1: DER lengths must be encoded with a minimum
-            // number of octets
-            if len > 0xFF {
-                Ok(len)
-            } else {
-                Err(Error)
-            }
-        }
-        _ => {
-            // We specialize to a maximum 3-byte length
-            Err(Error)
-        }
-    }
-}
-
-/// Parse DER-encoded INTEGER
-fn parse_integer(bytes: &mut &[u8]) -> Result<usize> {
-    if parse_byte(bytes)? != INTEGER_TAG {
-        return Err(Error);
-    }
-
-    // We presently specialize for 1-byte integers to parse versions
-    if parse_len(bytes)? == 1 {
-        Ok(parse_byte(bytes)? as usize)
-    } else {
-        Err(Error)
-    }
-}
-
-/// Parse length-delimited data
-fn parse_length_delimited<'a>(bytes: &mut &'a [u8], expected_tag: u8) -> Result<&'a [u8]> {
-    if parse_byte(bytes)? != expected_tag {
-        return Err(Error);
-    }
-
-    let len = parse_len(bytes)?;
-
-    if len <= bytes.len() {
-        let (head, tail) = bytes.split_at(len);
-        *bytes = tail;
-        Ok(head)
-    } else {
-        Err(Error)
-    }
-}
-
-/// Parse X.509 `AlgorithmIdentifier`.
-///
-/// Defined in RFC 5182 Section 4.1.1.2:
-/// <https://tools.ietf.org/html/rfc5280#section-4.1.1.2>
-///
-/// ```text
-/// AlgorithmIdentifier  ::=  SEQUENCE  {
-///      algorithm               OBJECT IDENTIFIER,
-///      parameters              ANY DEFINED BY algorithm OPTIONAL  }
-/// ```
-pub(crate) fn parse_algorithm_identifier(input: &mut &[u8]) -> Result<AlgorithmIdentifier> {
-    let mut bytes = parse_length_delimited(input, SEQUENCE_TAG)?;
-
-    // Check OBJECT ID header
-    if parse_byte(&mut bytes)? != OBJECT_IDENTIFIER_TAG {
-        return Err(Error);
-    }
-
-    let len = parse_len(&mut bytes)?;
-
-    if len > bytes.len() {
-        return Err(Error);
-    }
-
-    let (alg_bytes, mut param_bytes) = bytes.split_at(len);
-    let algorithm = ObjectIdentifier::from_ber(alg_bytes)?;
-
-    let parameters = match parse_byte(&mut param_bytes)? {
-        NULL_TAG => {
-            if parse_len(&mut param_bytes)? != 0 {
-                return Err(Error);
-            }
-
-            // Disallow any trailing data after the parameters
-            if !param_bytes.is_empty() {
-                return Err(Error);
-            }
-
-            None
-        }
-        OBJECT_IDENTIFIER_TAG => {
-            let len = parse_len(&mut param_bytes)?;
-
-            if len != param_bytes.len() {
-                return Err(Error);
-            }
-
-            Some(ObjectIdentifier::from_ber(param_bytes)?)
-        }
-        _ => return Err(Error),
-    };
-
-    Ok(AlgorithmIdentifier {
-        oid: algorithm,
-        parameters,
-    })
-}
-
-/// Parse a PKCS#8 document containing ASN.1 DER-encoded `PrivateKeyInfo`
-pub(crate) fn parse_private_key_info(mut input: &[u8]) -> Result<PrivateKeyInfo<'_>> {
-    let mut bytes = parse_length_delimited(&mut input, SEQUENCE_TAG)?;
-
-    if !input.is_empty() {
-        return Err(Error);
-    }
-
-    // Parse `version` INTEGER
-    let version = parse_integer(&mut bytes)?;
-
-    // RFC 5208 designates `0` as the only valid version for PKCS#8 documents
-    if version != 0 {
-        return Err(Error);
-    }
-
-    let algorithm = parse_algorithm_identifier(&mut bytes)?;
-    let private_key = parse_length_delimited(&mut bytes, OCTET_STRING_TAG)?;
-
-    // We currently don't support any trailing attribute data
-    if !bytes.is_empty() {
-        return Err(Error);
-    }
-
-    Ok(PrivateKeyInfo {
-        algorithm,
-        private_key,
-    })
-}
-
-/// Parse ASN.1 DER encoded `SubjectPublicKeyInfo`.
-///
-/// Note that this implementation assumes an outer `SEQUENCE` tag which is not
-/// present in X.509. This is for the purpose of public key storage.
-pub(crate) fn parse_spki(mut input: &[u8]) -> Result<SubjectPublicKeyInfo<'_>> {
-    let mut bytes = parse_length_delimited(&mut input, SEQUENCE_TAG)?;
-
-    if !input.is_empty() {
-        return Err(Error);
-    }
-
-    let algorithm = parse_algorithm_identifier(&mut bytes)?;
-    let subject_public_key = parse_length_delimited(&mut bytes, BIT_STRING_TAG)?;
-
-    if !bytes.is_empty() {
-        return Err(Error);
-    }
-
-    Ok(SubjectPublicKeyInfo {
-        algorithm,
-        subject_public_key,
-    })
+    /// ASN.1 `SEQUENCE` tag
+    Sequence = 0x30,
 }

--- a/pkcs8/src/asn1/decoder.rs
+++ b/pkcs8/src/asn1/decoder.rs
@@ -1,0 +1,199 @@
+//! PKCS#8 decoder: supports the subset of ASN.1 DER needed to parse PKCS#8.
+//!
+//! Note: per RFC 5208, PKCS#8 is technically BER encoded (despite what
+//! things like the OpenSSL's `-outform DER` would lead you to believe).
+//!
+//! Despite that, this implementation presently attempts to reject BER-encoded
+//! PKCS#8 keys that are not valid DER. This is because PKCS#8 keys are
+//! typically described as "DER", and if it actually turns out to be a
+//! legitimate practical problem the parsing rules can be relaxed.
+
+use super::Tag;
+use crate::{
+    AlgorithmIdentifier, Error, ObjectIdentifier, PrivateKeyInfo, Result, SubjectPublicKeyInfo,
+};
+
+/// Parse a single byte from a slice
+fn decode_byte(bytes: &mut &[u8]) -> Result<u8> {
+    let byte = *bytes.get(0).ok_or(Error)?;
+    *bytes = &bytes[1..];
+    Ok(byte)
+}
+
+/// Parse DER-encoded length
+fn decode_len(bytes: &mut &[u8]) -> Result<usize> {
+    match decode_byte(bytes)? {
+        // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite
+        // lengths, which are not allowed in DER
+        len if len < 0x80 => Ok(len as usize),
+        0x81 => {
+            let len = decode_byte(bytes)? as usize;
+
+            // X.690 Section 10.1: DER lengths must be encoded with a minimum
+            // number of octets
+            if len >= 0x80 {
+                Ok(len)
+            } else {
+                Err(Error)
+            }
+        }
+        0x82 => {
+            let len_hi = decode_byte(bytes)? as usize;
+            let len = (len_hi << 8) | (decode_byte(bytes)? as usize);
+
+            // X.690 Section 10.1: DER lengths must be encoded with a minimum
+            // number of octets
+            if len > 0xFF {
+                Ok(len)
+            } else {
+                Err(Error)
+            }
+        }
+        _ => {
+            // We specialize to a maximum 3-byte length
+            Err(Error)
+        }
+    }
+}
+
+/// Parse DER-encoded INTEGER
+fn decode_integer(bytes: &mut &[u8]) -> Result<usize> {
+    if decode_byte(bytes)? != Tag::Integer as u8 {
+        return Err(Error);
+    }
+
+    // We presently specialize for 1-byte integers to parse versions
+    if decode_len(bytes)? == 1 {
+        Ok(decode_byte(bytes)? as usize)
+    } else {
+        Err(Error)
+    }
+}
+
+/// Parse length-delimited data
+fn decode_length_delimited<'a>(bytes: &mut &'a [u8], expected_tag: Tag) -> Result<&'a [u8]> {
+    if decode_byte(bytes)? != expected_tag as u8 {
+        return Err(Error);
+    }
+
+    let len = decode_len(bytes)?;
+
+    if len <= bytes.len() {
+        let (head, tail) = bytes.split_at(len);
+        *bytes = tail;
+        Ok(head)
+    } else {
+        Err(Error)
+    }
+}
+
+/// Parse X.509 `AlgorithmIdentifier`.
+///
+/// Defined in RFC 5182 Section 4.1.1.2:
+/// <https://tools.ietf.org/html/rfc5280#section-4.1.1.2>
+///
+/// ```text
+/// AlgorithmIdentifier  ::=  SEQUENCE  {
+///      algorithm               OBJECT IDENTIFIER,
+///      parameters              ANY DEFINED BY algorithm OPTIONAL  }
+/// ```
+pub(crate) fn decode_algorithm_identifier(input: &mut &[u8]) -> Result<AlgorithmIdentifier> {
+    let mut bytes = decode_length_delimited(input, Tag::Sequence)?;
+
+    // Check OBJECT ID header
+    if decode_byte(&mut bytes)? != Tag::ObjectIdentifier as u8 {
+        return Err(Error);
+    }
+
+    let len = decode_len(&mut bytes)?;
+
+    if len > bytes.len() {
+        return Err(Error);
+    }
+
+    let (alg_bytes, mut param_bytes) = bytes.split_at(len);
+    let algorithm = ObjectIdentifier::from_ber(alg_bytes)?;
+    let tag = decode_byte(&mut param_bytes)?;
+
+    let parameters = if tag == Tag::Null as u8 {
+        if decode_len(&mut param_bytes)? != 0 {
+            return Err(Error);
+        }
+
+        // Disallow any trailing data after the parameters
+        if !param_bytes.is_empty() {
+            return Err(Error);
+        }
+
+        None
+    } else if tag == Tag::ObjectIdentifier as u8 {
+        let len = decode_len(&mut param_bytes)?;
+
+        if len != param_bytes.len() {
+            return Err(Error);
+        }
+
+        Some(ObjectIdentifier::from_ber(param_bytes)?)
+    } else {
+        return Err(Error);
+    };
+
+    Ok(AlgorithmIdentifier {
+        oid: algorithm,
+        parameters,
+    })
+}
+
+/// Parse a PKCS#8 document containing ASN.1 DER-encoded `PrivateKeyInfo`
+pub(crate) fn decode_private_key_info(mut input: &[u8]) -> Result<PrivateKeyInfo<'_>> {
+    let mut bytes = decode_length_delimited(&mut input, Tag::Sequence)?;
+
+    if !input.is_empty() {
+        return Err(Error);
+    }
+
+    // Parse `version` INTEGER
+    let version = decode_integer(&mut bytes)?;
+
+    // RFC 5208 designates `0` as the only valid version for PKCS#8 documents
+    if version != 0 {
+        return Err(Error);
+    }
+
+    let algorithm = decode_algorithm_identifier(&mut bytes)?;
+    let private_key = decode_length_delimited(&mut bytes, Tag::OctetString)?;
+
+    // We currently don't support any trailing attribute data
+    if !bytes.is_empty() {
+        return Err(Error);
+    }
+
+    Ok(PrivateKeyInfo {
+        algorithm,
+        private_key,
+    })
+}
+
+/// Parse ASN.1 DER encoded `SubjectPublicKeyInfo`.
+///
+/// Note that this implementation assumes an outer `SEQUENCE` tag which is not
+/// present in X.509. This is for the purpose of public key storage.
+pub(crate) fn decode_spki(mut input: &[u8]) -> Result<SubjectPublicKeyInfo<'_>> {
+    let mut bytes = decode_length_delimited(&mut input, Tag::Sequence)?;
+
+    if !input.is_empty() {
+        return Err(Error);
+    }
+
+    let algorithm = decode_algorithm_identifier(&mut bytes)?;
+    let subject_public_key = decode_length_delimited(&mut bytes, Tag::BitString)?;
+
+    if !bytes.is_empty() {
+        return Err(Error);
+    }
+
+    Ok(SubjectPublicKeyInfo {
+        algorithm,
+        subject_public_key,
+    })
+}

--- a/pkcs8/src/asn1/encoder.rs
+++ b/pkcs8/src/asn1/encoder.rs
@@ -1,0 +1,157 @@
+//! PKCS#8 encoder: supports the subset of ASN.1 DER needed to parse PKCS#8.
+//!
+//! Note: per RFC 5208, PKCS#8 is technically BER encoded (despite what
+//! things like the OpenSSL's `-outform DER` would lead you to believe).
+//!
+//! Despite that, this implementation presently attempts to encode
+//! PKCS#8 keys that are valid DER. This is because PKCS#8 keys are
+//! typically described as "DER", and if it actually turns out to be a
+//! legitimate practical problem the parsing rules can be relaxed.
+
+use super::Tag;
+use crate::{AlgorithmIdentifier, Error, ObjectIdentifier, PrivateKeyInfo, Result};
+
+/// Encode a single byte at the given offset
+fn encode_byte(buffer: &mut [u8], offset: usize, byte: u8) -> Result<()> {
+    buffer.get_mut(offset).map(|b| *b = byte).ok_or(Error)
+}
+
+/// Encode length prefix
+fn encode_len(buffer: &mut [u8], length: usize) -> Result<usize> {
+    match length {
+        0..=0x7F => {
+            encode_byte(buffer, 0, length as u8)?;
+            Ok(1)
+        }
+        0x80..=0xFF => {
+            encode_byte(buffer, 0, 0x81)?;
+            encode_byte(buffer, 1, length as u8)?;
+            Ok(2)
+        }
+        0x100..=0xFFFF => {
+            encode_byte(buffer, 0, 0x82)?;
+            encode_byte(buffer, 1, (length >> 8) as u8)?;
+            encode_byte(buffer, 2, (length & 0xFF) as u8)?;
+            Ok(3)
+        }
+        _ => Err(Error),
+    }
+}
+
+/// Compute the length of a header including the tag byte
+fn header_len(body_len: usize) -> Result<usize> {
+    match body_len {
+        0..=0x7F => Ok(2),
+        0x80..=0xFF => Ok(3),
+        0x100..=0xFFFF => Ok(4),
+        _ => Err(Error),
+    }
+}
+
+/// Encode a tag and a length header
+pub(crate) fn encode_header(buffer: &mut [u8], tag: Tag, length: usize) -> Result<usize> {
+    encode_byte(buffer, 0, tag as u8)?;
+    encode_len(&mut buffer[1..], length).and_then(|len| len.checked_add(1).ok_or(Error))
+}
+
+/// Encode length-delimited tagged data
+pub(crate) fn encode_length_delimited(buffer: &mut [u8], tag: Tag, data: &[u8]) -> Result<usize> {
+    let offset = encode_header(buffer, tag, data.len())?;
+
+    if buffer[offset..].len() < data.len() {
+        return Err(Error);
+    }
+
+    buffer[offset..(offset + data.len())].copy_from_slice(data);
+    offset.checked_add(data.len()).ok_or(Error)
+}
+
+/// Get the length of a DER-encoded OID
+pub(crate) fn oid_len(oid: ObjectIdentifier) -> Result<usize> {
+    let body_len = oid.ber_len();
+    header_len(body_len)?.checked_add(body_len).ok_or(Error)
+}
+
+/// Encode an OID
+pub(crate) fn encode_oid(buffer: &mut [u8], oid: ObjectIdentifier) -> Result<usize> {
+    let offset = encode_header(buffer, Tag::ObjectIdentifier, oid.ber_len())?;
+
+    offset
+        .checked_add(oid.write_ber(&mut buffer[offset..])?.len())
+        .ok_or(Error)
+}
+
+/// Get the length of a DER-encoded [`AlgorithmIdentifier`]
+pub(crate) fn algorithm_identifier_len(algorithm_id: &AlgorithmIdentifier) -> Result<usize> {
+    let alg_oid_len = oid_len(algorithm_id.oid)?;
+    let params_len = match algorithm_id.parameters {
+        Some(p) => oid_len(p)?,
+        None => 2, // OID or NULL (2-bytes)
+    };
+    let sequence_len = alg_oid_len.checked_add(params_len).unwrap();
+    header_len(sequence_len).and_then(|n| n.checked_add(sequence_len).ok_or(Error))
+}
+
+/// Encode an [`AlgorithmIdentifier`]
+pub(crate) fn encode_algorithm_identifier(
+    buffer: &mut [u8],
+    algorithm_id: &AlgorithmIdentifier,
+) -> Result<usize> {
+    let alg_oid_len = oid_len(algorithm_id.oid)?;
+    let params_len = match algorithm_id.parameters {
+        Some(p) => oid_len(p)?,
+        None => 2, // OID or NULL (2-bytes)
+    };
+    let sequence_len = alg_oid_len.checked_add(params_len).unwrap();
+
+    let mut offset = encode_header(buffer, Tag::Sequence, sequence_len)?;
+    offset += encode_oid(&mut buffer[offset..], algorithm_id.oid)?;
+    offset += match algorithm_id.parameters {
+        Some(oid) => encode_oid(&mut buffer[offset..], oid)?,
+        None => encode_header(&mut buffer[offset..], Tag::Null, 0)?,
+    };
+
+    Ok(offset)
+}
+
+/// Get the length of a DER-encoded [`PrivateKeyInfo`]
+#[cfg(feature = "alloc")]
+pub(crate) fn private_key_info_len(private_key_info: &PrivateKeyInfo<'_>) -> Result<usize> {
+    let alg_id_len = algorithm_identifier_len(&private_key_info.algorithm)?;
+    let version_len = 3;
+    let private_key_len = header_len(private_key_info.private_key.len())?
+        .checked_add(private_key_info.private_key.len())
+        .ok_or(Error)?;
+    let sequence_len = alg_id_len
+        .checked_add(version_len)
+        .and_then(|len| len.checked_add(private_key_len))
+        .ok_or(Error)?;
+    header_len(sequence_len).and_then(|n| n.checked_add(sequence_len).ok_or(Error))
+}
+
+/// Encode [`PrivateKeyInfo`]
+pub(crate) fn encode_private_key_info(
+    buffer: &mut [u8],
+    private_key_info: &PrivateKeyInfo<'_>,
+) -> Result<usize> {
+    let alg_id_len = algorithm_identifier_len(&private_key_info.algorithm)?;
+    let version_len = 3;
+    let private_key_len = header_len(private_key_info.private_key.len())?
+        .checked_add(private_key_info.private_key.len())
+        .ok_or(Error)?;
+    let sequence_len = alg_id_len
+        .checked_add(version_len)
+        .and_then(|len| len.checked_add(private_key_len))
+        .ok_or(Error)?;
+
+    let mut offset = encode_header(buffer, Tag::Sequence, sequence_len)?;
+    offset += encode_length_delimited(&mut buffer[offset..], Tag::Integer, &[0])?;
+    offset += encode_algorithm_identifier(&mut buffer[offset..], &private_key_info.algorithm)?;
+    offset += encode_length_delimited(
+        &mut buffer[offset..],
+        Tag::OctetString,
+        private_key_info.private_key,
+    )?;
+
+    Ok(offset)
+}

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -29,6 +29,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -38,7 +38,24 @@ pub struct PrivateKeyInfo<'a> {
 impl<'a> PrivateKeyInfo<'a> {
     /// Parse [`PrivateKeyInfo`] encoded as ASN.1 DER
     pub fn from_der(bytes: &'a [u8]) -> Result<Self> {
-        asn1::parse_private_key_info(bytes)
+        asn1::decoder::decode_private_key_info(bytes)
+    }
+
+    /// Write an ASN.1 DER-encoded [`AlgorithmIdentifier`] to the provided
+    /// buffer, returning a slice containing the encoded data.
+    pub fn write_der<'b>(&self, buffer: &'b mut [u8]) -> Result<&'b [u8]> {
+        let offset = asn1::encoder::encode_private_key_info(buffer, self)?;
+        Ok(&buffer[..offset])
+    }
+
+    /// Encode this [`AlgorithmIdentifier`] as ASN.1 DER
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn to_der(&self) -> alloc::vec::Vec<u8> {
+        let len = asn1::encoder::private_key_info_len(self).unwrap();
+        let mut buffer = vec![0u8; len];
+        self.write_der(&mut buffer).unwrap();
+        buffer
     }
 }
 

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -28,7 +28,7 @@ pub struct SubjectPublicKeyInfo<'a> {
 impl<'a> SubjectPublicKeyInfo<'a> {
     /// Parse [`SubjectPublicKeyInfo`] encoded as ASN.1 DER
     pub fn from_der(bytes: &'a [u8]) -> Result<Self> {
-        asn1::parse_spki(bytes)
+        asn1::decoder::decode_spki(bytes)
     }
 }
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -66,3 +66,19 @@ fn parse_rsa_2048_pem() {
     let pk_info = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
 }
+
+#[test]
+#[cfg(feature = "alloc")]
+fn serialize_ec_p256_pem() {
+    let pk = PrivateKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_der();
+    assert_eq!(EC_P256_DER_EXAMPLE, pk_encoded);
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn serialize_rsa_2048_pem() {
+    let pk = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_der();
+    assert_eq!(RSA_2048_DER_EXAMPLE, pk_encoded);
+}


### PR DESCRIPTION
Adds support for encoding `AlgorithmIdentifier` and `PrivateKeyInfo`