### PR TITLE
der: extract `Sequence::decode_nested`

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -74,9 +74,9 @@ impl<'a> Any<'a> {
     /// nested [`Decoder`] and calling the provided argument with it.
     pub fn sequence<F, T>(self, f: F) -> Result<T>
     where
-        F: FnOnce(Decoder<'a>) -> Result<T>,
+        F: FnOnce(&mut Decoder<'a>) -> Result<T>,
     {
-        Sequence::try_from(self).and_then(|seq| f(seq.decoder()))
+        Sequence::try_from(self)?.decode_nested(f)
     }
 
     /// Get the ASN.1 DER [`Header`] for this [`Any`] value

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -43,9 +43,16 @@ impl<'a> Sequence<'a> {
         self.inner.as_bytes()
     }
 
-    /// Obtain a [`Decoder`] for the data in this [`Sequence`]
-    pub fn decoder(&self) -> Decoder<'a> {
-        Decoder::new(self.as_bytes())
+    /// Decode values nested within a sequence, creating a new [`Decoder`] for
+    /// the data contained in the sequence's body and passing it to the provided
+    /// [`FnOnce`].
+    pub fn decode_nested<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Decoder<'a>) -> Result<T>,
+    {
+        let mut seq_decoder = Decoder::new(self.as_bytes());
+        let result = f(&mut seq_decoder)?;
+        seq_decoder.finish(result)
     }
 }
 

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -114,15 +114,9 @@ impl<'a> Decoder<'a> {
     where
         F: FnOnce(&mut Decoder<'a>) -> Result<T>,
     {
-        Sequence::decode(self).and_then(|seq| {
-            let mut seq_decoder = seq.decoder();
-
-            let result = f(&mut seq_decoder).map_err(|e| {
-                self.bytes.take();
-                e.nested(self.position)
-            })?;
-
-            seq_decoder.finish(result)
+        Sequence::decode(self)?.decode_nested(f).map_err(|e| {
+            self.bytes.take();
+            e.nested(self.position)
         })
     }
 

--- a/pkcs8/src/algorithm.rs
+++ b/pkcs8/src/algorithm.rs
@@ -66,7 +66,7 @@ impl TryFrom<der::Any<'_>> for AlgorithmIdentifier {
     type Error = der::Error;
 
     fn try_from(any: der::Any<'_>) -> der::Result<AlgorithmIdentifier> {
-        any.sequence(|mut decoder| {
+        any.sequence(|decoder| {
             let oid = decoder.decode()?;
             let parameters = decoder.decode()?;
             Ok(Self { oid, parameters })

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -92,9 +92,9 @@ impl<'a> TryFrom<der::Any<'a>> for PrivateKeyInfo<'a> {
     type Error = der::Error;
 
     fn try_from(any: der::Any<'a>) -> der::Result<PrivateKeyInfo<'a>> {
-        any.sequence(|mut decoder| {
+        any.sequence(|decoder| {
             // Parse and validate `version` INTEGER.
-            if i8::decode(&mut decoder)? != VERSION {
+            if i8::decode(decoder)? != VERSION {
                 return Err(der::ErrorKind::Value {
                     tag: der::Tag::Integer,
                 }
@@ -104,7 +104,7 @@ impl<'a> TryFrom<der::Any<'a>> for PrivateKeyInfo<'a> {
             let algorithm = decoder.decode()?;
             let private_key = decoder.octet_string()?.into();
 
-            decoder.finish(Self {
+            Ok(Self {
                 algorithm,
                 private_key,
             })

--- a/pkcs8/src/spki.rs
+++ b/pkcs8/src/spki.rs
@@ -78,7 +78,7 @@ impl<'a> TryFrom<der::Any<'a>> for SubjectPublicKeyInfo<'a> {
     type Error = der::Error;
 
     fn try_from(any: der::Any<'a>) -> der::Result<SubjectPublicKeyInfo<'a>> {
-        any.sequence(|mut decoder| {
+        any.sequence(|decoder| {
             let algorithm = decoder.decode()?;
             let subject_public_key = decoder.bit_string()?.as_bytes();
             Ok(Self {


### PR DESCRIPTION
DRYs out the parsing of fields nested in `Sequence` data into a new `Sequence::decode_nested` method.