### PR TITLE
b64ct v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "b64ct"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "blobby"

--- a/b64ct/CHANGELOG.md
+++ b/b64ct/CHANGELOG.md
@@ -4,5 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-01-19)
+### Added
+- `decode_in_place` method ([#206])
+
+### Changed
+- Panic-free operation ([#204], [#209])
+
+### Fixed
+- Overflow bug ([#212])
+
+[#204]: https://github.com/RustCrypto/utils/pull/204
+[#206]: https://github.com/RustCrypto/utils/pull/206
+[#209]: https://github.com/RustCrypto/utils/pull/209
+[#212]: https://github.com/RustCrypto/utils/pull/212
+
 ## 0.1.0 (2021-01-12)
 - Initial release

--- a/b64ct/Cargo.toml
+++ b/b64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b64ct"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of B64, a subset of the standard Base64 encoding
 (RFC 4648) used by the PHC string format. Implemented without data-dependent

--- a/b64ct/src/lib.rs
+++ b/b64ct/src/lib.rs
@@ -68,7 +68,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/b64ct/0.1.0"
+    html_root_url = "https://docs.rs/b64ct/0.2.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["crypto", "key", "private"]
 readme = "README.md"
 
 [dependencies]
-b64ct = { version = "0.1", optional = true, features = ["alloc"], path = "../b64ct" }
+b64ct = { version = "0.2", optional = true, features = ["alloc"], path = "../b64ct" }
 der = { version = "=0.2.0-pre", features = ["oid"], path = "../der" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
### Added
- `decode_in_place` method ([#206])

### Changed
- Panic-free operation ([#204], [#209])

### Fixed
- Overflow bug ([#212])

[#204]: https://github.com/RustCrypto/utils/pull/204
[#206]: https://github.com/RustCrypto/utils/pull/206
[#209]: https://github.com/RustCrypto/utils/pull/209
[#212]: https://github.com/RustCrypto/utils/pull/212