### PR TITLE
base64ct: Base64url encoding support

### DIFF
--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -47,6 +47,4 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
-[B64]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#b64
 [RFC 4648]: https://tools.ietf.org/html/rfc4648
-[PHC string format]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md

--- a/base64ct/src/errors.rs
+++ b/base64ct/src/errors.rs
@@ -2,26 +2,29 @@
 
 use core::fmt;
 
+const INVALID_ENCODING_MSG: &str = "invalid Base64 encoding";
+const INVALID_LENGTH_MSG: &str = "insufficient output buffer length";
+
 /// Insufficient output buffer length.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct InvalidLengthError;
 
 impl fmt::Display for InvalidLengthError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str("insufficient output buffer length")
+        f.write_str(INVALID_LENGTH_MSG)
     }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidLengthError {}
 
-/// Invalid encoding of provided "B64" string.
+/// Invalid encoding of provided Base64 string.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct InvalidEncodingError;
 
 impl fmt::Display for InvalidEncodingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str("invalid B64 encoding")
+        f.write_str(INVALID_ENCODING_MSG)
     }
 }
 
@@ -31,18 +34,18 @@ impl std::error::Error for InvalidEncodingError {}
 /// Generic error, union of [`InvalidLengthError`] and [`InvalidEncodingError`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
-    /// Insufficient output buffer length.
+    /// Invalid encoding of provided Base64 string.
     InvalidEncoding,
 
-    /// Invalid encoding of provided "B64" string.
+    /// Insufficient output buffer length.
     InvalidLength,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let s = match self {
-            Self::InvalidEncoding => "invalid B64 encoding",
-            Self::InvalidLength => "insufficient output buffer length",
+            Self::InvalidEncoding => INVALID_ENCODING_MSG,
+            Self::InvalidLength => INVALID_LENGTH_MSG,
         };
         f.write_str(s)
     }

--- a/base64ct/tests/lib.rs
+++ b/base64ct/tests/lib.rs
@@ -1,156 +1,290 @@
 //! Base64 tests
 
-use base64ct::{decode, decode_in_place, encode, encoded_len, Error};
+/// Generate test suite for a particular Base64 flavor
+macro_rules! impl_tests {
+    () => {
+        use crate::TestVector;
+        use base64ct::Error;
 
-#[cfg(feature = "alloc")]
-use base64ct::{decode_vec, encode_string};
+        #[test]
+        fn encode_test_vectors() {
+            let mut buf = [0u8; 1024];
+
+            for vector in TEST_VECTORS {
+                let out = encode(vector.raw, &mut buf).unwrap();
+                assert_eq!(encoded_len(vector.raw), vector.b64.len());
+                assert_eq!(vector.b64, &out[..]);
+
+                #[cfg(feature = "alloc")]
+                {
+                    let out = encode_string(vector.raw);
+                    assert_eq!(vector.b64, &out[..]);
+                }
+            }
+        }
+
+        #[test]
+        fn decode_test_vectors() {
+            let mut buf = [0u8; 1024];
+
+            for vector in TEST_VECTORS {
+                let out = decode(vector.b64, &mut buf).unwrap();
+                assert_eq!(vector.raw, &out[..]);
+
+                let n = vector.b64.len();
+                buf[..n].copy_from_slice(vector.b64.as_bytes());
+                let out = decode_in_place(&mut buf[..n]).unwrap();
+                assert_eq!(vector.raw, out);
+
+                #[cfg(feature = "alloc")]
+                {
+                    let out = decode_vec(vector.b64).unwrap();
+                    assert_eq!(vector.raw, &out[..]);
+                }
+            }
+        }
+
+        #[test]
+        fn encode_and_decode_various_lengths() {
+            let data = [b'X'; 64];
+            let mut inbuf = [0u8; 1024];
+            let mut outbuf = [0u8; 1024];
+
+            for i in 0..data.len() {
+                let encoded = encode(&data[..i], &mut inbuf).unwrap();
+
+                // Make sure it round trips
+                let decoded = decode(encoded, &mut outbuf).unwrap();
+                assert_eq!(decoded, &data[..i]);
+
+                let elen = encode(&data[..i], &mut inbuf).unwrap().len();
+                let buf = &mut inbuf[..elen];
+                let decoded = decode_in_place(buf).unwrap();
+                assert_eq!(decoded, &data[..i]);
+
+                #[cfg(feature = "alloc")]
+                {
+                    let encoded = encode_string(&data[..i]);
+                    let decoded = decode_vec(&encoded).unwrap();
+                    assert_eq!(decoded, &data[..i]);
+                }
+            }
+        }
+
+        #[test]
+        fn reject_trailing_whitespace() {
+            let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k\n";
+            let mut buf = [0u8; 1024];
+            assert_eq!(decode(input, &mut buf), Err(Error::InvalidEncoding));
+        }
+    };
+}
 
 struct TestVector {
     raw: &'static [u8],
     b64: &'static str,
 }
 
