### PR TITLE
pkcs8: special case RSA AlgorithmIdentifier parameters encoding

### DIFF
--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -3,6 +3,12 @@
 use crate::{asn1, Error, ObjectIdentifier, Result};
 use core::convert::TryFrom;
 
+/// [`AlgorithmIdentifier`] OID for RSA.
+/// We special case handling of RSA for compliance with [RFC 3279].
+///
+/// [RFC 3279]: https://tools.ietf.org/html/rfc3279
+const RSA_ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 1, 1]);
+
 /// X.509 `AlgorithmIdentifier`
 ///
 /// Defined in RFC 5280 Section 4.1.1.2:
@@ -55,6 +61,18 @@ impl AlgorithmIdentifier {
         let mut buffer = vec![0u8; len];
         self.write_der(&mut buffer).unwrap();
         buffer
+    }
+
+    /// Special case handling for the `parameters` field for RSA's
+    /// [`AlgorithmIdentifier`] to ensure compliance with
+    /// [RFC 3279 Section 2.3.1][1]:
+    ///
+    /// > The parameters field MUST have ASN.1 type NULL for this
+    /// > algorithm identifier.
+    ///
+    /// [1]: https://tools.ietf.org/html/rfc3279#section-2.3.1
+    pub(crate) fn is_params_field_null(&self) -> bool {
+        self.oid == RSA_ALGORITHM_OID
     }
 }
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -113,6 +113,14 @@ fn serialize_ec_p256_der() {
 
 #[test]
 #[cfg(feature = "alloc")]
+fn serialize_ed25519_der() {
+    let pk = PrivateKeyInfo::from_der(ED25519_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_der();
+    assert_eq!(ED25519_DER_EXAMPLE, pk_encoded.as_ref());
+}
+
+#[test]
+#[cfg(feature = "alloc")]
 fn serialize_rsa_2048_der() {
     let pk = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
@@ -124,7 +132,15 @@ fn serialize_rsa_2048_der() {
 fn serialize_ec_p256_pem() {
     let pk = PrivateKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_pem();
-    assert_eq!(EC_P256_PEM_EXAMPLE, &*pk_encoded);
+    assert_eq!(EC_P256_PEM_EXAMPLE.trim_end(), &*pk_encoded);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn serialize_ed25519_pem() {
+    let pk = PrivateKeyInfo::from_der(ED25519_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_pem();
+    assert_eq!(ED25519_PEM_EXAMPLE.trim_end(), &*pk_encoded);
 }
 
 #[test]
@@ -132,7 +148,7 @@ fn serialize_ec_p256_pem() {
 fn serialize_rsa_2048_pem() {
     let pk = PrivateKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_pem();
-    assert_eq!(RSA_2048_PEM_EXAMPLE, &*pk_encoded);
+    assert_eq!(RSA_2048_PEM_EXAMPLE.trim_end(), &*pk_encoded);
 }
 
 #[test]

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -105,6 +105,14 @@ fn serialize_ec_p256_der() {
 
 #[test]
 #[cfg(feature = "alloc")]
+fn serialize_ed25519_der() {
+    let pk = SubjectPublicKeyInfo::from_der(ED25519_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_der();
+    assert_eq!(ED25519_DER_EXAMPLE, pk_encoded.as_ref());
+}
+
+#[test]
+#[cfg(feature = "alloc")]
 fn serialize_rsa_2048_der() {
     let pk = SubjectPublicKeyInfo::from_der(RSA_2048_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_der();
@@ -117,6 +125,14 @@ fn serialize_ec_p256_pem() {
     let pk = SubjectPublicKeyInfo::from_der(EC_P256_DER_EXAMPLE).unwrap();
     let pk_encoded = pk.to_pem();
     assert_eq!(EC_P256_PEM_EXAMPLE.trim_end(), pk_encoded);
+}
+
+#[test]
+#[cfg(feature = "pem")]
+fn serialize_ed25519_pem() {
+    let pk = SubjectPublicKeyInfo::from_der(ED25519_DER_EXAMPLE).unwrap();
+    let pk_encoded = pk.to_pem();
+    assert_eq!(ED25519_PEM_EXAMPLE.trim_end(), pk_encoded);
 }
 
 #[test]


### PR DESCRIPTION
The immediate goal of this change is to ensure Ed25519 keys are encoded with AlgorithmIdentifiers that match keys generated by OpenSSL.

The `parameters` field of `AlgorithmIdentifier` is defined as being optional, and Ed25519 keys take advantage of this and completely omit any sort of `parameters` from the ASN.1 SEQUENCE.

The previous encoding logic hardcoded the RSA encoding behavior defined in RFC 3279 Section 2.3.1:

> The parameters field MUST have ASN.1 type NULL for this
> algorithm identifier.

However, this encoding appears to be a sort of unique historical accident specific to RSA.

While we could pursue a solution that doesn't require special casing RSA, it would be a breaking API change at the very least. It would also complicate the API for (all?) non-RSA algorithms.