### PR TITLE
base64ct: unify padded and unpadded decoding

### DIFF
--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -3,7 +3,7 @@ name: pkcs8
 on:
   pull_request:
     paths:
-      - "b64ct/**"
+      - "base64ct/**"
       - "const-oid/**"
       - "der/**"
       - "pkcs8/**"

--- a/base64ct/src/errors.rs
+++ b/base64ct/src/errors.rs
@@ -15,29 +15,17 @@ impl fmt::Display for InvalidLengthError {
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidLengthError {}
 
-/// Invalid encoding of provided "B64" string.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct InvalidEncodingError;
-
-impl fmt::Display for InvalidEncodingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str("invalid B64 encoding")
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidEncodingError {}
-
 /// Generic error, union of [`InvalidLengthError`] and [`InvalidEncodingError`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Error {
+pub enum DecodeError {
     /// Insufficient output buffer length.
     InvalidEncoding,
+
     /// Invalid encoding of provided "B64" string.
     InvalidLength,
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let s = match self {
             Self::InvalidEncoding => "invalid B64 encoding",
@@ -47,19 +35,12 @@ impl fmt::Display for Error {
     }
 }
 
-impl From<InvalidEncodingError> for Error {
+impl From<InvalidLengthError> for DecodeError {
     #[inline]
-    fn from(_: InvalidEncodingError) -> Error {
-        Error::InvalidEncoding
-    }
-}
-
-impl From<InvalidLengthError> for Error {
-    #[inline]
-    fn from(_: InvalidLengthError) -> Error {
-        Error::InvalidLength
+    fn from(_: InvalidLengthError) -> DecodeError {
+        DecodeError::InvalidLength
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl std::error::Error for DecodeError {}

--- a/base64ct/src/errors.rs
+++ b/base64ct/src/errors.rs
@@ -15,9 +15,22 @@ impl fmt::Display for InvalidLengthError {
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidLengthError {}
 
+/// Invalid encoding of provided "B64" string.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct InvalidEncodingError;
+
+impl fmt::Display for InvalidEncodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("invalid B64 encoding")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidEncodingError {}
+
 /// Generic error, union of [`InvalidLengthError`] and [`InvalidEncodingError`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum DecodeError {
+pub enum Error {
     /// Insufficient output buffer length.
     InvalidEncoding,
 
@@ -25,7 +38,7 @@ pub enum DecodeError {
     InvalidLength,
 }
 
-impl fmt::Display for DecodeError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let s = match self {
             Self::InvalidEncoding => "invalid B64 encoding",
@@ -35,12 +48,19 @@ impl fmt::Display for DecodeError {
     }
 }
 
-impl From<InvalidLengthError> for DecodeError {
+impl From<InvalidEncodingError> for Error {
     #[inline]
-    fn from(_: InvalidLengthError) -> DecodeError {
-        DecodeError::InvalidLength
+    fn from(_: InvalidEncodingError) -> Error {
+        Error::InvalidEncoding
+    }
+}
+
+impl From<InvalidLengthError> for Error {
+    #[inline]
+    fn from(_: InvalidLengthError) -> Error {
+        Error::InvalidLength
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for DecodeError {}
+impl std::error::Error for Error {}

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -398,13 +398,7 @@ fn unpadded_len_ct(input: &[u8]) -> usize {
 /// encoding-related errors prior to branching.
 fn validate_padding(input: &[u8]) -> Result<i16, DecodeError> {
     if input.len() % 4 != 0 {
-        match input.last().cloned() {
-            // TODO(tarcieri): constant-time whitespace check
-            Some(byte) if char::from(byte).is_whitespace() => {
-                return Err(DecodeError::InvalidEncoding)
-            }
-            _ => return Err(DecodeError::InvalidLength),
-        }
+        return Err(DecodeError::InvalidEncoding);
     }
 
     let padding_len = input.len() - unpadded_len_ct(input);

--- a/base64ct/tests/lib.rs
+++ b/base64ct/tests/lib.rs
@@ -1,6 +1,6 @@
 //! Base64 tests
 
-use base64ct::{decode, decode_in_place, encode, encoded_len, DecodeError};
+use base64ct::{decode, decode_in_place, encode, encoded_len, Error};
 
 #[cfg(feature = "alloc")]
 use base64ct::{decode_vec, encode_string};
@@ -143,10 +143,7 @@ fn encode_and_decode_various_lengths() {
 fn unpadded_reject_trailing_equals() {
     let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=";
     let mut buf = [0u8; 1024];
-    assert_eq!(
-        decode(input, &mut buf, false),
-        Err(DecodeError::InvalidEncoding)
-    );
+    assert_eq!(decode(input, &mut buf, false), Err(Error::InvalidEncoding));
 }
 
 #[test]
@@ -154,9 +151,6 @@ fn reject_trailing_whitespace() {
     for &padded in &[false, true] {
         let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k\n";
         let mut buf = [0u8; 1024];
-        assert_eq!(
-            decode(input, &mut buf, padded),
-            Err(DecodeError::InvalidEncoding)
-        );
+        assert_eq!(decode(input, &mut buf, padded), Err(Error::InvalidEncoding));
     }
 }

--- a/base64ct/tests/lib.rs
+++ b/base64ct/tests/lib.rs
@@ -1,6 +1,6 @@
 //! Base64 tests
 
-use base64ct::{decode, decode_in_place, decoded_len, encode, encoded_len, Error};
+use base64ct::{decode, decode_in_place, encode, encoded_len, DecodeError};
 
 #[cfg(feature = "alloc")]
 use base64ct::{decode_vec, encode_string};
@@ -94,7 +94,6 @@ fn decode_test_vectors() {
     for &(vectors, padded) in &[(PADDED_TEST_VECTORS, true), (UNPADDED_TEST_VECTORS, false)] {
         for vector in vectors {
             let out = decode(vector.b64, &mut buf, padded).unwrap();
-            assert_eq!(decoded_len(vector.b64, padded), out.len());
             assert_eq!(vector.raw, &out[..]);
 
             let n = vector.b64.len();
@@ -144,7 +143,10 @@ fn encode_and_decode_various_lengths() {
 fn unpadded_reject_trailing_equals() {
     let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=";
     let mut buf = [0u8; 1024];
-    assert_eq!(decode(input, &mut buf, false), Err(Error::InvalidEncoding));
+    assert_eq!(
+        decode(input, &mut buf, false),
+        Err(DecodeError::InvalidEncoding)
+    );
 }
 
 #[test]
@@ -152,6 +154,9 @@ fn reject_trailing_whitespace() {
     for &padded in &[false, true] {
         let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k\n";
         let mut buf = [0u8; 1024];
-        assert_eq!(decode(input, &mut buf, padded), Err(Error::InvalidEncoding));
+        assert_eq!(
+            decode(input, &mut buf, padded),
+            Err(DecodeError::InvalidEncoding)
+        );
     }
 }

--- a/pkcs8/src/pem.rs
+++ b/pkcs8/src/pem.rs
@@ -48,12 +48,12 @@ pub(crate) fn decode(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> 
 
     let mut s = Zeroizing::new(s.to_owned());
 
-    // TODO(tarcieri): less lenient, constant-time implementation
-    s.retain(|c| c != '=' && !c.is_whitespace());
+    // TODO(tarcieri): stricter constant-time whitespace trimming
+    s.retain(|c| !c.is_whitespace());
 
     base64::decode_vec(&*s, true)
-        .map_err(|_| Error::Decode)
         .map(Zeroizing::new)
+        .map_err(|_| Error::Decode)
 }
 
 /// Serialize "PEM encoding" as described in RFC 7468:


### PR DESCRIPTION
Removes padding prior to decoding, allowing the unpadded decoding path to be the "one true way" to handle all decoding.

Validates padding bytes in constant-time, returning an error flag to be OR'd into the other potential encoding errors and branched upon only after fully decoding/validating all other data.