### PR TITLE
pkcs8 v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "0.3.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const-oid",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2020-12-16)
+## 0.3.1 (2020-12-16)
+### Changed
+- Bump `const-oid` dependency to v0.4 ([#145])
+
+[#145]: https://github.com/RustCrypto/utils/pull/145
+
+## 0.3.0 (2020-12-16) [YANKED]
 ### Added
 - `AlgorithmParameters` enum ([#138])
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -43,7 +43,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/pkcs8/0.3.0"
+    html_root_url = "https://docs.rs/pkcs8/0.3.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
*NOTE:* this is technically a breaking change from v0.3.0 which was released earlier today. However, after v0.3.1 is released, v0.3.0 will be yanked and is hopefully not in use by anyone yet.

### Changed
- Bump `const-oid` dependency to v0.4 ([#145])

[#145]: https://github.com/RustCrypto/utils/pull/145