### PR TITLE
der_derive: custom derive support for the `der` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,17 @@ name = "der"
 version = "0.0.0"
 dependencies = [
  "const-oid",
+ "der_derive",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -86,6 +97,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "subtle-encoding"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,10 +124,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "cpuid-bool",
     "dbl",
     "der",
+    "der/derive",
     "hex-literal",
     "opaque-debug",
     "pkcs8"

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -19,8 +19,14 @@ version = "0.4"
 optional = true
 path = "../const-oid"
 
+[dependencies.der_derive]
+version = "0"
+optional = true
+path = "derive"
+
 [features]
 alloc = []
+derive = ["der_derive"]
 oid = ["const-oid"]
 std = ["alloc"]
 

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "der_derive"
+version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+description = """
+Procedural macro for automatically deriving the `der` crate's `Message` trait
+"""
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+documentation = "https://docs.rs/pkcs8"
+repository = "https://github.com/RustCrypto/utils/tree/master/der"
+categories = ["cryptography", "data-structures", "encoding", "no-std"]
+keywords = ["asn1", "der", "crypto", "itu", "pkcs"]
+readme = "README.md"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = "1"
+synstructure = "0.12"

--- a/der/derive/README.md
+++ b/der/derive/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: ASN.1 DER
+# RustCrypto: DER Custom Derive Support
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -7,25 +7,9 @@
 [![Project Chat][chat-image]][chat-link]
 [![Build Status][build-image]][build-link]
 
-Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules (DER)
-for Abstract Syntax Notation One (ASN.1) as described in ITU X.690.
+Procedural macro for automatically deriving the `der` crate's `Message` trait.
 
 [Documentation][docs-link]
-
-# About
-
-This crate provides a `no_std`-friendly implementation of a subset of ASN.1 DER
-necessary  for decoding/encoding various cryptography-related formats
-implemented as part of the [RustCrypto] project, e.g. the [`pkcs8`] crate.
-
-The core implementation avoids any heap usage (with convenience methods
-that allocate gated under the off-by-default `alloc` feature).
-
-The implementation is presently specialized for documents which are smaller
-than 64kB, as that provides a safe bound for the current use cases.
-However, that may be revisited in the future depending on interest in
-support for larger documents. Please open a [GitHub Issue] if you find
-this limit constraining in practice.
 
 ## License
 
@@ -44,10 +28,10 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/der.svg
-[crate-link]: https://crates.io/crates/der
-[docs-image]: https://docs.rs/der/badge.svg
-[docs-link]: https://docs.rs/der/
+[crate-image]: https://img.shields.io/crates/v/der_derive.svg
+[crate-link]: https://crates.io/crates/der_derive
+[docs-image]: https://docs.rs/der_derive/badge.svg
+[docs-link]: https://docs.rs/der_derive/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -1,0 +1,148 @@
+//! Custom derive support for the `der` crate
+
+#![crate_type = "proc-macro"]
+#![warn(rust_2018_idioms, trivial_casts, unused_qualifications)]
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{DataStruct, Field, Generics, Ident, Lifetime};
+use synstructure::{decl_derive, Structure};
+
+decl_derive!(
+    [Message] =>
+
+    /// Derive the [`Message`] trait.
+    ///
+    /// This custom derive macro can be used to automatically impl the
+    /// [`Message`] trait for any struct representing a message which is
+    /// encoded as an ASN.1 `SEQUENCE`.
+    derive_der_message
+);
+
+/// Custom derive for `der::Message`
+fn derive_der_message(s: Structure<'_>) -> TokenStream {
+    let ast = s.ast();
+
+    // TODO(tarcieri): enum support
+    match &ast.data {
+        syn::Data::Struct(data) => DeriveStruct::derive(s, data, &ast.generics),
+        other => panic!("can't derive `Message` on: {:?}", other),
+    }
+}
+
+/// Derive `Message` on a struct
+// TODO(tarcieri): make sure tags are in the right order and digest is the last field
+struct DeriveStruct {
+    /// Field decoders
+    decode_fields: TokenStream,
+
+    /// Bound fields of a struct to be returned
+    decode_result: TokenStream,
+
+    /// Fields of a struct to be serialized
+    encode_fields: TokenStream,
+}
+
+impl DeriveStruct {
+    pub fn derive(s: Structure<'_>, data: &DataStruct, generics: &Generics) -> TokenStream {
+        // Rust models structs as enums with a single variant
+        assert_eq!(s.variants().len(), 1, "expected one variant");
+
+        let mut state = Self {
+            decode_fields: TokenStream::new(),
+            decode_result: TokenStream::new(),
+            encode_fields: TokenStream::new(),
+        };
+
+        let variant = &s.variants()[0];
+        let bindings = &variant.bindings();
+
+        assert_eq!(
+            bindings.len(),
+            data.fields.len(),
+            "unexpected number of bindings ({} vs {})",
+            bindings.len(),
+            data.fields.len()
+        );
+
+        for (binding_info, field) in bindings.iter().zip(&data.fields) {
+            state.derive_field(field, &binding_info.binding);
+        }
+
+        state.finish(&s, generics)
+    }
+
+    /// Derive handling for a particular `#[field(...)]`
+    fn derive_field(&mut self, field: &Field, _binding: &Ident) {
+        let name = parse_field_name(field);
+        self.derive_field_decoder(name);
+        self.derive_field_encoder(name);
+    }
+
+    /// Derive code for decoding a field of a message
+    fn derive_field_decoder(&mut self, name: &Ident) {
+        let field_decoder = quote! { let #name = decoder.decode()?; };
+        field_decoder.to_tokens(&mut self.decode_fields);
+
+        let field_result = quote!(#name,);
+        field_result.to_tokens(&mut self.decode_result);
+    }
+
+    /// Derive code for encoding a field of a message
+    fn derive_field_encoder(&mut self, name: &Ident) {
+        let field_encoder = quote!(&self.#name,);
+        field_encoder.to_tokens(&mut self.encode_fields);
+    }
+
+    /// Finish deriving a struct
+    fn finish(self, s: &Structure<'_>, generics: &Generics) -> TokenStream {
+        let lifetime = match parse_lifetime(generics) {
+            Some(lifetime) => quote!(#lifetime),
+            None => quote!('_),
+        };
+
+        let decode_fields = self.decode_fields;
+        let decode_result = self.decode_result;
+        let encode_fields = self.encode_fields;
+
+        s.gen_impl(quote! {
+            gen impl core::convert::TryFrom<der::Any<#lifetime>> for @Self {
+                type Error = der::Error;
+
+                fn try_from(any: der::Any<#lifetime>) -> der::Result<Self> {
+                    any.sequence(|decoder| {
+                        #decode_fields
+                        Ok(Self { #decode_result })
+                    })
+                }
+            }
+
+            gen impl der::Message<#lifetime> for @Self {
+                fn fields<F, T>(&self, f: F) -> der::Result<T>
+                where
+                    F: FnOnce(&[&dyn der::Encodable]) -> der::Result<T>,
+                {
+                    f(&[#encode_fields])
+                }
+            }
+        })
+    }
+}
+
+/// Parse the name of a field
+fn parse_field_name(field: &Field) -> &Ident {
+    field
+        .ident
+        .as_ref()
+        .unwrap_or_else(|| panic!("no name on struct field (e.g. tuple structs unsupported)"))
+}
+
+/// Parse the first lifetime of the "self" type of the custom derive
+///
+/// Returns `None` if there is no first lifetime.
+fn parse_lifetime(generics: &Generics) -> Option<&Lifetime> {
+    generics
+        .lifetimes()
+        .next()
+        .map(|ref lt_ref| &lt_ref.lifetime)
+}


### PR DESCRIPTION
Adds a preliminary custom derive macro for the `der::Message` crate which works on any struct whose fields impl `Decodable` and `Encodable`.