### PR TITLE
der: fix unsigned INTEGER handling; more test vectors

### DIFF
--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -11,8 +11,8 @@ impl TryFrom<Any<'_>> for i8 {
     fn try_from(any: Any<'_>) -> Result<i8> {
         let tag = any.tag().assert_eq(Tag::Integer)?;
 
-        match any.as_bytes() {
-            [x] => Ok(*x as i8),
+        match *any.as_bytes() {
+            [x] => Ok(x as i8),
             _ => Err(ErrorKind::Length { tag }.into()),
         }
     }
@@ -48,14 +48,14 @@ impl TryFrom<Any<'_>> for i16 {
     fn try_from(any: Any<'_>) -> Result<i16> {
         let tag = any.tag().assert_eq(Tag::Integer)?;
 
-        match any.as_bytes() {
+        match *any.as_bytes() {
             [_] => i8::try_from(any).map(|x| x as i16),
             [hi, lo] => {
-                if *hi == 0 {
+                if hi == 0 && lo < 0x80 {
                     // Non-canonical integer: unnecessary leading 0
                     Err(ErrorKind::Noncanonical.into())
                 } else {
-                    Ok(i16::from_be_bytes([*hi, *lo]))
+                    Ok(i16::from_be_bytes([hi, lo]))
                 }
             }
             _ => Err(ErrorKind::Length { tag }.into()),
@@ -100,66 +100,52 @@ impl Tagged for i16 {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::{Decodable, Encodable};
+
+    // Vectors from Section 5.7 of:
+    // https://luca.ntop.org/Teaching/Appunti/asn1.html
+    pub(crate) const I0_BYTES: &[u8] = &[0x02, 0x01, 0x00];
+    pub(crate) const I127_BYTES: &[u8] = &[0x02, 0x01, 0x7F];
+    pub(crate) const I128_BYTES: &[u8] = &[0x02, 0x02, 0x00, 0x80];
+    pub(crate) const I256_BYTES: &[u8] = &[0x02, 0x02, 0x01, 0x00];
+    pub(crate) const INEG128_BYTES: &[u8] = &[0x02, 0x01, 0x80];
+    pub(crate) const INEG129_BYTES: &[u8] = &[0x02, 0x02, 0xFF, 0x7F];
+
+    // Additional vectors (TODO: double check these or find better ones)
+    pub(crate) const I255_BYTES: &[u8] = &[0x02, 0x02, 0x00, 0xFF];
+    pub(crate) const I32767_BYTES: &[u8] = &[0x02, 0x02, 0x7F, 0xFF];
+    pub(crate) const INEG32768_BYTES: &[u8] = &[0x02, 0x02, 0x80, 0x00];
 
     #[test]
     fn decode_i8() {
-        // 0
-        let int = i8::from_bytes(&[0x02, 0x01, 0x00]).unwrap();
-        assert_eq!(int, 0i8);
-
-        // 127
-        let int = i8::from_bytes(&[0x02, 0x01, 0x7F]).unwrap();
-        assert_eq!(int, 127i8);
-
-        // -128
-        let int = i8::from_bytes(&[0x02, 0x01, 0x80]).unwrap();
-        assert_eq!(int, -128i8);
+        assert_eq!(0, i8::from_bytes(I0_BYTES).unwrap());
+        assert_eq!(127, i8::from_bytes(I127_BYTES).unwrap());
+        assert_eq!(-128, i8::from_bytes(INEG128_BYTES).unwrap());
     }
 
     #[test]
     fn decode_i16() {
-        // 0
-        let int = i16::from_bytes(&[0x02, 0x01, 0x00]).unwrap();
-        assert_eq!(int, 0i16);
-
-        // 127
-        let int = i16::from_bytes(&[0x02, 0x01, 0x7F]).unwrap();
-        assert_eq!(int, 127i16);
-
-        // -128
-        let int = i16::from_bytes(&[0x02, 0x01, 0x80]).unwrap();
-        assert_eq!(int, -128i16);
-
-        // 32767
-        let int = i16::from_bytes(&[0x02, 0x02, 0x7F, 0xFF]).unwrap();
-        assert_eq!(int, 32767i16);
-
-        // -32768
-        let int = i16::from_bytes(&[0x02, 0x02, 0x80, 0x00]).unwrap();
-        assert_eq!(int, -32768i16);
+        assert_eq!(0, i16::from_bytes(I0_BYTES).unwrap());
+        assert_eq!(127, i16::from_bytes(I127_BYTES).unwrap());
+        assert_eq!(128, i16::from_bytes(I128_BYTES).unwrap());
+        assert_eq!(255, i16::from_bytes(I255_BYTES).unwrap());
+        assert_eq!(256, i16::from_bytes(I256_BYTES).unwrap());
+        assert_eq!(32767, i16::from_bytes(I32767_BYTES).unwrap());
+        assert_eq!(-128, i16::from_bytes(INEG128_BYTES).unwrap());
+        assert_eq!(-129, i16::from_bytes(INEG129_BYTES).unwrap());
+        assert_eq!(-32768, i16::from_bytes(INEG32768_BYTES).unwrap());
     }
 
     #[test]
     fn encode_i8() {
         let mut buffer = [0u8; 3];
 
-        // 0
-        assert_eq!(
-            &[0x02, 0x01, 0x00],
-            0i8.encode_to_slice(&mut buffer).unwrap()
-        );
+        assert_eq!(I0_BYTES, 0i8.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I127_BYTES, 127i8.encode_to_slice(&mut buffer).unwrap());
 
-        // 127
         assert_eq!(
-            &[0x02, 0x01, 0x7F],
-            127i8.encode_to_slice(&mut buffer).unwrap()
-        );
-
-        // -128
-        assert_eq!(
-            &[0x02, 0x01, 0x80],
+            INEG128_BYTES,
             (-128i8).encode_to_slice(&mut buffer).unwrap()
         );
     }
@@ -167,34 +153,25 @@ mod tests {
     #[test]
     fn encode_i16() {
         let mut buffer = [0u8; 4];
+        assert_eq!(I0_BYTES, 0i16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I127_BYTES, 127i16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I128_BYTES, 128i16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I255_BYTES, 255i16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I256_BYTES, 256i16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I32767_BYTES, 32767i16.encode_to_slice(&mut buffer).unwrap());
 
-        // 0
         assert_eq!(
-            &[0x02, 0x01, 0x00],
-            0i16.encode_to_slice(&mut buffer).unwrap()
-        );
-
-        // 127
-        assert_eq!(
-            &[0x02, 0x01, 0x7F],
-            127i16.encode_to_slice(&mut buffer).unwrap()
-        );
-
-        // -128
-        assert_eq!(
-            &[0x02, 0x01, 0x80],
+            INEG128_BYTES,
             (-128i16).encode_to_slice(&mut buffer).unwrap()
         );
 
-        // 32767
         assert_eq!(
-            &[0x02, 0x02, 0x7F, 0xFF],
-            32767i16.encode_to_slice(&mut buffer).unwrap()
+            INEG129_BYTES,
+            (-129i16).encode_to_slice(&mut buffer).unwrap()
         );
 
-        // -32768
         assert_eq!(
-            &[0x02, 0x02, 0x80, 0x00],
+            INEG32768_BYTES,
             (-32768i16).encode_to_slice(&mut buffer).unwrap()
         );
     }


### PR DESCRIPTION
Fixes a bug in leading `0` handling for unsigned integers (needed if the second octet is >=0x80)