### PR TITLE
const-oid: rename nodes to arcs

### DIFF
--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -45,16 +45,17 @@ extern crate std;
 
 use core::{convert::TryFrom, fmt, str::FromStr};
 
-/// Maximum number of nodes in an OID.
+/// Maximum number of arcs in an OID.
 ///
-/// Note: this is specialized to RustCrypto use cases for now.
-pub const MAX_NODES: usize = 10;
+/// Note: this limit is not a part of the OID standard, but represents an
+/// internal size constraint of this library.
+pub const MAX_ARCS: usize = 10;
 
-/// Maximum value of the first node in an OID
-const FIRST_NODE_MAX: u32 = 2;
+/// Maximum value of the first arc in an OID
+const FIRST_ARC_MAX: u32 = 2;
 
-/// Maximum value of the second node in an OID
-const SECOND_NODE_MAX: u32 = 39;
+/// Maximum value of the second arc in an OID
+const SECOND_ARC_MAX: u32 = 39;
 
 /// Error type
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -75,10 +76,10 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// Object identifier (OID)
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ObjectIdentifier {
-    /// Nodes in this OID
-    nodes: [u32; MAX_NODES],
+    /// Arcs in this OID
+    arcs: [u32; MAX_ARCS],
 
-    /// Number of nodes in this OID
+    /// Number of arcs in this OID
     length: usize,
 }
 
