### PR TITLE
const-oid: fix bug in const initializer

### DIFF
--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -176,7 +176,7 @@ impl ObjectIdentifier {
                 0, 0, 0, 0, 0
             ],
             4 => [
-                arcs[2], arcs[3], arcs[4], 0, 0,
+                arcs[2], arcs[3], 0, 0, 0,
                 0, 0, 0, 0, 0
             ],
             5 => [


### PR DESCRIPTION
One of the lengths (4) was mishandled, which prevented code from compiling when used in a const context.