### PR TITLE
der: u8 and u16 support

### DIFF
--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -1,9 +1,13 @@
 //! ASN.1 `INTEGER` support.
 
-// TODO(tarcieri): add support for `i32`, `u8`, `u16`, `u32`, etc.
+// TODO(tarcieri): add support for `i32`/`u32`
 
 use crate::{Any, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
+
+//
+// i8
+//
 
 impl TryFrom<Any<'_>> for i8 {
     type Error = Error;
@@ -42,6 +46,10 @@ impl Tagged for i8 {
     const TAG: Tag = Tag::Integer;
 }
 
+//
+// i16
+//
+
 impl TryFrom<Any<'_>> for i16 {
     type Error = Error;
 
@@ -50,14 +58,8 @@ impl TryFrom<Any<'_>> for i16 {
 
         match *any.as_bytes() {
             [_] => i8::try_from(any).map(|x| x as i16),
-            [hi, lo] => {
-                if hi == 0 && lo < 0x80 {
-                    // Non-canonical integer: unnecessary leading 0
-                    Err(ErrorKind::Noncanonical.into())
-                } else {
-                    Ok(i16::from_be_bytes([hi, lo]))
-                }
-            }
+            [0, lo] if lo < 0x80 => Err(ErrorKind::Noncanonical.into()),
+            [hi, lo] => Ok(i16::from_be_bytes([hi, lo])),
             _ => Err(ErrorKind::Length { tag }.into()),
         }
     }
