### PR TITLE
der: #[asn1(type = "...")] custom derive attribute

### DIFF
--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -5,17 +5,32 @@
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{DataStruct, Field, Generics, Ident, Lifetime};
+use syn::{
+    DataStruct, Field, Generics, Ident, Lifetime, Lit, Meta, MetaList, MetaNameValue, NestedMeta,
+};
 use synstructure::{decl_derive, Structure};
 
 decl_derive!(
-    [Message] =>
+    [Message, attributes(asn1)] =>
 
-    /// Derive the [`Message`] trait.
+    /// Derive the `Message` trait.
     ///
     /// This custom derive macro can be used to automatically impl the
-    /// [`Message`] trait for any struct representing a message which is
+    /// `Message` trait for any struct representing a message which is
     /// encoded as an ASN.1 `SEQUENCE`.
+    ///
+    /// # `#[asn1(type = "...")]` attribute
+    ///
+    /// Placing this attribute on fields of a struct makes it possible to
+    /// decode types which don't directly implement the `Decode` and `Encode`
+    /// traits but do impl `TryInto` and `From` for one of the ASN.1 types
+    /// listed below:
+    ///
+    /// - `bit-string`: performs an intermediate conversion to `der::BitString`
+    /// - `octet-string`: performs an intermediate conversion to `der::OctetString`
+    ///
+    /// Note: please open a GitHub Issue if you would like to request support
+    /// for additional ASN.1 types.
     derive_der_message
 );
 
