### PR TITLE
pkcs8: PEM encoder support

### DIFF
--- a/pkcs8/src/document.rs
+++ b/pkcs8/src/document.rs
@@ -38,7 +38,7 @@ impl PrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn from_pem(s: &str) -> Result<Self> {
-        let der_bytes = pem::parse(s, pem::BEGIN_PRIVATE_KEY, pem::END_PRIVATE_KEY)?;
+        let der_bytes = pem::parse(s, pem::PRIVATE_KEY_BOUNDARY)?;
         Self::from_der(&*der_bytes)
     }
 
@@ -107,7 +107,7 @@ impl PublicKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn from_pem(s: &str) -> Result<Self> {
-        let der_bytes = pem::parse(s, pem::BEGIN_PUBLIC_KEY, pem::END_PUBLIC_KEY)?;
+        let der_bytes = pem::parse(s, pem::PUBLIC_KEY_BOUNDARY)?;
         Self::from_der(&*der_bytes)
     }
 

--- a/pkcs8/src/pem.rs
+++ b/pkcs8/src/pem.rs
@@ -1,21 +1,31 @@
 //! PEM encoding support (RFC 7468)
 
 use crate::{Error, Result};
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
+use core::str;
 use subtle_encoding::base64;
 use zeroize::Zeroizing;
 
-/// Private key pre-encapsulation boundary
-pub(crate) const BEGIN_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\n";
+/// Encapsulation boundaries
+pub(crate) struct Boundary {
+    /// Pre-encapsulation boundary
+    pre: &'static str,
 
-/// Private key post-encapsulation boundary
-pub(crate) const END_PRIVATE_KEY: &str = "\n-----END PRIVATE KEY-----";
+    /// Post-encapsulation boundary
+    post: &'static str,
+}
 
-/// Public key pre-encapsulation boundary
-pub(crate) const BEGIN_PUBLIC_KEY: &str = "-----BEGIN PUBLIC KEY-----\n";
+/// Private key encapsulation boundary
+pub(crate) const PRIVATE_KEY_BOUNDARY: Boundary = Boundary {
+    pre: "-----BEGIN PRIVATE KEY-----\n",
+    post: "\n-----END PRIVATE KEY-----",
+};
 
-/// Public key post-encapsulation boundary
-pub(crate) const END_PUBLIC_KEY: &str = "\n-----END PUBLIC KEY-----";
+/// Public key encapsulation boundary
+pub(crate) const PUBLIC_KEY_BOUNDARY: Boundary = Boundary {
+    pre: "-----BEGIN PUBLIC KEY-----\n",
+    post: "\n-----END PUBLIC KEY-----",
+};
 
 /// Parse "PEM encoding" as described in RFC 7468:
 /// <https://tools.ietf.org/html/rfc7468>
@@ -25,16 +35,39 @@ pub(crate) const END_PUBLIC_KEY: &str = "\n-----END PUBLIC KEY-----";
 /// implements a dialect intended for textual encodings of PKIX,
 /// PKCS, and CMS structures.
 // TODO(tarcieri): better harden for fully constant-time operation
