### PR TITLE
der: error handling improvements

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `ANY` type.
 
 use crate::{
-    BitString, ByteSlice, Decodable, Decoder, Encodable, Encoder, Error, Header, Integer, Length,
-    Null, OctetString, Result, Sequence, Tag,
+    BitString, ByteSlice, Decodable, Decoder, Encodable, Encoder, ErrorKind, Header, Integer,
+    Length, Null, OctetString, Result, Sequence, Tag,
 };
 use core::convert::{TryFrom, TryInto};
 
@@ -24,7 +24,7 @@ impl<'a> Any<'a> {
     pub fn new(tag: Tag, value: &'a [u8]) -> Result<Self> {
         Ok(Self {
             tag,
-            value: ByteSlice::new(value).map_err(|_| Error::Length { tag })?,
+            value: ByteSlice::new(value).map_err(|_| ErrorKind::Length { tag })?,
         })
     }
 
@@ -98,7 +98,7 @@ impl<'a> Decodable<'a> for Any<'a> {
         let header = Header::decode(decoder)?;
         let tag = header.tag;
         let len = usize::from(header.length);
-        let value = decoder.bytes(len).map_err(|_| Error::Length { tag })?;
+        let value = decoder.bytes(len).map_err(|_| ErrorKind::Length { tag })?;
         Self::new(tag, value)
     }
 }

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `BIT STRING` support.
 
-use crate::{Any, ByteSlice, Encodable, Encoder, Error, Length, Result, Tag, Tagged};
+use crate::{Any, ByteSlice, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 /// ASN.1 `BIT STRING` type.
@@ -15,7 +15,7 @@ impl<'a> BitString<'a> {
     pub fn new(slice: &'a [u8]) -> Result<Self> {
         ByteSlice::new(slice)
             .map(|inner| Self { inner })
-            .map_err(|_| Error::Length { tag: Self::TAG })
+            .map_err(|_| ErrorKind::Length { tag: Self::TAG }.into())
     }
 
     /// Borrow the inner byte sequence

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `BOOLEAN` support.
 
-use crate::{Any, Encodable, Encoder, Error, Header, Length, Result, Tag, Tagged};
+use crate::{Any, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -47,7 +47,7 @@ impl TryFrom<Any<'_>> for Boolean {
         match any.as_bytes() {
             [FALSE_OCTET] => Ok(false.into()),
             [TRUE_OCTET] => Ok(true.into()),
-            _ => Err(Error::Noncanonical),
+            _ => Err(ErrorKind::Noncanonical.into()),
         }
     }
 }

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `INTEGER` support.
 
-use crate::{Any, Encodable, Encoder, Error, Header, Length, Result, Tag, Tagged};
+use crate::{Any, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 /// ASN.1 `INTEGER` type.
@@ -45,7 +45,7 @@ impl TryFrom<Any<'_>> for Integer {
 
         match any.as_bytes() {
             [x] => Ok(Integer(*x as i8)),
-            _ => Err(Error::Length { tag }),
+            _ => Err(ErrorKind::Length { tag }.into()),
         }
     }
 }

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `NULL` support.
 
-use crate::{Any, Encodable, Encoder, Error, Length, Result, Tag, Tagged};
+use crate::{Any, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 /// ASN.1 `NULL` type.
@@ -16,7 +16,7 @@ impl TryFrom<Any<'_>> for Null {
         if any.is_empty() {
             Ok(Null)
         } else {
-            Err(Error::Length { tag })
+            Err(ErrorKind::Length { tag }.into())
         }
     }
 }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `OCTET STRING` support.
 
