### PR TITLE
pkcs8: rename `load_*_file` methods to `read_*_file`

### DIFF
--- a/pkcs8/src/document.rs
+++ b/pkcs8/src/document.rs
@@ -55,7 +55,7 @@ impl PrivateKeyDocument {
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn load_der_file(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn read_der_file(path: impl AsRef<Path>) -> Result<Self> {
         fs::read(path).map_err(|_| Error).and_then(Self::try_from)
     }
 
@@ -63,7 +63,7 @@ impl PrivateKeyDocument {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn load_pem_file(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn read_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let bytes = fs::read(path).map(Zeroizing::new).map_err(|_| Error)?;
         let pem = str::from_utf8(&*bytes).map_err(|_| Error)?;
         Self::from_pem(pem)
@@ -178,7 +178,7 @@ impl PublicKeyDocument {
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn load_der_file(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn read_der_file(path: impl AsRef<Path>) -> Result<Self> {
         fs::read(path).map_err(|_| Error).and_then(Self::try_from)
     }
 
@@ -186,7 +186,7 @@ impl PublicKeyDocument {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn load_pem_file(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn read_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let pem = fs::read_to_string(path).map_err(|_| Error)?;
         Self::from_pem(&pem)
     }

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -49,16 +49,16 @@ pub trait FromPrivateKey: Sized {
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn load_pkcs8_der_file(path: impl AsRef<Path>) -> Result<Self> {
-        PrivateKeyDocument::load_der_file(path).and_then(|doc| Self::from_pkcs8_doc(&doc))
+    fn read_pkcs8_der_file(path: impl AsRef<Path>) -> Result<Self> {
+        PrivateKeyDocument::read_der_file(path).and_then(|doc| Self::from_pkcs8_doc(&doc))
     }
 
     /// Load PKCS#8 private key from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn load_pkcs8_pem_file(path: impl AsRef<Path>) -> Result<Self> {
-        PrivateKeyDocument::load_pem_file(path).and_then(|doc| Self::from_pkcs8_doc(&doc))
+    fn read_pkcs8_pem_file(path: impl AsRef<Path>) -> Result<Self> {
+        PrivateKeyDocument::read_pem_file(path).and_then(|doc| Self::from_pkcs8_doc(&doc))
     }
 }
 
@@ -97,16 +97,16 @@ pub trait FromPublicKey: Sized {
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn load_public_key_der_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
-        PublicKeyDocument::load_der_file(path).and_then(|doc| Self::from_public_key_doc(&doc))
+    fn read_public_key_der_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        PublicKeyDocument::read_der_file(path).and_then(|doc| Self::from_public_key_doc(&doc))
     }
 
     /// Load public key object from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn load_public_key_pem_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
-        PublicKeyDocument::load_pem_file(path).and_then(|doc| Self::from_public_key_doc(&doc))
+    fn read_public_key_pem_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        PublicKeyDocument::read_pem_file(path).and_then(|doc| Self::from_public_key_doc(&doc))
     }
 }
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -104,14 +104,14 @@ fn serialize_rsa_2048_pem() {
 
 #[test]
 #[cfg(feature = "std")]
-fn load_der_file() {
-    let pkcs8_doc = PrivateKeyDocument::load_der_file("tests/examples/p256-priv.der").unwrap();
+fn read_der_file() {
+    let pkcs8_doc = PrivateKeyDocument::read_der_file("tests/examples/p256-priv.der").unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }
 
 #[test]
 #[cfg(all(feature = "pem", feature = "std"))]
-fn load_pem_file() {
-    let pkcs8_doc = PrivateKeyDocument::load_pem_file("tests/examples/p256-priv.pem").unwrap();
+fn read_pem_file() {
+    let pkcs8_doc = PrivateKeyDocument::read_pem_file("tests/examples/p256-priv.pem").unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -99,14 +99,14 @@ fn serialize_rsa_2048_pem() {
 
 #[test]
 #[cfg(feature = "std")]
-fn load_der_file() {
-    let pkcs8_doc = PublicKeyDocument::load_der_file("tests/examples/p256-pub.der").unwrap();
+fn read_der_file() {
+    let pkcs8_doc = PublicKeyDocument::read_der_file("tests/examples/p256-pub.der").unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }
 
 #[test]
 #[cfg(all(feature = "pem", feature = "std"))]
-fn load_pem_file() {
-    let pkcs8_doc = PublicKeyDocument::load_pem_file("tests/examples/p256-pub.pem").unwrap();
+fn read_pem_file() {
+    let pkcs8_doc = PublicKeyDocument::read_pem_file("tests/examples/p256-pub.pem").unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }


### PR DESCRIPTION
Renames methods which read data from files to be prefixed with `read_*`

This is more consistent with Rust's `io::Read` trait.