### PR TITLE
pkcs8 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "0.3.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-01-26)
+### Changed
+- Bump `der` crate dependency to v0.2 ([#224])
+- Use `base64ct` v0.1 for PEM encoding ([#232])
+
+[#224]: https://github.com/RustCrypto/utils/pull/224
+[#232]: https://github.com/RustCrypto/utils/pull/232
+
 ## 0.3.3 (2020-12-21)
 ### Changed
 - Use `der` crate for decoding/encoding ASN.1 DER ([#153], [#180])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.4.0-pre"
+    html_root_url = "https://docs.rs/pkcs8/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Bump `der` crate dependency to v0.2 ([#224])
- Use `base64ct` v0.1 for PEM encoding ([#232])

[#224]: https://github.com/RustCrypto/utils/pull/224
[#232]: https://github.com/RustCrypto/utils/pull/232