### PR TITLE
der: `Decoder` struct

### DIFF
--- a/der/src/any.rs
+++ b/der/src/any.rs
@@ -1,6 +1,13 @@
 //! ASN.1 `ANY` type
 
-use crate::{Decodable, Decoder, Error, Header, Length, Result, Tag};
+use crate::{
+    BitString, Decodable, Decoder, Error, Header, Integer, Length, Null, OctetString, Result,
+    Sequence, Tag,
+};
+use core::convert::{TryFrom, TryInto};
+
+#[cfg(feature = "oid")]
+use crate::ObjectIdentifier;
 
 /// ASN.1 `ANY` type: represents any ASN.1 value
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -31,6 +38,42 @@ impl<'a> Any<'a> {
     pub fn value(self) -> &'a [u8] {
         self.value
     }
+
+    /// Attempt to decode an ASN.1 `BIT STRING`
+    pub fn bit_string(self) -> Result<BitString<'a>> {
+        self.try_into()
+    }
+
+    /// Attempt to decode an ASN.1 `INTEGER`
+    pub fn integer(self) -> Result<Integer> {
+        self.try_into()
+    }
+
+    /// Attempt to decode an ASN.1 `NULL` value
+    pub fn null(self) -> Result<Null> {
+        self.try_into()
+    }
+
+    /// Attempt to decode an ASN.1 `OCTET STRING`
+    pub fn octet_string(self) -> Result<OctetString<'a>> {
+        self.try_into()
+    }
+
+    /// Attempt to decode an ASN.1 `OBJECT IDENTIFIER`
+    #[cfg(feature = "oid")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
+    pub fn oid(self) -> Result<ObjectIdentifier> {
+        self.try_into()
+    }
+
+    /// Attempt to decode this value an ASN.1 `SEQUENCE`, creating a new
+    /// nested [`Decoder`] and calling the provided argument with it.
+    pub fn sequence<F, T>(self, f: F) -> Result<T>
+    where
+        F: FnOnce(Decoder<'a>) -> Result<T>,
+    {
+        Sequence::try_from(self).and_then(|seq| f(seq.decoder()))
+    }
 }
 
 impl<'a> Decodable<'a> for Any<'a> {
@@ -38,14 +81,7 @@ impl<'a> Decodable<'a> for Any<'a> {
         let header = Header::decode(decoder)?;
         let tag = header.tag;
         let len = usize::from(header.length);
-
-        if len > decoder.len() {
-            return Err(Error::Length { tag });
-        }
-
-        let (value, rest) = decoder.split_at(len);
-        *decoder = rest;
-
+        let value = decoder.bytes(len).map_err(|_| Error::Length { tag })?;
         Self::new(tag, value)
     }
 }

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -1,15 +1,121 @@
 //! ASN.1 DER decoder.
 
-use crate::{Error, Result};
+use crate::{
+    Any, BitString, Decodable, Error, Integer, Null, OctetString, Result, Sequence, Tagged,
+};
 
-/// Decoder type
-// TODO(tarcieri): refactor into a struct
-pub type Decoder<'a> = &'a [u8];
+#[cfg(feature = "oid")]
+use crate::ObjectIdentifier;
 