@@ -93,7 +94,8 @@ macro_rules! const_assert {
 
 #[allow(clippy::len_without_is_empty)]
 impl ObjectIdentifier {
-    /// Create an OID from a slice of integers.
+    /// Create an [`ObjectIdentifier`] from a slice of integers, where each
+    /// integer represents an "arc" (a.k.a. node) in the OID.
     ///
     /// # Panics
     ///
@@ -107,83 +109,81 @@ impl ObjectIdentifier {
     ///
     /// In order for an OID to be valid, it must meet the following criteria:
     ///
-    /// - The OID MUST have at least 3 nodes
-    /// - The OID MUST NOT have more nodes than the [`MAX_NODES`] constant
-    /// - The first node MUST be within the range 0-2
-    /// - The second node MUST be within the range 0-39
+    /// - The OID MUST have at least 3 arcs
+    /// - The OID MUST NOT have more arcs than the [`MAX_ARCS`] constant
+    /// - The first arc MUST be within the range 0-2
+    /// - The second arc MUST be within the range 0-39
     ///
     /// [1]: ./struct.ObjectIdentifier.html#impl-TryFrom%3C%26%27_%20%5Bu32%5D%3E
-    pub const fn new(nodes: &[u32]) -> Self {
-        const_assert!(nodes.len() >= 3, "OID too short (minimum 3 nodes)");
+    pub const fn new(arcs: &[u32]) -> Self {
+        const_assert!(arcs.len() >= 3, "OID too short (minimum 3 arcs)");
         const_assert!(
-            nodes.len() <= MAX_NODES,
+            arcs.len() <= MAX_ARCS,
             "OID too long (internal limit reached)"
         );
+        const_assert!(arcs[0] <= FIRST_ARC_MAX, "invalid first arc (must be 0-2)");
         const_assert!(
-            nodes[0] <= FIRST_NODE_MAX,
-            "invalid first node (must be 0-2)"
-        );
-        const_assert!(
-            nodes[1] <= SECOND_NODE_MAX,
-            "invalid second node (must be 0-39)"
+            arcs[1] <= SECOND_ARC_MAX,
+            "invalid second arc (must be 0-39)"
         );
 
         // TODO(tarcieri): use `const_mut_ref` when stable.
         // See: <https://github.com/rust-lang/rust/issues/57349>
         #[rustfmt::skip]
-        let n = match nodes.len() {
+        let n = match arcs.len() {
             3 => [
-                nodes[0], nodes[1], nodes[2], 0, 0,
+                arcs[0], arcs[1], arcs[2], 0, 0,
                 0, 0, 0, 0, 0
             ],
             4 => [
-                nodes[0], nodes[1], nodes[2], nodes[3], 0,
+                arcs[0], arcs[1], arcs[2], arcs[3], 0,
                 0, 0, 0, 0, 0
             ],
             5 => [
-                nodes[0], nodes[1], nodes[2], nodes[3], nodes[4],
+                arcs[0], arcs[1], arcs[2], arcs[3], arcs[4],
                 0, 0, 0, 0, 0,
             ],
             6 => [
-                nodes[0], nodes[1], nodes[2], nodes[3], nodes[4],
-                nodes[5], 0, 0, 0, 0,
+                arcs[0], arcs[1], arcs[2], arcs[3], arcs[4],
+                arcs[5], 0, 0, 0, 0,
             ],
             7 => [
-                nodes[0], nodes[1], nodes[2], nodes[3], nodes[4],
-                nodes[5], nodes[6], 0, 0, 0,
+                arcs[0], arcs[1], arcs[2], arcs[3], arcs[4],
+                arcs[5], arcs[6], 0, 0, 0,
             ],
             8 => [
-                nodes[0], nodes[1], nodes[2], nodes[3], nodes[4],
-                nodes[5], nodes[6], nodes[7], 0, 0,
+                arcs[0], arcs[1], arcs[2], arcs[3], arcs[4],
+                arcs[5], arcs[6], arcs[7], 0, 0,
             ],
             9 => [
-                nodes[0], nodes[1], nodes[2], nodes[3], nodes[4],
-                nodes[5], nodes[6], nodes[7], nodes[8], 0,
+                arcs[0], arcs[1], arcs[2], arcs[3], arcs[4],
+                arcs[5], arcs[6], arcs[7], arcs[8], 0,
             ],
             10 => [
-                nodes[0], nodes[1], nodes[2], nodes[3], nodes[4],
-                nodes[5], nodes[6], nodes[7], nodes[8], nodes[9],
+                arcs[0], arcs[1], arcs[2], arcs[3], arcs[4],
+                arcs[5], arcs[6], arcs[7], arcs[8], arcs[9],
             ],
-            _ => [0u32; MAX_NODES], // Checks above prevent this case, but makes Miri happy
+            _ => [0u32; MAX_ARCS], // Checks above prevent this case, but makes Miri happy
         };
 
         Self {
-            nodes: n,
-            length: nodes.len(),
+            arcs: n,
+            length: arcs.len(),
         }
     }
 
-    /// Iterate over the nodes in an [`ObjectIdentifier`].
+    /// Iterate over the arcs (a.k.a. nodes) in an [`ObjectIdentifier`].
     ///
-    /// This returns [`Nodes`], an iterator over `u32` values.
-    pub fn nodes(&self) -> Nodes {
-        Nodes {
+    /// Returns [`Arcs`], an iterator over `u32` values representing the value
+    /// of each arc/node.
+    pub fn arcs(&self) -> Arcs {
+        Arcs {
             oid: *self,
             index: 0,
         }
     }
 
-    /// Number of nodes in this [`ObjectIdentifier`].
+    /// Number of arcs in this [`ObjectIdentifier`].
     pub fn len(&self) -> usize {
         self.length
     }
@@ -192,17 +192,17 @@ impl ObjectIdentifier {
     pub fn from_ber(mut bytes: &[u8]) -> Result<Self> {
         let octet = parse_byte(&mut bytes)?;
 
-        let mut nodes = [0u32; MAX_NODES];
-        nodes[0] = (octet / (SECOND_NODE_MAX as u8 + 1)) as u32;
-        nodes[1] = (octet % (SECOND_NODE_MAX as u8 + 1)) as u32;
+        let mut arcs = [0u32; MAX_ARCS];
+        arcs[0] = (octet / (SECOND_ARC_MAX as u8 + 1)) as u32;
+        arcs[1] = (octet % (SECOND_ARC_MAX as u8 + 1)) as u32;
 
         let mut length = 2;
 
         while !bytes.is_empty() {
-            nodes[length] = parse_base128(&mut bytes)?;
+            arcs[length] = parse_base128(&mut bytes)?;
             length += 1;
 
-            if length > MAX_NODES {
+            if length > MAX_ARCS {
                 return Err(Error);
             }
         }
@@ -211,36 +211,36 @@ impl ObjectIdentifier {
             return Err(Error);
         }
 
-        validate_nodes(nodes)?;
-        Ok(Self { nodes, length })
+        validate_arcs(arcs)?;
+        Ok(Self { arcs, length })
     }
 
-    /// Get the length of this OID when serialized as ASN.1 BER
+    /// Get the length of this OID when serialized as ASN.1 BER.
     pub fn ber_len(&self) -> usize {
-        self.nodes[2..self.length]
+        self.arcs[2..self.length]
             .iter()
             .fold(1, |sum, n| sum + base128_len(*n))
     }
 
     /// Write the BER encoding of this OID into the given slice, returning
-    /// a new slice containing the written data
+    /// a new slice containing the written data.
     pub fn write_ber<'a>(&self, bytes: &'a mut [u8]) -> Result<&'a [u8]> {
         if bytes.is_empty() {
             return Err(Error);
         }
 
-        bytes[0] = (self.nodes[0] * (SECOND_NODE_MAX + 1)) as u8 | self.nodes[1] as u8;
+        bytes[0] = (self.arcs[0] * (SECOND_ARC_MAX + 1)) as u8 | self.arcs[1] as u8;
 
         let mut offset = 1;
 
-        for &node in &self.nodes[2..self.length] {
-            offset += write_base128(&mut bytes[offset..], node)?;
+        for &arc in &self.arcs[2..self.length] {
+            offset += write_base128(&mut bytes[offset..], arc)?;
         }
 
         Ok(&bytes[..offset])
     }
 
-    /// Serialize this OID as ASN.1 BER
+    /// Serialize this OID as ASN.1 BER.
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_ber(&self) -> alloc::vec::Vec<u8> {
@@ -255,38 +255,38 @@ impl FromStr for ObjectIdentifier {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let mut nodes = [0u32; MAX_NODES];
+        let mut arcs = [0u32; MAX_ARCS];
         let mut length = 0;
 
         for (i, n) in s.split('.').enumerate() {
-            if i + 1 == MAX_NODES {
+            if i + 1 == MAX_ARCS {
                 return Err(Error);
             }
 
-            nodes[i] = n.parse().map_err(|_| Error)?;
+            arcs[i] = n.parse().map_err(|_| Error)?;
             length += 1;
         }
 
-        validate_nodes(nodes)?;
-        Ok(Self { nodes, length })
+        validate_arcs(arcs)?;
+        Ok(Self { arcs, length })
     }
 }
 
 impl TryFrom<&[u32]> for ObjectIdentifier {
     type Error = Error;
 
-    fn try_from(nodes: &[u32]) -> Result<Self> {
-        if nodes.len() < 3 || nodes.len() > MAX_NODES {
+    fn try_from(arcs: &[u32]) -> Result<Self> {
+        if arcs.len() < 3 || arcs.len() > MAX_ARCS {
             return Err(Error);
         }
 
-        let mut nodes_arr = [0u32; MAX_NODES];
-        nodes_arr[..nodes.len()].copy_from_slice(nodes);
-        validate_nodes(nodes_arr)?;
+        let mut arcs_arr = [0u32; MAX_ARCS];
+        arcs_arr[..arcs.len()].copy_from_slice(arcs);
+        validate_arcs(arcs_arr)?;
 
         Ok(Self {
-            nodes: nodes_arr,
-            length: nodes.len(),
+            arcs: arcs_arr,
+            length: arcs.len(),
         })
     }
 }
@@ -299,8 +299,8 @@ impl fmt::Debug for ObjectIdentifier {
 
 impl fmt::Display for ObjectIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (i, node) in self.nodes().enumerate() {
-            write!(f, "{}", node)?;
+        for (i, arc) in self.arcs().enumerate() {
+            write!(f, "{}", arc)?;
 
             if i < self.len() - 1 {
                 write!(f, ".")?;
@@ -311,38 +311,38 @@ impl fmt::Display for ObjectIdentifier {
     }
 }
 
-/// [`Iterator`] over nodes in an [`ObjectIdentifier`].
+/// [`Iterator`] over arcs (a.k.a. nodes) in an [`ObjectIdentifier`].
 ///
-/// This iterates over all nodes in an OID, including the root.
-pub struct Nodes {
+/// This iterates over all arcs in an OID, including the root.
+pub struct Arcs {
     /// OID we're iterating over
     oid: ObjectIdentifier,
 
-    /// Current node
+    /// Current arc
     index: usize,
 }
 
-impl Iterator for Nodes {
+impl Iterator for Arcs {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
         if self.index < self.oid.length {
-            let node = self.oid.nodes[self.index];
+            let arc = self.oid.arcs[self.index];
             self.index = self.index.checked_add(1).unwrap();
-            Some(node)
+            Some(arc)
         } else {
             None
         }
     }
 }
 
-/// Run validations on a node array
-fn validate_nodes(nodes: [u32; MAX_NODES]) -> Result<()> {
-    if nodes[0] > FIRST_NODE_MAX {
+/// Run validations on a arc array
+fn validate_arcs(arcs: [u32; MAX_ARCS]) -> Result<()> {
+    if arcs[0] > FIRST_ARC_MAX {
         return Err(Error);
     }
 
-    if nodes[1] > SECOND_NODE_MAX {
+    if arcs[1] > SECOND_ARC_MAX {
         return Err(Error);
     }
 
@@ -449,10 +449,10 @@ mod tests {
         // Truncated
         assert!("1.2.840.10045.2.".parse::<ObjectIdentifier>().is_err());
 
-        // Invalid first node
+        // Invalid first arc
         assert!("3.2.840.10045.2.1".parse::<ObjectIdentifier>().is_err());
 
-        // Invalid second node
+        // Invalid second arc
         assert!("1.40.840.10045.2.1".parse::<ObjectIdentifier>().is_err());
     }
 
@@ -464,10 +464,10 @@ mod tests {
         // Truncated
         assert!(ObjectIdentifier::try_from([1, 2].as_ref()).is_err());
 
-        // Invalid first node
+        // Invalid first arc
         assert!(ObjectIdentifier::try_from([3, 2, 840, 10045, 3, 1, 7].as_ref()).is_err());
 
-        // Invalid second node
+        // Invalid second arc
         assert!(ObjectIdentifier::try_from([1, 40, 840, 10045, 3, 1, 7].as_ref()).is_err());
     }
 
@@ -492,13 +492,13 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn invalid_first_node() {
+    fn invalid_first_arc() {
         ObjectIdentifier::new(&[3, 2, 840, 10045, 3, 1, 7]);
     }
 
     #[test]
     #[should_panic]
-    fn invalid_second_node() {
+    fn invalid_second_arc() {
         ObjectIdentifier::new(&[1, 40, 840, 10045, 3, 1, 7]);
     }
 }


### PR DESCRIPTION
X.660 uses the term "arc" to describe the components of an OID.

This commit renames "nodes" (which is more of an informal term) to "arcs" to reflect this.