### PR TITLE
der: have `Decoder::sequence` call `::finish` automatically

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -100,12 +100,11 @@
 //!             // `decoder.optional()` method.
 //!             let parameters = decoder.decode()?;
 //!
-//!             // The `der::Decoder::finish` method asserts that the entire
-//!             // message has been consumed, and if so, returns the provided
-//!             // value which is in turn returned from the `any.sequence(...)`
-//!             // method above. Failure to consume the entire message will
-//!             // return an error instead.
-//!             decoder.finish(Self { algorithm, parameters })
+//!             // The value returned from the provided `FnOnce` will be
+//!             // returned from the `any.sequence(...)` call above.
+//!             // Note that the entire sequence body *MUST* be consumed
+//!             // or an error will be returned.
+//!             Ok(Self { algorithm, parameters })
 //!         })
 //!     }
 //! }

--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -73,7 +73,7 @@ impl TryFrom<der::Any<'_>> for AlgorithmIdentifier {
         any.sequence(|mut decoder| {
             let oid = decoder.decode()?;
             let parameters = decoder.decode()?;
-            decoder.finish(Self { oid, parameters })
+            Ok(Self { oid, parameters })
         })
     }
 }

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -85,7 +85,7 @@ impl<'a> TryFrom<der::Any<'a>> for SubjectPublicKeyInfo<'a> {
         any.sequence(|mut decoder| {
             let algorithm = decoder.decode()?;
             let subject_public_key = decoder.bit_string()?.as_bytes();
-            decoder.finish(Self {
+            Ok(Self {
                 algorithm,
                 subject_public_key,
             })


### PR DESCRIPTION
...on the nested decoder it creates.

This changes the API to have the `FnOnce` callback for decoding a sequence borrow the decoder rather than passing it by value.

This allows the caller function to retain ownership, and with that it can call finish automatically.