### PR TITLE
pkcs8 v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ version = "0.3.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "der",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.3 (2020-12-21)
+### Changed
+- Use `der` crate for decoding/encoding ASN.1 DER ([#153], [#180])
+
+[#153]: https://github.com/RustCrypto/utils/pull/153
+[#180]: https://github.com/RustCrypto/utils/pull/180
+
 ## 0.3.2 (2020-12-16)
 ### Added
 - `AlgorithmIdentifier::parameters_oid` method ([#148])
@@ -26,8 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Decoding/encoding support for Ed25519 keys ([#134], [#135])
 
-[#135]: https://github.com/RustCrypto/utils/pull/135
 [#134]: https://github.com/RustCrypto/utils/pull/134
+[#135]: https://github.com/RustCrypto/utils/pull/135
 
 ## 0.2.1 (2020-12-14)
 ### Added

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -43,7 +43,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/pkcs8/0.3.2"
+    html_root_url = "https://docs.rs/pkcs8/0.3.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Use `der` crate for decoding/encoding ASN.1 DER ([#153], [#180])

[#153]: https://github.com/RustCrypto/utils/pull/153
[#180]: https://github.com/RustCrypto/utils/pull/180