-pub(crate) fn parse(s: &str, begin: &str, end: &str) -> Result<Zeroizing<Vec<u8>>> {
+pub(crate) fn parse(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> {
     let s = s.trim_end();
 
     // TODO(tarcieri): handle missing newlines
-    let s = s.strip_prefix(begin).ok_or(Error)?;
-    let s = s.strip_suffix(end).ok_or(Error)?;
+    let s = s.strip_prefix(boundary.pre).ok_or(Error)?;
+    let s = s.strip_suffix(boundary.post).ok_or(Error)?;
 
     // TODO(tarcieri): fix subtle-encoding to tolerate whitespace
     let mut s = Zeroizing::new(s.to_owned());
     s.retain(|c| !c.is_whitespace());
 
     base64::decode(&*s).map_err(|_| Error).map(Zeroizing::new)
+}
+
+/// Serialize "PEM encoding" as described in RFC 7468:
+/// <https://tools.ietf.org/html/rfc7468>
+pub(crate) fn serialize(data: &[u8], boundary: Boundary) -> Result<String> {
+    let mut output = String::new();
+    output.push_str(boundary.pre);
+
+    let b64 = Zeroizing::new(base64::encode(data));
+    let chunks = b64.chunks(64);
+    let nchunks = chunks.len();
+
+    for (i, chunk) in chunks.enumerate() {
+        let line = str::from_utf8(chunk).expect("malformed base64");
+        output.push_str(line);
+
+        if i < nchunks.checked_sub(1).expect("unexpected chunks") {
+            output.push('\n');
+        }
+    }
+
+    output.push_str(boundary.post);
+    Ok(output)
 }

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -3,6 +3,9 @@
 use crate::{asn1, AlgorithmIdentifier, Error, Result};
 use core::convert::TryFrom;
 
+#[cfg(feature = "pem")]
+use crate::pem;
+
 /// X.509 `SubjectPublicKeyInfo` (SPKI)
 ///
 /// ASN.1 structure containing an [`AlgorithmIdentifier`] and public key
@@ -46,6 +49,14 @@ impl<'a> SubjectPublicKeyInfo<'a> {
         let mut buffer = vec![0u8; len];
         self.write_der(&mut buffer).unwrap();
         buffer
+    }
+
+    /// Encode this [`SubjectPublicKeyInfo`] as PEM-encoded ASN.1 DER.
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem(&self) -> alloc::string::String {
+        let doc = self.to_der();
+        pem::serialize(doc.as_ref(), pem::PUBLIC_KEY_BOUNDARY).expect("malformed PEM")
     }
 }
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -69,16 +69,32 @@ fn parse_rsa_2048_pem() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn serialize_ec_p256_pem() {
+fn serialize_ec_p256_der() {
     let pk = PrivateKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
-    assert_eq!(EC_P256_DER_EXAMPLE, pk_encoded);
+    assert_eq!(EC_P256_DER_EXAMPLE, pk_encoded.as_ref());
 }
 
 #[test]
 #[cfg(feature = "alloc")]
-fn serialize_rsa_2048_pem() {
+fn serialize_rsa_2048_der() {
     let pk = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
-    assert_eq!(RSA_2048_DER_EXAMPLE, pk_encoded);
+    assert_eq!(RSA_2048_DER_EXAMPLE, pk_encoded.as_ref());
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn serialize_ec_p256_pem() {
+    let pk = PrivateKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_pem();
+    assert_eq!(EC_P256_PEM_EXAMPLE, &*pk_encoded);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn serialize_rsa_2048_pem() {
+    let pk = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_pem();
+    assert_eq!(RSA_2048_PEM_EXAMPLE, &*pk_encoded);
 }

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -64,7 +64,7 @@ fn parse_rsa_2048_pem() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn serialize_ec_p256_pem() {
+fn serialize_ec_p256_der() {
     let pk = SubjectPublicKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
     assert_eq!(EC_P256_DER_EXAMPLE, pk_encoded);
@@ -72,8 +72,24 @@ fn serialize_ec_p256_pem() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn serialize_rsa_2048_pem() {
+fn serialize_rsa_2048_der() {
     let pk = SubjectPublicKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
     assert_eq!(RSA_2048_DER_EXAMPLE, pk_encoded);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn serialize_ec_p256_pem() {
+    let pk = SubjectPublicKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_pem();
+    assert_eq!(EC_P256_PEM_EXAMPLE.trim_end(), pk_encoded);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn serialize_rsa_2048_pem() {
+    let pk = SubjectPublicKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_pem();
+    assert_eq!(RSA_2048_PEM_EXAMPLE.trim_end(), pk_encoded);
 }


### PR DESCRIPTION
Support for encoding keys in RFC 7468 "PEM encoding" format.