### PR TITLE
pkcs8: error enum

### DIFF
--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -36,7 +36,7 @@ impl AlgorithmIdentifier {
         if bytes.is_empty() {
             Ok(algorithm)
         } else {
-            Err(Error)
+            Err(Error::Decode)
         }
     }
 

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -2,24 +2,66 @@
 
 use core::fmt;
 
+/// Result type
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Error type
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Error;
+#[non_exhaustive]
+pub enum Error {
+    /// Decoding errors
+    Decode,
+
+    /// Encoding errors
+    Encode,
+
+    /// General I/O errors
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    Io,
+
+    /// File not found error
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    FileNotFound,
+
+    /// Permission denied reading file
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    PermissionDenied,
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("PKCS#8 error")
-    }
-}
-
-impl From<const_oid::Error> for Error {
-    fn from(_: const_oid::Error) -> Error {
-        Error
+        match self {
+            Error::Decode => f.write_str("PKCS#8 decoding error"),
+            Error::Encode => f.write_str("PKCS#8 encoding error"),
+            #[cfg(feature = "std")]
+            Error::Io => f.write_str("I/O error"),
+            #[cfg(feature = "std")]
+            Error::FileNotFound => f.write_str("file not found"),
+            #[cfg(feature = "std")]
+            Error::PermissionDenied => f.write_str("permission denied"),
+        }
     }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
-/// Result type
-pub type Result<T> = core::result::Result<T, Error>;
+impl From<const_oid::Error> for Error {
+    fn from(_: const_oid::Error) -> Error {
+        Error::Decode
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error {
+        match err.kind() {
+            std::io::ErrorKind::NotFound => Error::FileNotFound,
+            std::io::ErrorKind::PermissionDenied => Error::PermissionDenied,
+            _ => Error::Io,
+        }
+    }
+}

--- a/pkcs8/src/pem.rs
+++ b/pkcs8/src/pem.rs
@@ -39,14 +39,16 @@ pub(crate) fn decode(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> 
     let s = s.trim_end();
 
     // TODO(tarcieri): handle missing newlines
-    let s = s.strip_prefix(boundary.pre).ok_or(Error)?;
-    let s = s.strip_suffix(boundary.post).ok_or(Error)?;
+    let s = s.strip_prefix(boundary.pre).ok_or(Error::Decode)?;
+    let s = s.strip_suffix(boundary.post).ok_or(Error::Decode)?;
 
     // TODO(tarcieri): fix subtle-encoding to tolerate whitespace
     let mut s = Zeroizing::new(s.to_owned());
     s.retain(|c| !c.is_whitespace());
 
-    base64::decode(&*s).map_err(|_| Error).map(Zeroizing::new)
+    base64::decode(&*s)
+        .map_err(|_| Error::Decode)
+        .map(Zeroizing::new)
 }
 
 /// Serialize "PEM encoding" as described in RFC 7468:


### PR DESCRIPTION
The previous opaque `Error` makes it impossible to distinguish from decoding errors (i.e. malformed ASN.1 DER) versus common filesystem errors which might occur, such as files not existing or permission errors.

This commit adds a very simple error enum which makes it possible to distinguish these cases and provides better error messages when these events occur.