### PR TITLE
pkcs8 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "0.3.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "const-oid",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2020-12-14)
+### Added
+- File writing methods for public/private keys ([#126])
+- Methods for loading `*Document` types from files ([#125])
+- DER encoding support ([#120], [#121])
+- PEM encoding support ([#122], [#124])
+- `ToPrivateKey`/`ToPublicKey` traits ([#123])
+
+### Changed
+- `Error` enum ([#128])
+- Rename `load_*_file` methods to `read_*_file` ([#127])
+
+[#128]: https://github.com/RustCrypto/utils/pull/128
+[#127]: https://github.com/RustCrypto/utils/pull/127
+[#126]: https://github.com/RustCrypto/utils/pull/126
+[#125]: https://github.com/RustCrypto/utils/pull/125
+[#124]: https://github.com/RustCrypto/utils/pull/124
+[#123]: https://github.com/RustCrypto/utils/pull/123
+[#122]: https://github.com/RustCrypto/utils/pull/122
+[#121]: https://github.com/RustCrypto/utils/pull/121
+[#120]: https://github.com/RustCrypto/utils/pull/120
+
 ## 0.1.1 (2020-12-06)
 ### Added
 - Helper methods to load keys from the local filesystem ([#115])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.1.1"
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -23,7 +23,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/pkcs8/0.1.1"
+    html_root_url = "https://docs.rs/pkcs8/0.2.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- File writing methods for public/private keys ([#126])
- Methods for loading `*Document` types from files ([#125])
- DER encoding support ([#120], [#121])
- PEM encoding support ([#122], [#124])
- `ToPrivateKey`/`ToPublicKey` traits ([#123])

### Changed
- `Error` enum ([#128])
- Rename `load_*_file` methods to `read_*_file` ([#127])

[#128]: https://github.com/RustCrypto/utils/pull/128
[#127]: https://github.com/RustCrypto/utils/pull/127
[#126]: https://github.com/RustCrypto/utils/pull/126
[#125]: https://github.com/RustCrypto/utils/pull/125
[#124]: https://github.com/RustCrypto/utils/pull/124
[#123]: https://github.com/RustCrypto/utils/pull/123
[#122]: https://github.com/RustCrypto/utils/pull/122
[#121]: https://github.com/RustCrypto/utils/pull/121
[#120]: https://github.com/RustCrypto/utils/pull/120