### PR TITLE
pkcs8: use DER encoding helpers

### DIFF
--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -30,9 +30,7 @@ pub struct AlgorithmIdentifier {
 impl AlgorithmIdentifier {
     /// Parse [`AlgorithmIdentifier`] encoded as ASN.1 DER
     pub fn from_der(bytes: &[u8]) -> Result<Self> {
-        let mut decoder = der::Decoder::new(bytes);
-        let result = Self::decode(&mut decoder)?;
-        decoder.finish(result).map_err(|_| Error::Decode)
+        Ok(Self::from_bytes(bytes)?)
     }
 
     /// Get the `parameters` field as an [`ObjectIdentifier`].
@@ -45,9 +43,7 @@ impl AlgorithmIdentifier {
     /// Write ASN.1 DER-encoded [`AlgorithmIdentifier`] to the provided
     /// buffer, returning a slice containing the encoded data.
     pub fn write_der<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a [u8]> {
-        let mut encoder = der::Encoder::new(buffer);
-        self.encode(&mut encoder)?;
-        Ok(encoder.finish()?)
+        Ok(self.encode_to_slice(buffer)?)
     }
 
     /// Encode this [`AlgorithmIdentifier`] as ASN.1 DER

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -51,17 +51,13 @@ pub struct PrivateKeyInfo<'a> {
 impl<'a> PrivateKeyInfo<'a> {
     /// Parse [`PrivateKeyInfo`] encoded as ASN.1 DER.
     pub fn from_der(bytes: &'a [u8]) -> Result<Self> {
-        let mut decoder = der::Decoder::new(bytes);
-        let result = Self::decode(&mut decoder)?;
-        decoder.finish(result).map_err(|_| Error::Decode)
+        Ok(Self::from_bytes(bytes)?)
     }
 
     /// Write ASN.1 DER-encoded [`PrivateKeyInfo`] to the provided
     /// buffer, returning a slice containing the encoded data.
     pub fn write_der<'b>(&self, buffer: &'b mut [u8]) -> Result<&'b [u8]> {
-        let mut encoder = der::Encoder::new(buffer);
-        self.encode(&mut encoder)?;
-        Ok(encoder.finish()?)
+        Ok(self.encode_to_slice(buffer)?)
     }
 
     /// Encode this [`PrivateKeyInfo`] as ASN.1 DER.

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -38,17 +38,13 @@ pub struct SubjectPublicKeyInfo<'a> {
 impl<'a> SubjectPublicKeyInfo<'a> {
     /// Parse [`SubjectPublicKeyInfo`] encoded as ASN.1 DER.
     pub fn from_der(bytes: &'a [u8]) -> Result<Self> {
-        let mut decoder = der::Decoder::new(bytes);
-        let result = Self::decode(&mut decoder)?;
-        decoder.finish(result).map_err(|_| Error::Decode)
+        Ok(Self::from_bytes(bytes)?)
     }
 
     /// Write ASN.1 DER-encoded [`SubjectPublicKeyInfo`] to the provided
     /// buffer, returning a slice containing the encoded data.
     pub fn write_der<'b>(&self, buffer: &'b mut [u8]) -> Result<&'b [u8]> {
-        let mut encoder = der::Encoder::new(buffer);
-        self.encode(&mut encoder)?;
-        Ok(encoder.finish()?)
+        Ok(self.encode_to_slice(buffer)?)
     }
 
     /// Encode this [`SubjectPublicKeyInfo] as ASN.1 DER.


### PR DESCRIPTION
Gets rid of some redundant boilerplate