### PR TITLE
der: extract `ByteSlice` type

### DIFF
--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -1,0 +1,50 @@
+//! Common handling for types backed by byte slices with enforcement of a
+//! library-level length limitation i.e. `Length::max()`.
+//!
+//! This limit is presently 65,535 bytes.
+
+use crate::{Length, Result};
+use core::convert::TryFrom;
+
+/// Byte slice newtype which respects the `Length::max()` limit.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ByteSlice<'a> {
+    /// Inner value
+    inner: &'a [u8],
+
+    /// Precomputed `Length` (avoids possible panicking conversions)
+    length: Length,
+}
+
+impl<'a> ByteSlice<'a> {
+    /// Create a new [`ByteSlice`], ensuring that the provided `slice` value
+    /// is shorter than `Length::max()`.
+    pub fn new(slice: &'a [u8]) -> Result<Self> {
+        let length = Length::try_from(slice.len())?;
+        Ok(Self {
+            inner: slice,
+            length,
+        })
+    }
+
+    /// Borrow the inner byte slice
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.inner
+    }
+
+    /// Get the [`Length`] of this [`ByteSlice`]
+    pub fn len(self) -> Length {
+        self.length
+    }
+
+    /// Is this [`ByteSlice`] empty?
+    pub fn is_empty(self) -> bool {
+        self.len() == Length::zero()
+    }
+}
+
+impl AsRef<[u8]> for ByteSlice<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -1,4 +1,4 @@
-//! ASN.1 DER decoder.
+//! DER decoder.
 
 use crate::{
     Any, BitString, Decodable, Error, Integer, Length, Null, OctetString, Result, Sequence, Tagged,
@@ -7,7 +7,7 @@ use crate::{
 #[cfg(feature = "oid")]
 use crate::ObjectIdentifier;
 
-/// ASN.1 DER decoder.
+/// DER decoder.
 pub struct Decoder<'a> {
     /// Byte slice being decoded
     bytes: &'a [u8],

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -1,4 +1,4 @@
-//! ASN.1 DER encoder.
+//! DER encoder.
 
 use crate::{BitString, Encodable, Error, Header, Integer, Length, Null, OctetString, Result, Tag};
 use core::convert::TryInto;
@@ -6,7 +6,7 @@ use core::convert::TryInto;
 #[cfg(feature = "oid")]
 use crate::ObjectIdentifier;
 
-/// ASN.1 DER encoder.
+/// DER encoder.
 pub struct Encoder<'a> {
     /// Buffer that message is being encoded into
     bytes: &'a mut [u8],

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -3,10 +3,10 @@
 use crate::{Length, Tag};
 use core::fmt;
 
-/// Result type
+/// Result type.
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// Error type
+/// Error type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {

--- a/der/src/integer.rs
+++ b/der/src/integer.rs
@@ -41,7 +41,7 @@ impl TryFrom<Any<'_>> for Integer {
     type Error = Error;
 
     fn try_from(any: Any<'_>) -> Result<Integer> {
-        let tag = any.tag().expect(Tag::Integer)?;
+        let tag = any.tag().assert_eq(Tag::Integer)?;
 
         if any.as_bytes().len() == 1 {
             Ok(Integer(any.as_bytes()[0] as i8))

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -3,11 +3,6 @@
 use crate::{Decodable, Decoder, Encodable, Encoder, Error, Result};
 use core::{convert::TryFrom, ops::Add};
 
-/// Error message for when length invariants are violated.
-///
-/// This is intended to be passed directly to [`Result::expect`].
-pub(crate) const ERROR_MSG: &str = "length invariant violated";
-
 /// ASN.1-encoded length.
 ///
 /// # Limits

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -32,6 +32,7 @@ extern crate std;
 
 mod any;
 mod bit_string;
+mod byte_slice;
 mod decoder;
 mod encoder;
 mod error;
@@ -63,7 +64,7 @@ pub use crate::{
     traits::{Decodable, Encodable, Message, Tagged},
 };
 
-pub(crate) use crate::header::Header;
+pub(crate) use crate::{byte_slice::ByteSlice, header::Header};
 
 #[cfg(feature = "oid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]

--- a/der/src/null.rs
+++ b/der/src/null.rs
@@ -11,7 +11,7 @@ impl TryFrom<Any<'_>> for Null {
     type Error = Error;
 
     fn try_from(any: Any<'_>) -> Result<Null> {
-        let tag = any.tag().expect(Tag::Null)?;
+        let tag = any.tag().assert_eq(Tag::Null)?;
 
         if any.is_empty() {
             Ok(Null)

--- a/der/src/oid.rs
+++ b/der/src/oid.rs
@@ -9,7 +9,7 @@ impl TryFrom<Any<'_>> for ObjectIdentifier {
     type Error = Error;
 
     fn try_from(any: Any<'_>) -> Result<ObjectIdentifier> {
-        any.tag().expect(Tag::ObjectIdentifier)?;
+        any.tag().assert_eq(Tag::ObjectIdentifier)?;
         Ok(ObjectIdentifier::from_ber(any.as_bytes())?)
     }
 }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -27,9 +27,10 @@ pub enum Tag {
 }
 
 impl Tag {
-    /// Expect a specific tag type, returning an error if the tag is not the
-    /// one we're expecting
-    pub fn expect(self, expected: Tag) -> Result<Tag> {
+    /// Assert that this [`Tag`] matches the provided expected tag.
+    ///
+    /// On mismatch, returns [`Error::UnexpectedTag`].
+    pub fn assert_eq(self, expected: Tag) -> Result<Tag> {
         if self == expected {
             Ok(self)
         } else {

--- a/der/src/traits.rs
+++ b/der/src/traits.rs
@@ -9,7 +9,7 @@ use {
     core::{convert::TryInto, iter},
 };
 
-/// Decoding trait
+/// Decoding trait.
 pub trait Decodable<'a>: Sized {
     /// Attempt to decode this message using the provided decoder.
     fn decode(decoder: &mut Decoder<'a>) -> Result<Self>;
@@ -24,7 +24,7 @@ where
     }
 }
 
-/// Encoding trait
+/// Encoding trait.
 pub trait Encodable {
     /// Compute the length of this value in bytes when encoded as ASN.1 DER.
     fn encoded_len(&self) -> Result<Length>;
@@ -65,7 +65,7 @@ pub trait Encodable {
     }
 }
 
-/// Types with an associated ASN.1 tag
+/// Types with an associated ASN.1 [`Tag`].
 pub trait Tagged {
     /// ASN.1 tag
     const TAG: Tag;
@@ -81,6 +81,10 @@ pub trait Tagged {
 pub trait Message {
     /// Call the provided function with a slice of [`Encodable`] trait objects
     /// representing the fields of this message.
+    ///
+    /// This method uses a callback because structs with fields which aren't
+    /// directly [`Encodable`] may need to construct temporary values from
+    /// their fields prior to encoding.
     fn fields<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&[&dyn Encodable]) -> Result<T>;


### PR DESCRIPTION
Adds a newtype for byteslices that provides a central place to check the `Length::max()` invariant inforced by this library.

Uses this newly introduced type to impl `Any`, `BitString`, `OctetString`, and `Sequence`.

This eliminates the last of the `Result::expect` calls in this library and moves it closer to being panic-free.