@@ -65,22 +67,19 @@ impl TryFrom<Any<'_>> for i16 {
 
 impl Encodable for i16 {
     fn encoded_len(&self) -> Result<Length> {
-        let inner_len = if i8::try_from(*self).is_ok() {
-            1u8
-        } else {
-            2u8
-        };
+        if let Ok(x) = i8::try_from(*self) {
+            return x.encoded_len();
+        }
 
         Header {
             tag: Tag::Integer,
-            length: inner_len.into(),
+            length: 2u8.into(),
         }
         .encoded_len()?
-            + inner_len
+            + 2u8
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        // If value is in the `i8` range, encode it as one
         if let Ok(x) = i8::try_from(*self) {
             return x.encode(encoder);
         }
@@ -99,6 +98,117 @@ impl Tagged for i16 {
     const TAG: Tag = Tag::Integer;
 }
 
+//
+// u8
+//
+
+impl TryFrom<Any<'_>> for u8 {
+    type Error = Error;
+
+    fn try_from(any: Any<'_>) -> Result<u8> {
+        let tag = any.tag().assert_eq(Tag::Integer)?;
+
+        match *any.as_bytes() {
+            [x] if x < 0x80 => Ok(x),
+            [x] if x >= 0x80 => Err(ErrorKind::Noncanonical.into()),
+            [0, x] if x < 0x80 => Err(ErrorKind::Noncanonical.into()),
+            [0, x] if x >= 0x80 => Ok(x),
+            _ => Err(ErrorKind::Length { tag }.into()),
+        }
+    }
+}
+
+impl Encodable for u8 {
+    fn encoded_len(&self) -> Result<Length> {
+        let inner_len = if *self < 0x80 { 1u8 } else { 2u8 };
+
+        Header {
+            tag: Tag::Integer,
+            length: inner_len.into(),
+        }
+        .encoded_len()?
+            + inner_len
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Header {
+            tag: Tag::Integer,
+            length: if *self < 0x80 { 1u8 } else { 2u8 }.into(),
+        }
+        .encode(encoder)?;
+
+        if *self >= 0x80 {
+            encoder.byte(0)?;
+        }
+
+        encoder.byte(*self as u8)
+    }
+}
+
+impl Tagged for u8 {
+    const TAG: Tag = Tag::Integer;
+}
+
+//
+// u16
+//
+
+impl TryFrom<Any<'_>> for u16 {
+    type Error = Error;
+
+    fn try_from(any: Any<'_>) -> Result<u16> {
+        let tag = any.tag().assert_eq(Tag::Integer)?;
+
+        match *any.as_bytes() {
+            [x] if x < 0x80 => Ok(x as u16),
+            [x] if x >= 0x80 => Err(ErrorKind::Noncanonical.into()),
+            [0, x] if x < 0x80 => Err(ErrorKind::Noncanonical.into()),
+            [hi, lo] if hi < 0x80 => Ok(u16::from_be_bytes([hi, lo])),
+            [0, hi, lo] if hi >= 0x80 => Ok(u16::from_be_bytes([hi, lo])),
+            _ => Err(ErrorKind::Length { tag }.into()),
+        }
+    }
+}
+
+impl Encodable for u16 {
+    fn encoded_len(&self) -> Result<Length> {
+        if let Ok(x) = u8::try_from(*self) {
+            return x.encoded_len();
+        }
+
+        let inner_len = if *self < 0x8000 { 2u16 } else { 3u16 };
+
+        Header {
+            tag: Tag::Integer,
+            length: inner_len.into(),
+        }
+        .encoded_len()?
+            + inner_len
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        if let Ok(x) = u8::try_from(*self) {
+            return x.encode(encoder);
+        }
+
+        Header {
+            tag: Tag::Integer,
+            length: if *self < 0x8000 { 2u16 } else { 3u16 }.into(),
+        }
+        .encode(encoder)?;
+
+        if *self >= 0x8000 {
+            encoder.byte(0)?;
+        }
+
+        encoder.bytes(&self.to_be_bytes())
+    }
+}
+
+impl Tagged for u16 {
+    const TAG: Tag = Tag::Integer;
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::{Decodable, Encodable};
@@ -112,9 +222,10 @@ pub(crate) mod tests {
     pub(crate) const INEG128_BYTES: &[u8] = &[0x02, 0x01, 0x80];
     pub(crate) const INEG129_BYTES: &[u8] = &[0x02, 0x02, 0xFF, 0x7F];
 
-    // Additional vectors (TODO: double check these or find better ones)
+    // Additional vectors
     pub(crate) const I255_BYTES: &[u8] = &[0x02, 0x02, 0x00, 0xFF];
     pub(crate) const I32767_BYTES: &[u8] = &[0x02, 0x02, 0x7F, 0xFF];
+    pub(crate) const I65535_BYTES: &[u8] = &[0x02, 0x03, 0x00, 0xFF, 0xFF];
     pub(crate) const INEG32768_BYTES: &[u8] = &[0x02, 0x02, 0x80, 0x00];
 
     #[test]
@@ -135,6 +246,23 @@ pub(crate) mod tests {
         assert_eq!(-128, i16::from_bytes(INEG128_BYTES).unwrap());
         assert_eq!(-129, i16::from_bytes(INEG129_BYTES).unwrap());
         assert_eq!(-32768, i16::from_bytes(INEG32768_BYTES).unwrap());
+    }
+
+    #[test]
+    fn decode_u8() {
+        assert_eq!(0, u8::from_bytes(I0_BYTES).unwrap());
+        assert_eq!(127, u8::from_bytes(I127_BYTES).unwrap());
+        assert_eq!(255, u8::from_bytes(I255_BYTES).unwrap());
+    }
+
+    #[test]
+    fn decode_u16() {
+        assert_eq!(0, u16::from_bytes(I0_BYTES).unwrap());
+        assert_eq!(127, u16::from_bytes(I127_BYTES).unwrap());
+        assert_eq!(255, u16::from_bytes(I255_BYTES).unwrap());
+        assert_eq!(256, u16::from_bytes(I256_BYTES).unwrap());
+        assert_eq!(32767, u16::from_bytes(I32767_BYTES).unwrap());
+        assert_eq!(65535, u16::from_bytes(I65535_BYTES).unwrap());
     }
 
     #[test]
@@ -176,10 +304,32 @@ pub(crate) mod tests {
         );
     }
 
+    #[test]
+    fn encode_u8() {
+        let mut buffer = [0u8; 4];
+        assert_eq!(I0_BYTES, 0u8.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I127_BYTES, 127u8.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I255_BYTES, 255u8.encode_to_slice(&mut buffer).unwrap());
+    }
+
+    #[test]
+    fn encode_u16() {
+        let mut buffer = [0u8; 5];
+        assert_eq!(I0_BYTES, 0u16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I127_BYTES, 127u16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I128_BYTES, 128u16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I255_BYTES, 255u16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I256_BYTES, 256u16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I32767_BYTES, 32767u16.encode_to_slice(&mut buffer).unwrap());
+        assert_eq!(I65535_BYTES, 65535u16.encode_to_slice(&mut buffer).unwrap());
+    }
+
     /// Integers must be encoded with a minimum number of octets
     #[test]
     fn reject_non_canonical() {
         assert!(i8::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
         assert!(i16::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
+        assert!(u8::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
+        assert!(u16::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -32,7 +32,7 @@
 //! The traits are impl'd for the following Rust core types:
 //!
 //! - [`bool`] (ASN.1 `BOOLEAN`)
-//! - [`i8`], [`i16`] (ASN.1 `INTEGER`)
+//! - [`i8`], [`i16`], [`u8`], [`u16`] (ASN.1 `INTEGER`)
 //! - [`Option`] (ASN.1 `OPTIONAL`)
 //!
 //! The following ASN.1 types provided by this crate also impl these traits:

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -14,7 +14,7 @@ use {
 use {crate::pem, zeroize::Zeroizing};
 
 /// RFC 5208 designates `0` as the only valid version for PKCS#8 documents
-const VERSION: i8 = 0;
+const VERSION: u8 = 0;
 
 /// PKCS#8 `PrivateKeyInfo`
 ///
@@ -94,7 +94,7 @@ impl<'a> TryFrom<der::Any<'a>> for PrivateKeyInfo<'a> {
     fn try_from(any: der::Any<'a>) -> der::Result<PrivateKeyInfo<'a>> {
         any.sequence(|decoder| {
             // Parse and validate `version` INTEGER.
-            if i8::decode(decoder)? != VERSION {
+            if u8::decode(decoder)? != VERSION {
                 return Err(der::ErrorKind::Value {
                     tag: der::Tag::Integer,
                 }


### PR DESCRIPTION
Support for encoding/decoding unsigned ASN.1 INTEGER values to/from these Rust primitive types.