### PR TITLE
const-oid v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.3.5"
+version = "0.4.0"
 
 [[package]]
 name = "cpuid-bool"

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-12-16)
+### Added
+- `Arcs` iterator ([#141], [#142])
+
+### Changed
+- Rename "nodes" to "arcs" ([#142])
+- Layout optimization ([#143])
+- Refactor and improve length limits ([#144])
+
+[#144]: https://github.com/RustCrypto/utils/pull/144
+[#143]: https://github.com/RustCrypto/utils/pull/143
+[#142]: https://github.com/RustCrypto/utils/pull/142
+[#141]: https://github.com/RustCrypto/utils/pull/141
+
 ## 0.3.5 (2020-12-12)
 ### Added
 - `ObjectIdentifier::{write_ber, to_ber}` methods ([#118])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -39,7 +39,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/const-oid/0.3.5"
+    html_root_url = "https://docs.rs/const-oid/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["crypto", "key", "private"]
 readme = "README.md"
 
 [dependencies.const-oid]
-version = "0.3.5"
+version = "0.4"
 path = "../const-oid"
 
 [dependencies.subtle-encoding]


### PR DESCRIPTION
### Added
- `Arcs` iterator ([#141], [#142])

### Changed
- Rename "nodes" to "arcs" ([#142])
- Layout optimization ([#143])
- Refactor and improve length limits ([#144])

[#144]: https://github.com/RustCrypto/utils/pull/144
[#143]: https://github.com/RustCrypto/utils/pull/143
[#142]: https://github.com/RustCrypto/utils/pull/142
[#141]: https://github.com/RustCrypto/utils/pull/141