### PR TITLE
der: extract `length` module

### DIFF
--- a/der/src/encode.rs
+++ b/der/src/encode.rs
@@ -5,18 +5,6 @@ use crate::{Error, Result, Tag};
 #[cfg(feature = "oid")]
 use crate::ObjectIdentifier;
 
-/// Compute the length of a header including the tag byte.
-///
-/// This function supports `body` lengths up to 65,535 bytes.
-pub fn header_len(body_len: usize) -> Result<usize> {
-    match body_len {
-        0..=0x7F => Ok(2),
-        0x80..=0xFF => Ok(3),
-        0x100..=0xFFFF => Ok(4),
-        _ => Err(Error),
-    }
-}
-
 /// Encode a tag and a length header
 pub fn header(buffer: &mut [u8], tag: Tag, len: usize) -> Result<usize> {
     byte(buffer, 0, tag as u8)?;
@@ -33,14 +21,6 @@ pub fn nested(buffer: &mut [u8], tag: Tag, data: &[u8]) -> Result<usize> {
 
     buffer[offset..(offset + data.len())].copy_from_slice(data);
     offset.checked_add(data.len()).ok_or(Error)
-}
-
-/// Get the length of a DER-encoded OID
-#[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
-pub fn oid_len(oid: ObjectIdentifier) -> Result<usize> {
-    let body_len = oid.ber_len();
-    header_len(body_len)?.checked_add(body_len).ok_or(Error)
 }
 
 /// Encode [`ObjectIdentifier`].

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -1,0 +1,26 @@
+//! Length calculations for encoded ASN.1 DER values
+
+use crate::{Error, Result};
+
+#[cfg(feature = "oid")]
+use oid::ObjectIdentifier;
+
+/// Compute the length of a header including the tag byte.
+///
+/// This function supports `nested_len` values up to 65,535 bytes.
+pub fn header(nested_len: usize) -> Result<usize> {
+    match nested_len {
+        0..=0x7F => Ok(2),
+        0x80..=0xFF => Ok(3),
+        0x100..=0xFFFF => Ok(4),
+        _ => Err(Error),
+    }
+}
+
+/// Get the length of a DER-encoded OID
+#[cfg(feature = "oid")]
+#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
+pub fn oid(oid: ObjectIdentifier) -> Result<usize> {
+    let body_len = oid.ber_len();
+    header(body_len)?.checked_add(body_len).ok_or(Error)
+}

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -30,6 +30,7 @@ extern crate std;
 pub mod decode;
 pub mod encode;
 mod error;
+pub mod length;
 mod tag;
 
 pub use crate::{

--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -173,7 +173,7 @@ pub(crate) fn encode_identifier(
     buffer: &mut [u8],
     algorithm_id: &AlgorithmIdentifier,
 ) -> Result<usize> {
-    let alg_oid_len = der::encode::oid_len(algorithm_id.oid)?;
+    let alg_oid_len = der::length::oid(algorithm_id.oid)?;
     let params_len = parameters_len(algorithm_id)?;
     let sequence_len = alg_oid_len.checked_add(params_len).unwrap();
 
@@ -192,11 +192,11 @@ pub(crate) fn encode_identifier(
 
 /// Get the length of a DER-encoded [`AlgorithmIdentifier`]
 pub(crate) fn identifier_len(algorithm_id: &AlgorithmIdentifier) -> Result<usize> {
-    let alg_oid_len = der::encode::oid_len(algorithm_id.oid)?;
+    let alg_oid_len = der::length::oid(algorithm_id.oid)?;
     let params_len = parameters_len(algorithm_id)?;
     let sequence_len = alg_oid_len.checked_add(params_len).unwrap();
 
-    der::encode::header_len(sequence_len)
+    der::length::header(sequence_len)
         .ok()
         .and_then(|n| n.checked_add(sequence_len))
         .ok_or(Error::Encode)
@@ -207,7 +207,7 @@ pub(crate) fn identifier_len(algorithm_id: &AlgorithmIdentifier) -> Result<usize
 fn parameters_len(algorithm_id: &AlgorithmIdentifier) -> Result<usize> {
     match algorithm_id.parameters {
         Some(AlgorithmParameters::Null) => Ok(2),
-        Some(AlgorithmParameters::Oid(oid)) => Ok(der::encode::oid_len(oid)?),
+        Some(AlgorithmParameters::Oid(oid)) => Ok(der::length::oid(oid)?),
         None => Ok(0),
     }
 }

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -120,14 +120,14 @@ impl<'a> fmt::Debug for PrivateKeyInfo<'a> {
 fn private_key_info_len(private_key_info: &PrivateKeyInfo<'_>) -> Result<usize> {
     let alg_id_len = algorithm::identifier_len(&private_key_info.algorithm)?;
     let version_len = 3;
-    let private_key_len = der::encode::header_len(private_key_info.private_key.len())?
+    let private_key_len = der::length::header(private_key_info.private_key.len())?
         .checked_add(private_key_info.private_key.len())
         .ok_or(Error::Encode)?;
     let sequence_len = alg_id_len
         .checked_add(version_len)
         .and_then(|len| len.checked_add(private_key_len))
         .ok_or(Error::Encode)?;
-    der::encode::header_len(sequence_len)
+    der::length::header(sequence_len)
         .ok()
         .and_then(|n| n.checked_add(sequence_len))
         .ok_or(Error::Encode)
@@ -140,7 +140,7 @@ fn encode_private_key_info(
 ) -> Result<usize> {
     let alg_id_len = algorithm::identifier_len(&private_key_info.algorithm)?;
     let version_len = 3;
-    let private_key_len = der::encode::header_len(private_key_info.private_key.len())?
+    let private_key_len = der::length::header(private_key_info.private_key.len())?
         .checked_add(private_key_info.private_key.len())
         .ok_or(Error::Encode)?;
     let sequence_len = alg_id_len

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -57,7 +57,7 @@ impl<'a> SubjectPublicKeyInfo<'a> {
     /// buffer, returning a slice containing the encoded data.
     pub fn write_der<'b>(&self, buffer: &'b mut [u8]) -> Result<&'b [u8]> {
         let alg_id_len = algorithm::identifier_len(&self.algorithm)?;
-        let private_key_len = der::encode::header_len(self.subject_public_key.len())?
+        let private_key_len = der::length::header(self.subject_public_key.len())?
             .checked_add(self.subject_public_key.len())
             .ok_or(Error::Encode)?;
         let sequence_len = alg_id_len
@@ -106,13 +106,13 @@ impl<'a> TryFrom<&'a [u8]> for SubjectPublicKeyInfo<'a> {
 #[cfg(feature = "alloc")]
 fn spki_len(spki: &SubjectPublicKeyInfo<'_>) -> Result<usize> {
     let alg_id_len = algorithm::identifier_len(&spki.algorithm)?;
-    let public_key_len = der::encode::header_len(spki.subject_public_key.len())?
+    let public_key_len = der::length::header(spki.subject_public_key.len())?
         .checked_add(spki.subject_public_key.len())
         .ok_or(Error::Encode)?;
     let sequence_len = alg_id_len
         .checked_add(public_key_len)
         .ok_or(Error::Encode)?;
-    der::encode::header_len(sequence_len)
+    der::length::header(sequence_len)
         .ok()
         .and_then(|n| n.checked_add(sequence_len))
         .ok_or(Error::Encode)


### PR DESCRIPTION
Small cleanup and consistency improvement.

It may be possible to eliminate this module in the future, or it might make sense to make it the one place for all length-related functionality which could be useful.

For now, it gets this code out of the way to permit more refactoring.