### PR TITLE
base64ct v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "base64ct"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "blobby"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2021-01-31)
+### Added
+- bcrypt encoding ([#237])
+- `crypt(3)` encoding ([#239])
+
+### Changed
+- Internal refactoring ([#235], [#236])
+
+[#235]: https://github.com/RustCrypto/utils/pull/235
+[#236]: https://github.com/RustCrypto/utils/pull/236
+[#237]: https://github.com/RustCrypto/utils/pull/237
+[#239]: https://github.com/RustCrypto/utils/pull/239
+
 ## 0.1.1 (2021-01-27)
 - Minor code improvements ([#234])
 

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation Base64 (RFC 4648) implemented without data-dependent
 branches/LUTs thereby providing portable "best effort" constant-time operation

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -76,7 +76,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/0.1.1"
+    html_root_url = "https://docs.rs/base64ct/0.1.2"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
### Added
- bcrypt encoding ([#237])
- `crypt(3)` encoding ([#239])

### Changed
- Internal refactoring ([#235], [#236])

[#235]: https://github.com/RustCrypto/utils/pull/235
[#236]: https://github.com/RustCrypto/utils/pull/236
[#237]: https://github.com/RustCrypto/utils/pull/237
[#239]: https://github.com/RustCrypto/utils/pull/239