### PR TITLE
Add decode_in_place and benchmarks to b64ct

### DIFF
--- a/b64ct/benches/mod.rs
+++ b/b64ct/benches/mod.rs
@@ -1,0 +1,58 @@
+#![feature(test)]
+extern crate test;
+use test::Bencher;
+
+const B64_LEN: usize = 100_002;
+const RAW_LEN: usize = (3*B64_LEN)/4;
+
+#[inline(never)]
+fn get_raw_data() -> Vec<u8> {
+    (0..RAW_LEN).map(|i| i as u8).collect()
+}
+
+#[inline(never)]
+fn get_b64_data() -> String {
+    (0..B64_LEN)
+        .map(|i| match (i % 64) as u8 {
+            v @ 0..=25 => (v + 'A' as u8) as char,
+            v @ 26..=51 => (v - 26 + 'a' as u8) as char,
+            v @ 52..=61 => (v - 52 + '0' as u8) as char,
+            62 => '+',
+            _ => '/',
+        })
+        .collect()
+}
+
+#[bench]
+fn decode_bench(b: &mut Bencher) {
+    let b64_data = get_b64_data();
+    let mut buf = get_raw_data();
+    b.iter(|| {
+        let out = b64ct::decode(&b64_data, &mut buf).unwrap();
+        test::black_box(out);
+    });
+    b.bytes = RAW_LEN as u64;
+}
+
+#[bench]
+fn decode_inplace_bench(b: &mut Bencher) {
+    let mut b64_data = get_b64_data().into_bytes();
+    b.iter(|| {
+        // since it works on the same buffer over and over,
+        // almost always `out` will be an error
+        let out = b64ct::decode_inplace(&mut b64_data);
+        let _ = test::black_box(out);
+    });
+    b.bytes = RAW_LEN as u64;
+}
+
+#[bench]
+fn encode_bench(b: &mut Bencher) {
+    let mut buf = get_b64_data().into_bytes();
+    let raw_data = get_raw_data();
+    b.iter(|| {
+        let out = b64ct::encode(&raw_data, &mut buf).unwrap();
+        test::black_box(out);
+    });
+    b.bytes = RAW_LEN as u64;
+}

--- a/b64ct/benches/mod.rs
+++ b/b64ct/benches/mod.rs
@@ -35,12 +35,12 @@ fn decode_bench(b: &mut Bencher) {
 }
 
 #[bench]
-fn decode_inplace_bench(b: &mut Bencher) {
+fn decode_in_place_bench(b: &mut Bencher) {
     let mut b64_data = get_b64_data().into_bytes();
     b.iter(|| {
         // since it works on the same buffer over and over,
         // almost always `out` will be an error
-        let out = b64ct::decode_inplace(&mut b64_data);
+        let out = b64ct::decode_in_place(&mut b64_data);
         let _ = test::black_box(out);
     });
     b.bytes = RAW_LEN as u64;

--- a/b64ct/benches/mod.rs
+++ b/b64ct/benches/mod.rs
@@ -3,7 +3,7 @@ extern crate test;
 use test::Bencher;
 
 const B64_LEN: usize = 100_002;
-const RAW_LEN: usize = (3*B64_LEN)/4;
+const RAW_LEN: usize = (3 * B64_LEN) / 4;
 
 #[inline(never)]
 fn get_raw_data() -> Vec<u8> {

--- a/b64ct/src/lib.rs
+++ b/b64ct/src/lib.rs
@@ -124,7 +124,7 @@ pub fn decode<'a>(src: &str, dst: &'a mut [u8]) -> Result<&'a [u8], Error> {
 }
 
 /// Decode B64-encoded string in-place.
-pub fn decode_inplace<'a>(buf: &'a mut [u8]) -> Result<&'a [u8], InvalidEncodingError> {
+pub fn decode_inplace(buf: &mut [u8]) -> Result<&[u8], InvalidEncodingError> {
     // TODO: make panic-free
     let mut err: isize = 0;
     let mut tmp_in = [0u8; 4];

--- a/b64ct/src/lib.rs
+++ b/b64ct/src/lib.rs
@@ -130,18 +130,18 @@ pub fn decode_inplace<'a>(buf: &'a mut [u8]) -> Result<&'a [u8], InvalidEncoding
     let mut tmp_in = [0u8; 4];
     let mut tmp_out = [0u8; 3];
 
-    let full_chunks = buf.len()/4;
+    let full_chunks = buf.len() / 4;
 
     for chunk in 0..full_chunks {
-        tmp_in.copy_from_slice(&buf[4*chunk..][..4]);
+        tmp_in.copy_from_slice(&buf[4 * chunk..][..4]);
         err |= decode_3bytes(&tmp_in, &mut tmp_out);
-        buf[3*chunk..][..3].copy_from_slice(&tmp_out);
+        buf[3 * chunk..][..3].copy_from_slice(&tmp_out);
     }
 
     let dlen = decoded_len_inner(buf.len());
-    let src_rem_pos = 4*full_chunks;
+    let src_rem_pos = 4 * full_chunks;
     let src_rem_len = buf.len() - src_rem_pos;
-    let dst_rem_pos = 3*full_chunks;
+    let dst_rem_pos = 3 * full_chunks;
     let dst_rem_len = dlen - dst_rem_pos;
 
     err |= !(src_rem_len == 0 || src_rem_len >= 2) as isize;

--- a/b64ct/src/lib.rs
+++ b/b64ct/src/lib.rs
@@ -124,7 +124,7 @@ pub fn decode<'a>(src: &str, dst: &'a mut [u8]) -> Result<&'a [u8], Error> {
 }
 
 /// Decode B64-encoded string in-place.
-pub fn decode_inplace(buf: &mut [u8]) -> Result<&[u8], InvalidEncodingError> {
+pub fn decode_in_place(buf: &mut [u8]) -> Result<&[u8], InvalidEncodingError> {
     // TODO: make panic-free
     let mut err: isize = 0;
     let mut tmp_in = [0u8; 4];

--- a/b64ct/tests/mod.rs
+++ b/b64ct/tests/mod.rs
@@ -1,4 +1,4 @@
-use b64ct::{decode, decode_inplace, decoded_len, encode, encoded_len, Error};
+use b64ct::{decode, decode_in_place, decoded_len, encode, encoded_len, Error};
 
 /// "B64" test vector
 struct TestVector {
@@ -59,7 +59,7 @@ fn decode_test_vectors() {
 
         let n = vector.b64.len();
         buf[..n].copy_from_slice(vector.b64.as_bytes());
-        let out = decode_inplace(&mut buf[..n]).unwrap();
+        let out = decode_in_place(&mut buf[..n]).unwrap();
         assert_eq!(vector.raw, out);
     }
 }
@@ -79,7 +79,7 @@ fn encode_and_decode_various_lengths() {
 
         let elen = encode(&data[..i], &mut inbuf).unwrap().len();
         let buf = &mut inbuf[..elen];
-        let decoded = decode_inplace(buf).unwrap();
+        let decoded = decode_in_place(buf).unwrap();
         assert_eq!(decoded, &data[..i]);
     }
 }


### PR DESCRIPTION
As discussed in #205, unfortunately, compiler is not smart enough to remove panics even if we'll guard against the potential overflow. It's possible to make it panic-free by sprinkling a number of `get_uncheked`, but I would like avoid following this route if possible. Thus this panicking version should be a good enough starting point.