@@ -45,52 +60,56 @@ struct DeriveStruct {
 
 impl DeriveStruct {
     pub fn derive(s: Structure<'_>, data: &DataStruct, generics: &Generics) -> TokenStream {
-        // Rust models structs as enums with a single variant
-        assert_eq!(s.variants().len(), 1, "expected one variant");
-
         let mut state = Self {
             decode_fields: TokenStream::new(),
             decode_result: TokenStream::new(),
             encode_fields: TokenStream::new(),
         };
 
-        let variant = &s.variants()[0];
-        let bindings = &variant.bindings();
-
-        assert_eq!(
-            bindings.len(),
-            data.fields.len(),
-            "unexpected number of bindings ({} vs {})",
-            bindings.len(),
-            data.fields.len()
-        );
-
-        for (binding_info, field) in bindings.iter().zip(&data.fields) {
-            state.derive_field(field, &binding_info.binding);
+        for field in &data.fields {
+            state.derive_field(field);
         }
 
         state.finish(&s, generics)
     }
 
     /// Derive handling for a particular `#[field(...)]`
-    fn derive_field(&mut self, field: &Field, _binding: &Ident) {
-        let name = parse_field_name(field);
-        self.derive_field_decoder(name);
-        self.derive_field_encoder(name);
+    fn derive_field(&mut self, field: &Field) {
+        let attrs = FieldAttrs::new(field);
+        self.derive_field_decoder(&attrs);
+        self.derive_field_encoder(&attrs);
     }
 
     /// Derive code for decoding a field of a message
-    fn derive_field_decoder(&mut self, name: &Ident) {
-        let field_decoder = quote! { let #name = decoder.decode()?; };
+    fn derive_field_decoder(&mut self, field: &FieldAttrs) {
+        let field_name = &field.name;
+        let field_decoder = match field.asn1_type {
+            Some(Asn1Type::BitString) => {
+                quote! { let #field_name = decoder.bit_string()?.try_into()?; }
+            }
+            Some(Asn1Type::OctetString) => {
+                quote! { let #field_name = decoder.octet_string()?.try_into()?; }
+            }
+            None => quote! { let #field_name = decoder.decode()?; },
+        };
         field_decoder.to_tokens(&mut self.decode_fields);
 
-        let field_result = quote!(#name,);
+        let field_result = quote!(#field_name,);
         field_result.to_tokens(&mut self.decode_result);
     }
 
     /// Derive code for encoding a field of a message
-    fn derive_field_encoder(&mut self, name: &Ident) {
-        let field_encoder = quote!(&self.#name,);
+    fn derive_field_encoder(&mut self, field: &FieldAttrs) {
+        let field_name = &field.name;
+        let field_encoder = match field.asn1_type {
+            Some(Asn1Type::BitString) => {
+                quote!(&der::BitString::new(&self.#field_name)?,)
+            }
+            Some(Asn1Type::OctetString) => {
+                quote!(&der::OctetString::new(&self.#field_name)?,)
+            }
+            None => quote!(&self.#field_name,),
+        };
         field_encoder.to_tokens(&mut self.encode_fields);
     }
 
@@ -110,6 +129,9 @@ impl DeriveStruct {
                 type Error = der::Error;
 
                 fn try_from(any: der::Any<#lifetime>) -> der::Result<Self> {
+                    #[allow(unused_imports)]
+                    use core::convert::TryInto;
+
                     any.sequence(|decoder| {
                         #decode_fields
                         Ok(Self { #decode_result })
@@ -129,14 +151,6 @@ impl DeriveStruct {
     }
 }
 
-/// Parse the name of a field
-fn parse_field_name(field: &Field) -> &Ident {
-    field
-        .ident
-        .as_ref()
-        .unwrap_or_else(|| panic!("no name on struct field (e.g. tuple structs unsupported)"))
-}
-
 /// Parse the first lifetime of the "self" type of the custom derive
 ///
 /// Returns `None` if there is no first lifetime.
@@ -145,4 +159,87 @@ fn parse_lifetime(generics: &Generics) -> Option<&Lifetime> {
         .lifetimes()
         .next()
         .map(|ref lt_ref| &lt_ref.lifetime)
+}
+
+/// Attributes of a field
+#[derive(Debug)]
+struct FieldAttrs {
+    /// Name of the field
+    pub name: Ident,
+
+    /// Value of the `#[asn1(type = "...")]` attribute if provided
+    pub asn1_type: Option<Asn1Type>,
+}
+
+impl FieldAttrs {
+    /// Parse the attributes of a field
+    fn new(field: &Field) -> Self {
+        let name = field
+            .ident
+            .as_ref()
+            .cloned()
+            .expect("no name on struct field i.e. tuple structs unsupported");
+
+        let mut asn1_type = None;
+
+        for attr in &field.attrs {
+            if !attr.path.is_ident("asn1") {
+                continue;
+            }
+
+            match attr.parse_meta().expect("error parsing `asn1` attribute") {
+                Meta::List(MetaList { nested, .. }) if nested.len() == 1 => {
+                    match nested.first() {
+                        Some(NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+                            path,
+                            lit: Lit::Str(lit_str),
+                            ..
+                        }))) => {
+                            // Parse the `type = "..."` attribute
+                            if !path.is_ident("type") {
+                                panic!("unknown `asn1` attribute for field `{}`: {:?}", name, path);
+                            }
+
+                            if asn1_type.is_some() {
+                                panic!("duplicate ASN.1 `type` attribute for field: {}", name);
+                            }
+
+                            asn1_type = Some(Asn1Type::new(&lit_str.value()));
+                        }
+                        other => panic!(
+                            "malformed `asn1` attribute for field `{}`: {:?}",
+                            name, other
+                        ),
+                    }
+                }
+                other => panic!(
+                    "malformed `asn1` attribute for field `{}`: {:?}",
+                    name, other
+                ),
+            }
+        }
+
+        Self { name, asn1_type }
+    }
+}
+
+/// ASN.1 built-in types supported by the `#[asn1(type = "...")]` attribute
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum Asn1Type {
+    /// ASN.1 `BIT STRING`
+    BitString,
+
+    /// ASN.1 `OCTET STRING`
+    OctetString,
+}
+
+impl Asn1Type {
+    /// Parse ASN.1 type
+    pub fn new(s: &str) -> Self {
+        match s {
+            "bit-string" => Self::BitString,
+            "octet-string" => Self::OctetString,
+            _ => panic!("unrecognized ASN.1 type: {}", s),
+        }
+    }
 }

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types.
 
 use crate::{Length, Tag};
-use core::fmt;
+use core::{convert::Infallible, fmt};
 
 /// Result type.
 pub type Result<T> = core::result::Result<T, Error>;
@@ -66,6 +66,19 @@ impl From<ErrorKind> for Error {
             kind,
             position: None,
         }
+    }
+}
+
+impl From<core::convert::Infallible> for Error {
+    fn from(_: Infallible) -> Error {
+        unreachable!()
+    }
+}
+
+#[cfg(feature = "oid")]
+impl From<const_oid::Error> for Error {
+    fn from(_: const_oid::Error) -> Error {
+        ErrorKind::Oid.into()
     }
 }
 
@@ -188,12 +201,5 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::Value { tag } => write!(f, "malformed ASN.1 DER value for {}", tag),
         }
-    }
-}
-
-#[cfg(feature = "oid")]
-impl From<const_oid::Error> for Error {
-    fn from(_: const_oid::Error) -> Error {
-        ErrorKind::Oid.into()
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -219,7 +219,7 @@
 //! It can be used to automatically derive the code given in the above example:
 //!
 //! ```
-//! # #[cfg(feature = "derive")]
+//! # #[cfg(all(feature = "alloc", feature = "derive", feature = "oid"))]
 //! # {
 //! use der::{Any, Encodable, Decodable, Message, ObjectIdentifier};
 //! use core::convert::TryInto;
@@ -260,6 +260,40 @@
 //! # }
 //! ```
 //!
+//! For fields which don't directly impl [`Decodable`] and [`Encodable`],
+//! you can add annotations to convert to an intermediate ASN.1 type
+//! first, so long as that type impls `TryFrom` and `Into` for the
+//! ASN.1 type.
+//!
+//! For example, structs containing `&'a [u8]` fields may want them encoded
+//! as either a `BIT STRING` or `OCTET STRING`. By using the
+//! `#[asn1(type = "bit-string")]` annotation it's possible to select which
+//! ASN.1 type should be used.
+//!
+//! Building off the above example:
+//!
+//! ```rust
+//! # #[cfg(all(feature = "alloc", feature = "derive", feature = "oid"))]
+//! # {
+//! # use der::{Any, Message, ObjectIdentifier};
+//! #
+//! # #[derive(Copy, Clone, Debug, Eq, PartialEq, Message)]
+//! # pub struct AlgorithmIdentifier<'a> {
+//! #     pub algorithm: ObjectIdentifier,
+//! #     pub parameters: Option<Any<'a>>
+//! # }
+//! /// X.509 `SubjectPublicKeyInfo` (SPKI)
+//! #[derive(Copy, Clone, Debug, Eq, PartialEq, Message)]
+//! pub struct SubjectPublicKeyInfo<'a> {
+//!     /// X.509 `AlgorithmIdentifier`
+//!     pub algorithm: AlgorithmIdentifier<'a>,
+//!
+//!     /// Public key data
+//!     #[asn1(type = "bit-string")]
+//!     pub subject_public_key: &'a [u8],
+//! }
+//! # }
+//! ```
 //!
 //! [X.690]: https://www.itu.int/rec/T-REC-X.690/
 //! [RustCrypto]: https://github.com/rustcrypto


### PR DESCRIPTION
Adds a field attribute for providing a type hint when decoding/encoding messages.

This can be used to implement intermediate conversions, e.g. in the event a field doesn't directly implement `Decodable` and `Encodable`.