### PR TITLE
der: fix doc links

### DIFF
--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -8,7 +8,7 @@ for Abstract Syntax Notation One (ASN.1) as described in ITU X.690
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
-documentation = "https://docs.rs/pkcs8"
+documentation = "https://docs.rs/der"
 repository = "https://github.com/RustCrypto/utils/tree/master/der"
 categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["asn1", "crypto", "itu", "pkcs"]

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -7,7 +7,7 @@ Procedural macro for automatically deriving the `der` crate's `Message` trait
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
-documentation = "https://docs.rs/pkcs8"
+documentation = "https://docs.rs/der"
 repository = "https://github.com/RustCrypto/utils/tree/master/der"
 categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["asn1", "der", "crypto", "itu", "pkcs"]

--- a/der/derive/README.md
+++ b/der/derive/README.md
@@ -38,9 +38,3 @@ dual licensed as above, without any additional terms or conditions.
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 [build-image]: https://github.com/RustCrypto/utils/workflows/der/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/utils/actions?query=workflow:der
-
-[//]: # (general links)
-
-[RustCrypto]: https://github.com/rustcrypto
-[`pkcs8`]: https://docs.rs/pkcs8/
-[GitHub Issue]: https://github.com/RustCrypto/utils/issues


### PR DESCRIPTION
Some were mistakenly pointed at the `pkcs8` crate