### PR TITLE
der: bound `Message` on `Decodable`

### DIFF
--- a/der/src/traits.rs
+++ b/der/src/traits.rs
@@ -78,7 +78,7 @@ pub trait Tagged {
 /// Types which impl this trait receive blanket impls for the [`Decodable`],
 /// [`Encodable`], and [`Tagged`] traits.
 // TODO(tarcieri): ensure all `Message` types impl `Decodable`
-pub trait Message {
+pub trait Message<'a>: Decodable<'a> {
     /// Call the provided function with a slice of [`Encodable`] trait objects
     /// representing the fields of this message.
     ///
@@ -90,7 +90,10 @@ pub trait Message {
         F: FnOnce(&[&dyn Encodable]) -> Result<T>;
 }
 
-impl<M: Message> Encodable for M {
+impl<'a, M> Encodable for M
+where
+    M: Message<'a>,
+{
     fn encoded_len(&self) -> Result<Length> {
         self.fields(sequence::encoded_len)
     }
@@ -100,6 +103,9 @@ impl<M: Message> Encodable for M {
     }
 }
 
-impl<M: Message> Tagged for M {
+impl<'a, M> Tagged for M
+where
+    M: Message<'a>,
+{
     const TAG: Tag = Tag::Sequence;
 }

--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -78,7 +78,7 @@ impl TryFrom<der::Any<'_>> for AlgorithmIdentifier {
     }
 }
 
-impl Message for AlgorithmIdentifier {
+impl<'a> Message<'a> for AlgorithmIdentifier {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
         F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -115,7 +115,7 @@ impl<'a> TryFrom<der::Any<'a>> for PrivateKeyInfo<'a> {
     }
 }
 
-impl<'a> Message for PrivateKeyInfo<'a> {
+impl<'a> Message<'a> for PrivateKeyInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
         F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -93,7 +93,7 @@ impl<'a> TryFrom<der::Any<'a>> for SubjectPublicKeyInfo<'a> {
     }
 }
 
-impl<'a> Message for SubjectPublicKeyInfo<'a> {
+impl<'a> Message<'a> for SubjectPublicKeyInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
         F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,


### PR DESCRIPTION
Unfortunately this adds the `Decodable` lifetime to `Message`, but I'm not sure there's much that can be done about that.

I tried HRTBs but encountered HRTB-related errors (e.g. "error: implementation of `TryFrom` is not general enough") so it seemed simpler to just add a lifetime to `Message`.