-/// Extract the leading byte from a slice.
-// TODO(tarcieri): refactor into a hypothetical `Decoder` struct
-pub fn byte(bytes: &mut &[u8]) -> Result<u8> {
-    let byte = *bytes.get(0).ok_or(Error::Truncated)?;
-    *bytes = &bytes[1..];
-    Ok(byte)
+/// ASN.1 DER decoder.
+pub struct Decoder<'a> {
+    /// Byte slice being decoded
+    bytes: &'a [u8],
+
+    /// Position within the decoded slice
+    pos: usize,
+}
+
+impl<'a> Decoder<'a> {
+    /// Create a new decoder for the given byte slice
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    /// Decode a value which impls the [`Decodable`] trait
+    pub fn decode<T: Decodable<'a>>(&mut self) -> Result<T> {
+        T::decode(self)
+    }
+
+    /// Attempt to decode an ASN.1 `ANY` value
+    pub fn any(&mut self) -> Result<Any<'a>> {
+        self.decode()
+    }
+
+    /// Attempt to decode an ASN.1 `BIT STRING`
+    pub fn bit_string(&mut self) -> Result<BitString<'a>> {
+        self.decode()
+    }
+
+    /// Attempt to decode an ASN.1 `INTEGER`
+    pub fn integer(&mut self) -> Result<Integer> {
+        self.decode()
+    }
+
+    /// Attempt to decode an ASN.1 `NULL` value
+    pub fn null(&mut self) -> Result<Null> {
+        self.decode()
+    }
+
+    /// Attempt to decode an ASN.1 `OCTET STRING`
+    pub fn octet_string(&mut self) -> Result<OctetString<'a>> {
+        self.decode()
+    }
+
+    /// Attempt to decode an ASN.1 `OBJECT IDENTIFIER`
+    #[cfg(feature = "oid")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
+    pub fn oid(&mut self) -> Result<ObjectIdentifier> {
+        self.decode()
+    }
+
+    /// Attempt to decode an ASN.1 `OPTIONAL` value
+    pub fn optional<T: Decodable<'a>>(&mut self) -> Result<Option<T>> {
+        self.decode()
+    }
+
+    /// Attempt to decode an ASN.1 `SEQUENCE`, creating a new nested
+    /// [`Decoder`] and calling the provided argument with it.
+    pub fn sequence<F, T>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(Decoder<'a>) -> Result<T>,
+    {
+        Sequence::decode(self).and_then(|seq| f(seq.decoder()))
+    }
+
+    /// Finish decoding, returning the given value if there is no
+    /// remaining data, or an error otherwise
+    pub fn finish<T: Tagged>(self, value: T) -> Result<T> {
+        if self.is_finished() {
+            Ok(value)
+        } else {
+            Err(Error::Length { tag: T::TAG })
+        }
+    }
+
+    /// Have we decoded all of the bytes in this [`Decoder`]?
+    pub fn is_finished(&self) -> bool {
+        self.remaining().is_empty()
+    }
+
+    /// Decode a single byte, updating the internal cursor.
+    pub(crate) fn byte(&mut self) -> Result<u8> {
+        let byte = *self.bytes.get(self.pos).ok_or(Error::Truncated)?;
+        self.pos = self.pos.checked_add(1).ok_or(Error::Overflow)?;
+        Ok(byte)
+    }
+
+    /// Obtain a slice of bytes of the given length from the current cursor
+    /// position, or return an error if we have insufficient data.
+    pub(crate) fn bytes(&mut self, len: usize) -> Result<&'a [u8]> {
+        if len > self.remaining().len() {
+            return Err(Error::Truncated);
+        }
+
+        let result = &self.remaining()[..len];
+        self.pos = self.pos.checked_add(len).ok_or(Error::Overflow)?;
+        Ok(result)
+    }
+
+    /// Obtain the remaining bytes in this decoder from the current cursor
+    /// position.
+    fn remaining(&self) -> &'a [u8] {
+        &self.bytes[self.pos..]
+    }
+}
+
+impl<'a> From<&'a [u8]> for Decoder<'a> {
+    fn from(bytes: &'a [u8]) -> Decoder<'a> {
+        Decoder::new(bytes)
+    }
 }

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -52,13 +52,12 @@ impl TryFrom<usize> for Length {
 
 impl Decodable<'_> for Length {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Length> {
-        // TODO(tarcieri): move `decode::byte` to `Decoder`
-        match crate::decoder::byte(decoder)? {
+        match decoder.byte()? {
             // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite
             // lengths, which are not allowed in DER, so disallow that byte.
             len if len < 0x80 => Ok(len.into()),
             0x81 => {
-                let len = crate::decoder::byte(decoder)?;
+                let len = decoder.byte()?;
 
                 // X.690 Section 10.1: DER lengths must be encoded with a minimum
                 // number of octets
@@ -69,8 +68,8 @@ impl Decodable<'_> for Length {
                 }
             }
             0x82 => {
-                let len_hi = crate::decoder::byte(decoder)? as u16;
-                let len = (len_hi << 8) | (crate::decoder::byte(decoder)? as u16);
+                let len_hi = decoder.byte()? as u16;
+                let len = (len_hi << 8) | (decoder.byte()? as u16);
 
                 // X.690 Section 10.1: DER lengths must be encoded with a minimum
                 // number of octets

--- a/der/src/optional.rs
+++ b/der/src/optional.rs
@@ -1,17 +1,16 @@
 //! ASN.1 `OPTIONAL` as mapped to Rust's `Option` type
 
-use crate::{Any, Decodable, Decoder, Result};
-use core::convert::TryFrom;
+use crate::{Decodable, Decoder, Result};
 
 impl<'a, T> Decodable<'a> for Option<T>
 where
-    T: TryFrom<Any<'a>>,
+    T: Decodable<'a>,
 {
     fn decode(decoder: &mut Decoder<'a>) -> Result<Option<T>> {
-        if decoder.is_empty() {
+        if decoder.is_finished() {
             Ok(None)
         } else {
-            Any::decode(decoder).map(|any| T::try_from(any).ok())
+            T::decode(decoder).map(Some)
         }
     }
 }

--- a/der/src/sequence.rs
+++ b/der/src/sequence.rs
@@ -27,7 +27,7 @@ impl<'a> Sequence<'a> {
 
     /// Obtain a [`Decoder`] for the data in this [`Sequence`]
     pub fn decoder(&self) -> Decoder<'a> {
-        self.inner
+        Decoder::new(self.inner)
     }
 }
 

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -43,8 +43,7 @@ impl Tag {
 
 impl Decodable<'_> for Tag {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Self> {
-        // TODO(tarcieri): move `decode::byte` to `Decoder`
-        crate::decoder::byte(decoder).and_then(Self::try_from)
+        decoder.byte().and_then(Self::try_from)
     }
 }
 


### PR DESCRIPTION
Adds a `Decoder` struct which wraps a slice that's in the process of being decoded, along with ample helper methods for various types which simplify writing decoders.