### PR TITLE
pkcs8: PEM serialization support

### DIFF
--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -53,9 +53,12 @@ pub use crate::{
     error::{Error, Result},
     private_key_info::PrivateKeyInfo,
     spki::SubjectPublicKeyInfo,
-    traits::{FromPrivateKey, FromPublicKey, ToPrivateKey, ToPublicKey},
+    traits::{FromPrivateKey, FromPublicKey},
 };
 pub use const_oid::ObjectIdentifier;
 
 #[cfg(feature = "alloc")]
-pub use crate::document::{PrivateKeyDocument, PublicKeyDocument};
+pub use crate::{
+    document::{PrivateKeyDocument, PublicKeyDocument},
+    traits::{ToPrivateKey, ToPublicKey},
+};

--- a/pkcs8/src/pem.rs
+++ b/pkcs8/src/pem.rs
@@ -35,7 +35,7 @@ pub(crate) const PUBLIC_KEY_BOUNDARY: Boundary = Boundary {
 /// implements a dialect intended for textual encodings of PKIX,
 /// PKCS, and CMS structures.
 // TODO(tarcieri): better harden for fully constant-time operation
-pub(crate) fn parse(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> {
+pub(crate) fn decode(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> {
     let s = s.trim_end();
 
     // TODO(tarcieri): handle missing newlines
@@ -51,7 +51,7 @@ pub(crate) fn parse(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> {
 
 /// Serialize "PEM encoding" as described in RFC 7468:
 /// <https://tools.ietf.org/html/rfc7468>
-pub(crate) fn serialize(data: &[u8], boundary: Boundary) -> Result<String> {
+pub(crate) fn encode(data: &[u8], boundary: Boundary) -> String {
     let mut output = String::new();
     output.push_str(boundary.pre);
 
@@ -69,5 +69,5 @@ pub(crate) fn serialize(data: &[u8], boundary: Boundary) -> Result<String> {
     }
 
     output.push_str(boundary.post);
-    Ok(output)
+    output
 }

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -4,9 +4,7 @@ use crate::{asn1, AlgorithmIdentifier, Error, Result};
 use core::{convert::TryFrom, fmt};
 
 #[cfg(feature = "alloc")]
-use crate::document::PrivateKeyDocument;
-#[cfg(feature = "alloc")]
-use zeroize::Zeroizing;
+use {crate::document::PrivateKeyDocument, zeroize::Zeroizing};
 
 #[cfg(feature = "pem")]
 use crate::pem;
@@ -71,7 +69,7 @@ impl<'a> PrivateKeyInfo<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<alloc::string::String> {
         let doc = self.to_der();
-        let pem = pem::serialize(doc.as_ref(), pem::PRIVATE_KEY_BOUNDARY).expect("malformed PEM");
+        let pem = pem::encode(doc.as_ref(), pem::PRIVATE_KEY_BOUNDARY);
         Zeroizing::new(pem)
     }
 }

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -67,7 +67,7 @@ fn parse_rsa_2048_pem() {
 fn serialize_ec_p256_der() {
     let pk = SubjectPublicKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
-    assert_eq!(EC_P256_DER_EXAMPLE, pk_encoded);
+    assert_eq!(EC_P256_DER_EXAMPLE, pk_encoded.as_ref());
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn serialize_ec_p256_der() {
 fn serialize_rsa_2048_der() {
     let pk = SubjectPublicKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
-    assert_eq!(RSA_2048_DER_EXAMPLE, pk_encoded);
+    assert_eq!(RSA_2048_DER_EXAMPLE, pk_encoded.as_ref());
 }
 
 #[test]


### PR DESCRIPTION
Support for serializing the following as PEM:

- `PrivateKeyInfo`, `SubjectPublicKeyInfo`
- `PrivateKeyDocument`, `PublicKeyDocument`
- Trait-based serialization via `ToPrivateKey`, `ToPublicKey`