### PR TITLE
der: make `sequence` module public

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -11,4 +11,4 @@ pub(crate) mod octet_string;
 #[cfg(feature = "oid")]
 pub(crate) mod oid;
 pub(crate) mod optional;
-pub(crate) mod sequence;
+pub mod sequence;

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -8,7 +8,7 @@ use core::convert::TryFrom;
 
 /// Obtain the length of an ASN.1 `SEQUENCE` of [`Encodable`] values when
 /// serialized as ASN.1 DER, including the `SEQUENCE` tag and length prefix.
-pub(crate) fn encoded_len(encodables: &[&dyn Encodable]) -> Result<Length> {
+pub fn encoded_len(encodables: &[&dyn Encodable]) -> Result<Length> {
     let inner_len = encoded_len_inner(encodables)?;
     Header::new(Tag::Sequence, inner_len)?.encoded_len() + inner_len
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -328,8 +328,12 @@ mod traits;
 
 pub use crate::{
     asn1::{
-        any::Any, bit_string::BitString, integer::RawInteger, null::Null,
-        octet_string::OctetString, sequence::Sequence,
+        any::Any,
+        bit_string::BitString,
+        integer::RawInteger,
+        null::Null,
+        octet_string::OctetString,
+        sequence::{self, Sequence},
     },
     decoder::Decoder,
     encoder::Encoder,


### PR DESCRIPTION
Provides access to `der::sequence::encoded_len`, which is helpful for lower-level use cases.