-const PADDED_TEST_VECTORS: &[TestVector] = &[
-    TestVector { raw: b"", b64: "" },
-    TestVector {
-        raw: b"\0",
-        b64: "AA==",
-    },
-    TestVector {
-        raw: b"***",
-        b64: "Kioq",
-    },
-    TestVector {
-        raw: b"\x01\x02\x03\x04",
-        b64: "AQIDBA==",
-    },
-    TestVector {
-        raw: b"\xAD\xAD\xAD\xAD\xAD",
-        b64: "ra2tra0=",
-    },
-    TestVector {
-        raw: b"\xFF\xFF\xFF\xFF\xFF",
-        b64: "//////8=",
-    },
-    TestVector {
-        raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
-                   \x49\x7D\x35\x29\x6B\xCC\x24\x65\xF6\xF9\xD0\x41\x08\x7B\xD7\xA9",
-        b64: "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=",
-    },
-];
+/// Standard Base64 tests
+mod base64 {
+    /// Standard Base64 with `=` padding
+    mod padded {
+        use base64ct::padded::*;
 
-const UNPADDED_TEST_VECTORS: &[TestVector] = &[
-    TestVector { raw: b"", b64: "" },
-    TestVector {
-        raw: b"\0",
-        b64: "AA",
-    },
-    TestVector {
-        raw: b"***",
-        b64: "Kioq",
-    },
-    TestVector {
-        raw: b"\x01\x02\x03\x04",
-        b64: "AQIDBA",
-    },
-    TestVector {
-        raw: b"\xAD\xAD\xAD\xAD\xAD",
-        b64: "ra2tra0",
-    },
-    TestVector {
-        raw: b"\xFF\xFF\xFF\xFF\xFF",
-        b64: "//////8",
-    },
-    TestVector {
-        raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
+        const TEST_VECTORS: &[TestVector] = &[
+            TestVector { raw: b"", b64: "" },
+            TestVector {
+                raw: b"\0",
+                b64: "AA==",
+            },
+            TestVector {
+                raw: b"***",
+                b64: "Kioq",
+            },
+            TestVector {
+                raw: b"\x01\x02\x03\x04",
+                b64: "AQIDBA==",
+            },
+            TestVector {
+                raw: b"\xAD\xAD\xAD\xAD\xAD",
+                b64: "ra2tra0=",
+            },
+            TestVector {
+                raw: b"\xFF\xEF\xFE\xFF\xEF\xFE",
+                b64: "/+/+/+/+",
+            },
+            TestVector {
+                raw: b"\xFF\xFF\xFF\xFF\xFF",
+                b64: "//////8=",
+            },
+            TestVector {
+                raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
+                           \x49\x7D\x35\x29\x6B\xCC\x24\x65\xF6\xF9\xD0\x41\x08\x7B\xD7\xA9",
+                b64: "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=",
+            },
+            TestVector {
+                raw: b"\x00\x10\x83\x10Q\x87 \x92\x8B0\xD3\x8FA\x14\x93QU\x97a\x96\x9Bq\
+                       \xD7\x9F\x82\x18\xA3\x92Y\xA7\xA2\x9A\xAB\xB2\xDB\xAF\xC3\x1C\xB3\
+                       \xFB\xF0\x00",
+                b64: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/AA",
+            },
+        ];
+
+        impl_tests!();
+    }
+
+    /// Standard Base64 *without* padding
+    mod unpadded {
+        use base64ct::unpadded::*;
+
+        const TEST_VECTORS: &[TestVector] = &[
+            TestVector { raw: b"", b64: "" },
+            TestVector {
+                raw: b"\0",
+                b64: "AA",
+            },
+            TestVector {
+                raw: b"***",
+                b64: "Kioq",
+            },
+            TestVector {
+                raw: b"\x01\x02\x03\x04",
+                b64: "AQIDBA",
+            },
+            TestVector {
+                raw: b"\xAD\xAD\xAD\xAD\xAD",
+                b64: "ra2tra0",
+            },
+            TestVector {
+                raw: b"\xFF\xEF\xFE\xFF\xEF\xFE",
+                b64: "/+/+/+/+",
+            },
+            TestVector {
+                raw: b"\xFF\xFF\xFF\xFF\xFF",
+                b64: "//////8",
+            },
+            TestVector {
+                raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
+                       \x49\x7D\x35\x29\x6B\xCC\x24\x65\xF6\xF9\xD0\x41\x08\x7B\xD7\xA9",
+                b64: "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k",
+            },
+            TestVector {
+                raw: b"\x00\x10\x83\x10Q\x87 \x92\x8B0\xD3\x8FA\x14\x93QU\x97a\x96\x9Bq\
+                       \xD7\x9F\x82\x18\xA3\x92Y\xA7\xA2\x9A\xAB\xB2\xDB\xAF\xC3\x1C\xB3\
+                       \xFB\xF0\x00",
+                b64: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/AA",
+            },
+        ];
+
+        #[test]
+        fn unpadded_reject_trailing_equals() {
+            let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=";
+            let mut buf = [0u8; 1024];
+            assert_eq!(decode(input, &mut buf), Err(Error::InvalidEncoding));
+        }
+
+        impl_tests!();
+    }
+}
+
+/// URL-safe Base64 tests
+mod base64url {
+    /// URL-safe Base64 with `=` padding
+    mod padded {
+        use base64ct::url::padded::*;
+
+        const TEST_VECTORS: &[TestVector] = &[
+            TestVector { raw: b"", b64: "" },
+            TestVector {
+                raw: b"\0",
+                b64: "AA==",
+            },
+            TestVector {
+                raw: b"***",
+                b64: "Kioq",
+            },
+            TestVector {
+                raw: b"\x01\x02\x03\x04",
+                b64: "AQIDBA==",
+            },
+            TestVector {
+                raw: b"\xAD\xAD\xAD\xAD\xAD",
+                b64: "ra2tra0=",
+            },
+            TestVector {
+                raw: b"\xFF\xEF\xFE\xFF\xEF\xFE",
+                b64: "_-_-_-_-",
+            },
+            TestVector {
+                raw: b"\xFF\xFF\xFF\xFF\xFF",
+                b64: "______8=",
+            },
+            TestVector {
+                raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
+                           \x49\x7D\x35\x29\x6B\xCC\x24\x65\xF6\xF9\xD0\x41\x08\x7B\xD7\xA9",
+                b64: "QME_vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=",
+            },
+            TestVector {
+                raw: b"\x00\x10\x83\x10Q\x87 \x92\x8B0\xD3\x8FA\x14\x93QU\x97a\x96\x9Bq\
+                       \xD7\x9F\x82\x18\xA3\x92Y\xA7\xA2\x9A\xAB\xB2\xDB\xAF\xC3\x1C\xB3\
+                       \xFB\xF0\x00",
+                b64: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_AA",
+            },
+        ];
+
+        impl_tests!();
+    }
+
+    /// URL-safe Base64 *without* padding
+    mod unpadded {
+        use base64ct::url::unpadded::*;
+
+        const TEST_VECTORS: &[TestVector] = &[
+            TestVector { raw: b"", b64: "" },
+            TestVector {
+                raw: b"\0",
+                b64: "AA",
+            },
+            TestVector {
+                raw: b"***",
+                b64: "Kioq",
+            },
+            TestVector {
+                raw: b"\x01\x02\x03\x04",
+                b64: "AQIDBA",
+            },
+            TestVector {
+                raw: b"\xAD\xAD\xAD\xAD\xAD",
+                b64: "ra2tra0",
+            },
+            TestVector {
+                raw: b"\xFF\xEF\xFE\xFF\xEF\xFE",
+                b64: "_-_-_-_-",
+            },
+            TestVector {
+                raw: b"\xFF\xFF\xFF\xFF\xFF",
+                b64: "______8",
+            },
+            TestVector {
+                raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
                \x49\x7D\x35\x29\x6B\xCC\x24\x65\xF6\xF9\xD0\x41\x08\x7B\xD7\xA9",
-        b64: "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k",
-    },
-];
+                b64: "QME_vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k",
+            },
+            TestVector {
+                raw: b"\x00\x10\x83\x10Q\x87 \x92\x8B0\xD3\x8FA\x14\x93QU\x97a\x96\x9Bq\
+               \xD7\x9F\x82\x18\xA3\x92Y\xA7\xA2\x9A\xAB\xB2\xDB\xAF\xC3\x1C\xB3\
+               \xFB\xF0\x00",
+                b64: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_AA",
+            },
+        ];
 
-#[test]
-fn encode_test_vectors() {
-    let mut buf = [0u8; 1024];
+        impl_tests!();
 
-    for &(vectors, padded) in &[(PADDED_TEST_VECTORS, true), (UNPADDED_TEST_VECTORS, false)] {
-        for vector in vectors {
-            let out = encode(vector.raw, &mut buf, padded).unwrap();
-            assert_eq!(encoded_len(vector.raw, padded), vector.b64.len());
-            assert_eq!(vector.b64, &out[..]);
-
-            #[cfg(feature = "alloc")]
-            {
-                let out = encode_string(vector.raw, padded);
-                assert_eq!(vector.b64, &out[..]);
-            }
+        #[test]
+        fn unpadded_reject_trailing_equals() {
+            let input = "QME_vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=";
+            let mut buf = [0u8; 1024];
+            assert_eq!(decode(input, &mut buf), Err(Error::InvalidEncoding));
         }
-    }
-}
-
-#[test]
-fn decode_test_vectors() {
-    let mut buf = [0u8; 1024];
-
-    for &(vectors, padded) in &[(PADDED_TEST_VECTORS, true), (UNPADDED_TEST_VECTORS, false)] {
-        for vector in vectors {
-            let out = decode(vector.b64, &mut buf, padded).unwrap();
-            assert_eq!(vector.raw, &out[..]);
-
-            let n = vector.b64.len();
-            buf[..n].copy_from_slice(vector.b64.as_bytes());
-            let out = decode_in_place(&mut buf[..n], padded).unwrap();
-            assert_eq!(vector.raw, out);
-
-            #[cfg(feature = "alloc")]
-            {
-                let out = decode_vec(vector.b64, padded).unwrap();
-                assert_eq!(vector.raw, &out[..]);
-            }
-        }
-    }
-}
-
-#[test]
-fn encode_and_decode_various_lengths() {
-    let data = [b'X'; 64];
-    let mut inbuf = [0u8; 1024];
-    let mut outbuf = [0u8; 1024];
-
-    for &padded in &[false, true] {
-        for i in 0..data.len() {
-            let encoded = encode(&data[..i], &mut inbuf, padded).unwrap();
-
-            // Make sure it round trips
-            let decoded = decode(encoded, &mut outbuf, padded).unwrap();
-            assert_eq!(decoded, &data[..i]);
-
-            let elen = encode(&data[..i], &mut inbuf, padded).unwrap().len();
-            let buf = &mut inbuf[..elen];
-            let decoded = decode_in_place(buf, padded).unwrap();
-            assert_eq!(decoded, &data[..i]);
-
-            #[cfg(feature = "alloc")]
-            {
-                let encoded = encode_string(&data[..i], padded);
-                let decoded = decode_vec(&encoded, padded).unwrap();
-                assert_eq!(decoded, &data[..i]);
-            }
-        }
-    }
-}
-
-#[test]
-fn unpadded_reject_trailing_equals() {
-    let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k=";
-    let mut buf = [0u8; 1024];
-    assert_eq!(decode(input, &mut buf, false), Err(Error::InvalidEncoding));
-}
-
-#[test]
-fn reject_trailing_whitespace() {
-    for &padded in &[false, true] {
-        let input = "QME/vQVMciqjwvIRc8Bp6kl9NSlrzCRl9vnQQQh716k\n";
-        let mut buf = [0u8; 1024];
-        assert_eq!(decode(input, &mut buf, padded), Err(Error::InvalidEncoding));
     }
 }

--- a/pkcs8/src/pem.rs
+++ b/pkcs8/src/pem.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use alloc::{borrow::ToOwned, string::String, vec::Vec};
-use base64ct as base64;
+use base64ct::padded as base64;
 use core::str;
 use zeroize::Zeroizing;
 
@@ -51,7 +51,7 @@ pub(crate) fn decode(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> 
     // TODO(tarcieri): stricter constant-time whitespace trimming
     s.retain(|c| !c.is_whitespace());
 
-    base64::decode_vec(&*s, true)
+    base64::decode_vec(&*s)
         .map(Zeroizing::new)
         .map_err(|_| Error::Decode)
 }
@@ -62,7 +62,7 @@ pub(crate) fn encode(data: &[u8], boundary: Boundary) -> String {
     let mut output = String::new();
     output.push_str(boundary.pre);
 
-    let b64 = Zeroizing::new(base64::encode_string(data, true));
+    let b64 = Zeroizing::new(base64::encode_string(data));
     let chunks = b64.as_bytes().chunks(CHUNK_SIZE);
     let nchunks = chunks.len();
 


### PR DESCRIPTION
Adds support for Base64url: a URL-safe variant of the standard Base64 encoding.

Uses `-` and `_` for encoding Base64 values 62/63, as opposed to the standard `+` and `/`.