### PR TITLE
base64ct: minor code improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "base64ct"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "blobby"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,5 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2021-01-27)
+- Minor code improvements ([#234])
+
+[#234]: https://github.com/RustCrypto/utils/pull/234
+
 ## 0.1.0 (2021-01-26)
 - Initial release

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation Base64 (RFC 4648) implemented without data-dependent
 branches/LUTs thereby providing portable "best effort" constant-time operation

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -397,7 +397,7 @@ fn encode<'a>(
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline(always)]
 fn encode_string(input: &[u8], padded: bool, hi_bytes: (u8, u8)) -> String {
-    let elen = encoded_len(input, padded);
+    let elen = encoded_len_inner(input.len(), padded).expect("input is too big");
     let mut dst = vec![0u8; elen];
     let res = encode(input, &mut dst, padded, hi_bytes).expect("encoding error");
 


### PR DESCRIPTION
Improves the `encode` function by improving code reuse and removing an unreachable panic in the padded path. Also marks all inner functions with `#[inline(always)]` to remove call indirection. Most often crates will use only one module, so I think such inlining is warranted.