### PR TITLE
der: `Debug` and `Display` impls for `Tag`

### DIFF
--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -20,10 +20,9 @@ impl<'a> ByteSlice<'a> {
     /// Create a new [`ByteSlice`], ensuring that the provided `slice` value
     /// is shorter than `Length::max()`.
     pub fn new(slice: &'a [u8]) -> Result<Self> {
-        let length = Length::try_from(slice.len())?;
         Ok(Self {
             inner: slice,
-            length,
+            length: Length::try_from(slice.len())?,
         })
     }
 


### PR DESCRIPTION
Adds `Display` impl with upper case type names (e.g. "OBJECT IDENTIFIER") and a `Debug` impl with the hex octet and the type name:

    Tag(0x06: OBJECT IDENTIFIER)