### PR TITLE
der v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,5 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-01-22)
+### Added
+- `BigUInt` type ([#196])
+- `i16` support ([#199])
+- `u8` and `u16` support ([#210])
+- Integer decoder helper methods ([#219])
+
+### Fixed
+- Handle leading byte of `BIT STRING`s ([#193])
+
+[#193]: https://github.com/RustCrypto/utils/pull/193
+[#196]: https://github.com/RustCrypto/utils/pull/196
+[#199]: https://github.com/RustCrypto/utils/pull/199
+[#210]: https://github.com/RustCrypto/utils/pull/210
+[#219]: https://github.com/RustCrypto/utils/pull/219
+
 ## 0.1.0 (2020-12-21)
 - Initial release

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -306,7 +306,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.2.0-pre"
+    html_root_url = "https://docs.rs/der/0.2.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 base64ct = { version = "0", optional = true, features = ["alloc"], path = "../base64ct" }
-der = { version = "=0.2.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.2", features = ["oid"], path = "../der" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added
- `BigUInt` type ([#196])
- `i16` support ([#199])
- `u8` and `u16` support ([#210])
- Integer decoder helper methods ([#219])

### Fixed
- Handle leading byte of `BIT STRING`s ([#193])

[#193]: https://github.com/RustCrypto/utils/pull/193
[#196]: https://github.com/RustCrypto/utils/pull/196
[#199]: https://github.com/RustCrypto/utils/pull/199
[#210]: https://github.com/RustCrypto/utils/pull/210
[#219]: https://github.com/RustCrypto/utils/pull/219