### PR TITLE
der: refactor decoder using lambdas

### DIFF
--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types.
 
+use crate::Tag;
 use core::fmt;
 
 /// Result type
@@ -7,10 +8,57 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Error;
+#[non_exhaustive]
+pub enum Error {
+    /// Incorrect length
+    Length {
+        /// Tag type of the value being decoded
+        tag: Tag,
+    },
+
+    /// Message is not canonically encoded
+    Noncanonical,
+
+    /// Malformed OID
+    Oid,
+
+    /// Integer overflow occurred (library bug!)
+    Overflow,
+
+    /// Message is longer than this library's internal limits support
+    Overlength,
+
+    /// Message is truncated
+    Truncated,
+
+    /// Unexpected tag
+    UnexpectedTag {
+        /// Tag the decoder was expecting (if there is a single such tag).
+        ///
+        /// `None` if multiple tags are expected/allowed, but the `actual` tag
+        /// does not match any of them.
+        expected: Option<Tag>,
+
+        /// Actual tag encountered in the message
+        actual: Tag,
+    },
+
+    /// Unknown/unsupported tag
+    UnknownTag {
+        /// Raw byte value of the tag
+        byte: u8,
+    },
+
+    /// Unexpected value
+    Value {
+        /// Tag of the unexpected value
+        tag: Tag,
+    },
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO(tarcieri): real `Display` impl with good error messages
         f.write_str("ASN.1 error")
     }
 }
@@ -18,7 +66,7 @@ impl fmt::Display for Error {
 #[cfg(feature = "oid")]
 impl From<oid::Error> for Error {
     fn from(_: oid::Error) -> Error {
-        Error
+        Error::Oid
     }
 }
 

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -13,7 +13,7 @@ pub fn header(nested_len: usize) -> Result<usize> {
         0..=0x7F => Ok(2),
         0x80..=0xFF => Ok(3),
         0x100..=0xFFFF => Ok(4),
-        _ => Err(Error),
+        _ => Err(Error::Overlength),
     }
 }
 
@@ -22,5 +22,7 @@ pub fn header(nested_len: usize) -> Result<usize> {
 #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 pub fn oid(oid: ObjectIdentifier) -> Result<usize> {
     let body_len = oid.ber_len();
-    header(body_len)?.checked_add(body_len).ok_or(Error)
+    header(body_len)?
+        .checked_add(body_len)
+        .ok_or(Error::Overflow)
 }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -26,6 +26,21 @@ pub enum Tag {
     Sequence = 0x30,
 }
 
+impl Tag {
+    /// Expect a specific tag type, returning an error if the tag is not the
+    /// one we're expecting
+    pub fn expect(self, expected: Tag) -> Result<Tag> {
+        if self == expected {
+            Ok(self)
+        } else {
+            Err(Error::UnexpectedTag {
+                expected: Some(expected),
+                actual: self,
+            })
+        }
+    }
+}
+
 impl TryFrom<u8> for Tag {
     type Error = Error;
 
@@ -37,7 +52,7 @@ impl TryFrom<u8> for Tag {
             0x05 => Ok(Tag::Null),
             0x06 => Ok(Tag::ObjectIdentifier),
             0x30 => Ok(Tag::Sequence),
-            _ => Err(Error),
+            _ => Err(Error::UnknownTag { byte }),
         }
     }
 }


### PR DESCRIPTION
Adds a lambda argument to the `nested` function, having it perform TLV decoding and yielding the decoded tag and value to the lambda.

Also adds a set of new functions for parsing fields with expected tags, including a general purpose `tagged` for expecting a particular tag, and ones for the supported ASN.1 types presently used by the `pkcs8` crate.