-use crate::{Any, ByteSlice, Encodable, Encoder, Error, Length, Result, Tag, Tagged};
+use crate::{Any, ByteSlice, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 /// ASN.1 `OCTET STRING` type.
@@ -15,7 +15,7 @@ impl<'a> OctetString<'a> {
     pub fn new(slice: &'a [u8]) -> Result<Self> {
         ByteSlice::new(slice)
             .map(|inner| Self { inner })
-            .map_err(|_| Error::Length { tag: Self::TAG })
+            .map_err(|_| ErrorKind::Length { tag: Self::TAG }.into())
     }
 
     /// Borrow the inner byte sequence

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -1,7 +1,8 @@
 //! ASN.1 `SEQUENCE` support.
 
 use crate::{
-    Any, ByteSlice, Decoder, Encodable, Encoder, Error, Header, Length, Result, Tag, Tagged,
+    Any, ByteSlice, Decoder, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag,
+    Tagged,
 };
 use core::convert::TryFrom;
 
@@ -34,7 +35,7 @@ impl<'a> Sequence<'a> {
     pub fn new(slice: &'a [u8]) -> Result<Self> {
         ByteSlice::new(slice)
             .map(|inner| Self { inner })
-            .map_err(|_| Error::Length { tag: Self::TAG })
+            .map_err(|_| ErrorKind::Length { tag: Self::TAG }.into())
     }
 
     /// Borrow the inner byte sequence

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER headers.
 
-use crate::{Decodable, Decoder, Encodable, Encoder, Error, Length, Result, Tag};
+use crate::{Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Result, Tag};
 use core::convert::TryInto;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
@@ -18,7 +18,7 @@ impl Header {
     ///
     /// Returns [`Error`] if the length exceeds the limits of [`Length`]
     pub fn new(tag: Tag, length: impl TryInto<Length>) -> Result<Self> {
-        let length = length.try_into().map_err(|_| Error::Overflow)?;
+        let length = length.try_into().map_err(|_| ErrorKind::Overflow)?;
         Ok(Self { tag, length })
     }
 }
@@ -28,8 +28,8 @@ impl Decodable<'_> for Header {
         let tag = Tag::decode(decoder)?;
 
         let length = Length::decode(decoder).map_err(|e| {
-            if e == Error::Overlength {
-                Error::Length { tag }
+            if e.kind() == ErrorKind::Overlength {
+                ErrorKind::Length { tag }.into()
             } else {
                 e
             }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::{
     },
     decoder::Decoder,
     encoder::Encoder,
-    error::{Error, Result},
+    error::{Error, ErrorKind, Result},
     length::Length,
     tag::Tag,
     traits::{Decodable, Encodable, Message, Tagged},

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -1,6 +1,6 @@
 //! ASN.1 tags.
 
-use crate::{Decodable, Decoder, Encodable, Encoder, Error, Length, Result};
+use crate::{Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Length, Result};
 use core::{convert::TryFrom, fmt};
 
 /// ASN.1 tags.
@@ -41,7 +41,7 @@ impl TryFrom<u8> for Tag {
             0x05 => Ok(Tag::Null),
             0x06 => Ok(Tag::ObjectIdentifier),
             0x30 => Ok(Tag::Sequence),
-            _ => Err(Error::UnknownTag { byte }),
+            _ => Err(ErrorKind::UnknownTag { byte }.into()),
         }
     }
 }
@@ -54,10 +54,11 @@ impl Tag {
         if self == expected {
             Ok(self)
         } else {
-            Err(Error::UnexpectedTag {
+            Err(ErrorKind::UnexpectedTag {
                 expected: Some(expected),
                 actual: self,
-            })
+            }
+            .into())
         }
     }
 

--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -47,7 +47,7 @@ impl AlgorithmIdentifier {
     pub fn write_der<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a [u8]> {
         let mut encoder = der::Encoder::new(buffer);
         self.encode(&mut encoder)?;
-        Ok(encoder.finish())
+        Ok(encoder.finish()?)
     }
 
     /// Encode this [`AlgorithmIdentifier`] as ASN.1 DER
@@ -147,10 +147,11 @@ impl TryFrom<der::Any<'_>> for AlgorithmParameters {
         match any.tag() {
             der::Tag::Null => any.null().map(Into::into),
             der::Tag::ObjectIdentifier => any.oid().map(Into::into),
-            _ => Err(der::Error::UnexpectedTag {
+            _ => Err(der::ErrorKind::UnexpectedTag {
                 expected: None,
                 actual: any.tag(),
-            }),
+            }
+            .into()),
         }
     }
 }

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -61,7 +61,7 @@ impl<'a> PrivateKeyInfo<'a> {
     pub fn write_der<'b>(&self, buffer: &'b mut [u8]) -> Result<&'b [u8]> {
         let mut encoder = der::Encoder::new(buffer);
         self.encode(&mut encoder)?;
-        Ok(encoder.finish())
+        Ok(encoder.finish()?)
     }
 
     /// Encode this [`PrivateKeyInfo`] as ASN.1 DER.
@@ -99,9 +99,10 @@ impl<'a> TryFrom<der::Any<'a>> for PrivateKeyInfo<'a> {
         any.sequence(|mut decoder| {
             // Parse and validate `version` INTEGER.
             if decoder.integer()? != VERSION.into() {
-                return Err(der::Error::Value {
+                return Err(der::ErrorKind::Value {
                     tag: der::Tag::Integer,
-                });
+                }
+                .into());
             }
 
             let algorithm = decoder.decode()?;

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -48,7 +48,7 @@ impl<'a> SubjectPublicKeyInfo<'a> {
     pub fn write_der<'b>(&self, buffer: &'b mut [u8]) -> Result<&'b [u8]> {
         let mut encoder = der::Encoder::new(buffer);
         self.encode(&mut encoder)?;
-        Ok(encoder.finish())
+        Ok(encoder.finish()?)
     }
 
     /// Encode this [`SubjectPublicKeyInfo] as ASN.1 DER.


### PR DESCRIPTION
Renames the previous `Error` enum to `ErrorKind`, and adds an `Error` struct with a `::kind()` method as well as an optional position where the error occurred to assist in debugging.

Also adds a proper `Display` impl to `ErrorKind` with messages about each of the variants.