### PR TITLE
Rustified panic-free modification of b64ct

### DIFF
--- a/b64ct/src/errors.rs
+++ b/b64ct/src/errors.rs
@@ -1,0 +1,63 @@
+use core::fmt;
+
+/// Insufficient output buffer length.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct InvalidLengthError;
+
+impl fmt::Display for InvalidLengthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("insufficient output buffer length")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidLengthError {}
+
+/// Invalid encoding of provided "B64" string.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct InvalidEncodingError;
+
+impl fmt::Display for InvalidEncodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("insufficient output buffer length")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidEncodingError {}
+
+/// Generic error, union of [`InvalidLengthError`] and [`InvalidEncodingError`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Insufficient output buffer length.
+    InvalidEncoding,
+    /// Invalid encoding of provided "B64" string.
+    InvalidLength,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            v @ Self::InvalidEncoding => v.fmt(f),
+            v @ Self::InvalidLength => v.fmt(f),
+        }
+    }
+}
+
+impl From<InvalidEncodingError> for Error {
+    #[inline]
+    fn from(_: InvalidEncodingError) -> Error {
+        Error::InvalidEncoding
+    }
+}
+
+impl From<InvalidLengthError> for Error {
+    #[inline]
+    fn from(_: InvalidLengthError) -> Error {
+        Error::InvalidLength
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+

--- a/b64ct/src/errors.rs
+++ b/b64ct/src/errors.rs
@@ -19,7 +19,7 @@ pub struct InvalidEncodingError;
 
 impl fmt::Display for InvalidEncodingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str("insufficient output buffer length")
+        f.write_str("invalid B64 encoding")
     }
 }
 
@@ -37,10 +37,11 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            v @ Self::InvalidEncoding => v.fmt(f),
-            v @ Self::InvalidLength => v.fmt(f),
-        }
+        let s = match self {
+            Self::InvalidEncoding => "invalid B64 encoding",
+            Self::InvalidLength => "insufficient output buffer length",
+        };
+        f.write_str(s)
     }
 }
 

--- a/b64ct/src/errors.rs
+++ b/b64ct/src/errors.rs
@@ -61,4 +61,3 @@ impl From<InvalidLengthError> for Error {
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
-

--- a/b64ct/src/lib.rs
+++ b/b64ct/src/lib.rs
@@ -39,7 +39,7 @@ use alloc::{string::String, vec::Vec};
 
 mod errors;
 
-pub use errors::{Error, InvalidLengthError, InvalidEncodingError};
+pub use errors::{Error, InvalidEncodingError, InvalidLengthError};
 
 /// Encode the input byte slice as "B64", writing the result into the provided
 /// destination slice, and returning an ASCII-encoded string value.

--- a/b64ct/tests/mod.rs
+++ b/b64ct/tests/mod.rs
@@ -1,0 +1,90 @@
+use b64ct::{decode, decoded_len, encode, encoded_len, Error};
+
+/// "B64" test vector
+struct TestVector {
+    /// Raw bytes.
+    raw: &'static [u8],
+    /// "B64" encoded.
+    b64: &'static str,
+}
+
+const TEST_VECTORS: &[TestVector] = &[
+    TestVector { raw: b"", b64: "" },
+    TestVector {
+        raw: b"\0",
+        b64: "AA",
+    },
+    TestVector {
+        raw: b"***",
+        b64: "Kioq",
+    },
+    TestVector {
+        raw: b"\x01\x02\x03\x04",
+        b64: "AQIDBA",
+    },
+    TestVector {
+        raw: b"\xAD\xAD\xAD\xAD\xAD",
+        b64: "ra2tra0",
+    },
+    TestVector {
+        raw: b"\xFF\xFF\xFF\xFF\xFF",
+        b64: "//////8",
+    },
+    TestVector {
+        raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
+               \x49\x7D\x35\x29\x6B\xCC\x24\x65\xF6\xF9\xD0\x41\x08\x7B\xD7\xA9",
+        b64: "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k",
+    },
+];
+
+#[test]
+fn encode_test_vectors() {
+    let mut buf = [0u8; 1024];
+
+    for vector in TEST_VECTORS {
+        let out = encode(vector.raw, &mut buf).unwrap();
+        assert_eq!(encoded_len(vector.raw), vector.b64.len());
+        assert_eq!(vector.b64, &out[..]);
+    }
+}
+
+#[test]
+fn decode_test_vectors() {
+    let mut buf = [0u8; 1024];
+
+    for vector in TEST_VECTORS {
+        println!("{:?}", vector.raw);
+        let out = decode(vector.b64, &mut buf).unwrap();
+        assert_eq!(decoded_len(vector.b64), out.len());
+        assert_eq!(vector.raw, &out[..]);
+    }
+}
+
+#[test]
+fn encode_and_decode_various_lengths() {
+    let data = [b'X'; 64];
+    let mut inbuf = [0u8; 1024];
+    let mut outbuf = [0u8; 1024];
+
+    for i in 0..data.len() {
+        let encoded = encode(&data[..i], &mut inbuf).unwrap();
+
+        // Make sure it round trips
+        let decoded = decode(encoded, &mut outbuf).unwrap();
+        assert_eq!(decoded, &data[..i]);
+    }
+}
+
+#[test]
+fn reject_trailing_equals() {
+    let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=";
+    let mut buf = [0u8; 1024];
+    assert_eq!(decode(input, &mut buf), Err(Error::InvalidEncoding));
+}
+
+#[test]
+fn reject_trailing_whitespace() {
+    let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k\n";
+    let mut buf = [0u8; 1024];
+    assert_eq!(decode(input, &mut buf), Err(Error::InvalidEncoding));
+}


### PR DESCRIPTION
This PR adds two `unsafe` line for conversion into strings. We could remove them by using byte slices/vectors instead of strings. I am not sure how useful in practice is to have `&str`/`String` instead of `&[u8]`/`Vec<u8>`.

Panic-free property was verified in [godbolt](https://rust.godbolt.org/z/qe5Y5z).

Errors become a bit verbose, ideally it would be nice to have "anonymous enums" (i.e. `InvalidLengthError | InvalidEncodingError`), but we have to work with what we have.

One potential optimization is to modify `decode` API to:
```rust
// `buf` contains a B64-encoded string
pub fn decode<'a>(buf: &'a mut [u8]) -> Result<&'a [u8], InvalidEncodingError> { .. }
```
This way we will be able to reuse the buffer and remove the `Error` enum, but, again, I am not sure how such change would influence downstream crates.