### PR TITLE
der: assorted tests

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `ANY` type.
 
 use crate::{
-    BitString, ByteSlice, Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Header,
-    Integer, Length, Null, OctetString, Result, Sequence, Tag,
+    BitString, ByteSlice, Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Header, Length,
+    Null, OctetString, Result, Sequence, Tag,
 };
 use core::convert::{TryFrom, TryInto};
 
@@ -50,11 +50,6 @@ impl<'a> Any<'a> {
 
     /// Attempt to decode an ASN.1 `BIT STRING`
     pub fn bit_string(self) -> Result<BitString<'a>> {
-        self.try_into()
-    }
-
-    /// Attempt to decode an ASN.1 `INTEGER`
-    pub fn integer(self) -> Result<Integer> {
         self.try_into()
     }
 

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -40,3 +40,25 @@ impl Encodable for Null {
 impl Tagged for Null {
     const TAG: Tag = Tag::Integer;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Null;
+    use crate::{Decodable, Encodable};
+
+    #[test]
+    fn decode() {
+        assert!(Null::from_bytes(&[0x05, 0x00]).is_ok());
+    }
+
+    #[test]
+    fn encode() {
+        let mut buffer = [0u8; 2];
+        assert_eq!(&[0x05, 0x00], Null.encode_to_slice(&mut buffer).unwrap())
+    }
+
+    #[test]
+    fn reject_non_canonical() {
+        assert!(Null::from_bytes(&[0x05, 0x81, 0x00]).is_err());
+    }
+}

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -29,3 +29,28 @@ impl Encodable for ObjectIdentifier {
 impl<'a> Tagged for ObjectIdentifier {
     const TAG: Tag = Tag::ObjectIdentifier;
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Decodable, Encodable, ObjectIdentifier};
+
+    const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 113549]);
+    const EXAMPLE_OID_BYTES: &[u8; 8] = &[0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d];
+
+    #[test]
+    fn decode() {
+        assert_eq!(
+            EXAMPLE_OID,
+            ObjectIdentifier::from_bytes(EXAMPLE_OID_BYTES).unwrap()
+        );
+    }
+
+    #[test]
+    fn encode() {
+        let mut buffer = [0u8; 8];
+        assert_eq!(
+            EXAMPLE_OID_BYTES,
+            EXAMPLE_OID.encode_to_slice(&mut buffer).unwrap()
+        );
+    }
+}

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -167,3 +167,66 @@ impl fmt::Display for Length {
         self.0.fmt(f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Length;
+    use crate::{Decodable, Encodable};
+
+    #[test]
+    fn decode() {
+        assert_eq!(Length::zero(), Length::from_bytes(&[0x00]).unwrap());
+
+        assert_eq!(Length::from(0x7Fu8), Length::from_bytes(&[0x7F]).unwrap());
+
+        assert_eq!(
+            Length::from(0x80u8),
+            Length::from_bytes(&[0x81, 0x80]).unwrap()
+        );
+
+        assert_eq!(
+            Length::from(0xFFu8),
+            Length::from_bytes(&[0x81, 0xFF]).unwrap()
+        );
+
+        assert_eq!(
+            Length::from(0x100u16),
+            Length::from_bytes(&[0x82, 0x01, 0x00]).unwrap()
+        );
+    }
+
+    #[test]
+    fn encode() {
+        let mut buffer = [0u8; 3];
+
+        assert_eq!(
+            &[0x00],
+            Length::zero().encode_to_slice(&mut buffer).unwrap()
+        );
+
+        assert_eq!(
+            &[0x7F],
+            Length::from(0x7Fu8).encode_to_slice(&mut buffer).unwrap()
+        );
+
+        assert_eq!(
+            &[0x81, 0x80],
+            Length::from(0x80u8).encode_to_slice(&mut buffer).unwrap()
+        );
+
+        assert_eq!(
+            &[0x81, 0xFF],
+            Length::from(0xFFu8).encode_to_slice(&mut buffer).unwrap()
+        );
+
+        assert_eq!(
+            &[0x82, 0x01, 0x00],
+            Length::from(0x100u16).encode_to_slice(&mut buffer).unwrap()
+        );
+    }
+
+    #[test]
+    fn reject_indefinite_lengths() {
+        assert!(Length::from_bytes(&[0x80]).is_err());
+    }
+}

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -3,9 +3,9 @@
 //!
 //! # About
 //!
-//! This crate presently provides an implementation of a subset of ASN.1 DER
-//! necessary for decoding/encoding various cryptography-related formats
-//! implemented as part of the [RustCrypto] project, e.g. the [`pkcs8`] crate.
+//! This crate provides an implementation of a subset of ASN.1 DER necessary
+//! for decoding/encoding various cryptography-related formats implemented as
+//! part of the [RustCrypto] project, e.g. the [`pkcs8`] crate.
 //!
 //! The core implementation avoids any heap usage (with convenience methods
 //! that allocate gated under the off-by-default `alloc` feature).
@@ -220,13 +220,8 @@ mod traits;
 
 pub use crate::{
     asn1::{
-        any::Any,
-        bit_string::BitString,
-        boolean::Boolean,
-        integer::{Integer, RawInteger},
-        null::Null,
-        octet_string::OctetString,
-        sequence::Sequence,
+        any::Any, bit_string::BitString, integer::RawInteger, null::Null,
+        octet_string::OctetString, sequence::Sequence,
     },
     decoder::Decoder,
     encoder::Encoder,

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -30,6 +30,7 @@ pub enum Tag {
     /// Note that the universal tag number for `SEQUENCE` is technically `0x10`
     /// however we presently only support the constructed form, which has the
     /// 6th bit (i.e. `0x20`) set.
+    // TODO(tarcieri): explicitly handle primitive vs constructed forms?
     Sequence = 0x30,
 }
 

--- a/der/src/traits.rs
+++ b/der/src/traits.rs
@@ -42,6 +42,14 @@ pub trait Encodable {
     /// Encode this value as ASN.1 DER using the provided [`Encoder`].
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()>;
 
+    /// Encode this value to the provided byte slice, returning a sub-slice
+    /// containing the encoded message.
+    fn encode_to_slice<'a>(&self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+        let mut encoder = Encoder::new(buf);
+        self.encode(&mut encoder)?;
+        Ok(encoder.finish()?)
+    }
+
     /// Encode this message as ASN.1 DER, appending it to the provided
     /// byte vector.
     #[cfg(feature = "alloc")]

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -98,7 +98,7 @@ impl<'a> TryFrom<der::Any<'a>> for PrivateKeyInfo<'a> {
     fn try_from(any: der::Any<'a>) -> der::Result<PrivateKeyInfo<'a>> {
         any.sequence(|mut decoder| {
             // Parse and validate `version` INTEGER.
-            if decoder.integer()? != VERSION.into() {
+            if i8::decode(&mut decoder)? != VERSION {
                 return Err(der::ErrorKind::Value {
                     tag: der::Tag::Integer,
                 }
@@ -122,7 +122,7 @@ impl<'a> Message<'a> for PrivateKeyInfo<'a> {
         F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
     {
         f(&[
-            &der::Integer::from(VERSION),
+            &VERSION,
             &self.algorithm,
             &der::OctetString::new(self.private_key)?,
         ])


### PR DESCRIPTION
Adds some basic tests for encoding/decoding, including ones for various ASN.1 types and the `Decoder` and `Encoder` types themselves.