### PR TITLE
base64ct: declarative decoding/encoding

### DIFF
--- a/base64ct/src/bcrypt.rs
+++ b/base64ct/src/bcrypt.rs
@@ -1,9 +1,6 @@
 //! bcrypt Base64 encoding.
 
-use crate::{
-    encoding::{match_gt_ct, match_range_ct},
-    variant::Variant,
-};
+use crate::variant::{Decode, Encode, Variant};
 
 /// bcrypt Base64 encoding.
 ///
@@ -15,22 +12,18 @@ pub struct Base64Bcrypt;
 
 impl Variant for Base64Bcrypt {
     const PADDED: bool = false;
+    const BASE: u8 = b'.';
 
-    #[inline]
-    fn decode_6bits(src: u8) -> i16 {
-        let mut res: i16 = -1;
-        res += match_range_ct(src, b'.'..b'/', src as i16 - 45);
-        res += match_range_ct(src, b'A'..b'Z', src as i16 - 62);
-        res += match_range_ct(src, b'a'..b'z', src as i16 - 68);
-        res + match_range_ct(src, b'0'..b'9', src as i16 + 7)
-    }
+    const DECODER: &'static [Decode] = &[
+        Decode::Range(b'.'..b'/', -45),
+        Decode::Range(b'A'..b'Z', -62),
+        Decode::Range(b'a'..b'z', -68),
+        Decode::Range(b'0'..b'9', 7),
+    ];
 
-    #[inline]
-    fn encode_6bits(mut src: i16) -> u8 {
-        src += 0x2e;
-        src += match_gt_ct(src, 0x2f, 17);
-        src += match_gt_ct(src, 0x5a, 6);
-        src -= match_gt_ct(src, 0x7a, 75);
-        src as u8
-    }
+    const ENCODER: &'static [Encode] = &[
+        Encode::Apply(0x2f, 17),
+        Encode::Apply(0x5a, 6),
+        Encode::Apply(0x7a, -75),
+    ];
 }

--- a/base64ct/src/crypt.rs
+++ b/base64ct/src/crypt.rs
@@ -1,9 +1,6 @@
 //! `crypt(3)` Base64 encoding.
 
-use crate::{
-    encoding::{match_gt_ct, match_range_ct},
-    variant::Variant,
-};
+use crate::variant::{Decode, Encode, Variant};
 
 /// `crypt(3)` Base64 encoding.
 ///
@@ -15,20 +12,13 @@ pub struct Base64Crypt;
 
 impl Variant for Base64Crypt {
     const PADDED: bool = false;
+    const BASE: u8 = b'.';
 
-    #[inline]
-    fn decode_6bits(src: u8) -> i16 {
-        let mut res: i16 = -1;
-        res += match_range_ct(src, b'.'..b'9', src as i16 - 45);
-        res += match_range_ct(src, b'A'..b'Z', src as i16 - 52);
-        res + match_range_ct(src, b'a'..b'z', src as i16 - 58)
-    }
+    const DECODER: &'static [Decode] = &[
+        Decode::Range(b'.'..b'9', -45),
+        Decode::Range(b'A'..b'Z', -52),
+        Decode::Range(b'a'..b'z', -58),
+    ];
 
-    #[inline]
-    fn encode_6bits(mut src: i16) -> u8 {
-        src += 0x2e;
-        src += match_gt_ct(src, 0x39, 7);
-        src += match_gt_ct(src, 0x5a, 6);
-        src as u8
-    }
+    const ENCODER: &'static [Encode] = &[Encode::Apply(0x39, 7), Encode::Apply(0x5a, 6)];
 }

--- a/base64ct/src/url.rs
+++ b/base64ct/src/url.rs
@@ -1,9 +1,6 @@
 //! URL-safe Base64 encoding.
 
-use crate::{
-    encoding::{match_eq_ct, match_gt_ct, match_range_ct},
-    variant::Variant,
-};
+use crate::variant::{Decode, Encode, Variant};
 
 /// URL-safe Base64 encoding with `=` padding.
 ///
@@ -15,16 +12,9 @@ pub struct Base64Url;
 
 impl Variant for Base64Url {
     const PADDED: bool = true;
-
-    #[inline]
-    fn decode_6bits(src: u8) -> i16 {
-        decode_6bits(src)
-    }
-
-    #[inline]
-    fn encode_6bits(src: i16) -> u8 {
-        encode_6bits(src)
-    }
+    const BASE: u8 = b'A';
+    const DECODER: &'static [Decode] = DECODER;
+    const ENCODER: &'static [Encode] = ENCODER;
 }
 
 /// URL-safe Base64 encoding *without* padding.
@@ -37,34 +27,24 @@ pub struct Base64UrlUnpadded;
 
 impl Variant for Base64UrlUnpadded {
     const PADDED: bool = false;
-
-    #[inline]
-    fn decode_6bits(src: u8) -> i16 {
-        decode_6bits(src)
-    }
-
-    #[inline]
-    fn encode_6bits(src: i16) -> u8 {
-        encode_6bits(src)
-    }
+    const BASE: u8 = b'A';
+    const DECODER: &'static [Decode] = DECODER;
+    const ENCODER: &'static [Encode] = ENCODER;
 }
 
-#[inline(always)]
-fn decode_6bits(src: u8) -> i16 {
-    let mut res: i16 = -1;
-    res += match_range_ct(src, b'A'..b'Z', src as i16 - 64);
-    res += match_range_ct(src, b'a'..b'z', src as i16 - 70);
-    res += match_range_ct(src, b'0'..b'9', src as i16 + 5);
-    res += match_eq_ct(src, b'-', 63);
-    res + match_eq_ct(src, b'_', 64)
-}
+/// URL-safe Base64 decoder
+const DECODER: &[Decode] = &[
+    Decode::Range(b'A'..b'Z', -64),
+    Decode::Range(b'a'..b'z', -70),
+    Decode::Range(b'0'..b'9', 5),
+    Decode::Eq(b'-', 63),
+    Decode::Eq(b'_', 64),
+];
 
-#[inline(always)]
-fn encode_6bits(src: i16) -> u8 {
-    let mut diff = b'A' as i16;
-    diff += match_gt_ct(src, 25, 6);
-    diff -= match_gt_ct(src, 51, 75);
-    diff -= match_gt_ct(src, 61, b'-' as i16 - 0x20);
-    diff += match_gt_ct(src, 62, b'_' as i16 - b'-' as i16 - 1);
-    (src + diff) as u8
-}
+/// URL-safe Base64 encoder
+const ENCODER: &[Encode] = &[
+    Encode::Diff(25, 6),
+    Encode::Diff(51, -75),
+    Encode::Diff(61, -(b'-' as i16 - 0x20)),
+    Encode::Diff(62, b'_' as i16 - b'-' as i16 - 1),
+];

--- a/base64ct/src/variant.rs
+++ b/base64ct/src/variant.rs
@@ -1,13 +1,110 @@
 //! Base64 variants
 
+use core::ops::Range;
+
 /// Core encoder/decoder functions for a particular Base64 variant
 pub trait Variant {
     /// Is this encoding padded?
     const PADDED: bool;
 
+    /// First character in this Base64 alphabet
+    const BASE: u8;
+
+    /// Decoder passes
+    const DECODER: &'static [Decode];
+
+    /// Encoder passes
+    const ENCODER: &'static [Encode];
+
+    /// Decode 3 bytes of a Base64 message.
+    #[inline(always)]
+    fn decode_3bytes(src: &[u8], dst: &mut [u8]) -> i16 {
+        debug_assert_eq!(src.len(), 4);
+        debug_assert!(dst.len() >= 3, "dst too short: {}", dst.len());
+
+        let c0 = Self::decode_6bits(src[0]);
+        let c1 = Self::decode_6bits(src[1]);
+        let c2 = Self::decode_6bits(src[2]);
+        let c3 = Self::decode_6bits(src[3]);
+
+        dst[0] = ((c0 << 2) | (c1 >> 4)) as u8;
+        dst[1] = ((c1 << 4) | (c2 >> 2)) as u8;
+        dst[2] = ((c2 << 6) | c3) as u8;
+
+        ((c0 | c1 | c2 | c3) >> 8) & 1
+    }
+
     /// Decode 6-bits of a Base64 message
-    fn decode_6bits(src: u8) -> i16;
+    fn decode_6bits(src: u8) -> i16 {
+        let mut res: i16 = -1;
+
+        for decoder in Self::DECODER {
+            res += match decoder {
+                Decode::Range(range, offset) => {
+                    // Compute exclusive range from inclusive one
+                    let start = range.start as i16 - 1;
+                    let end = range.end as i16 + 1;
+                    (((start - src as i16) & (src as i16 - end)) >> 8) & (src as i16 + *offset)
+                }
+                Decode::Eq(value, offset) => {
+                    let start = *value as i16 - 1;
+                    let end = *value as i16 + 1;
+                    (((start - src as i16) & (src as i16 - end)) >> 8) & *offset
+                }
+            };
+        }
+
+        res
+    }
+
+    /// Encode 3-bytes of a Base64 message
+    #[inline(always)]
+    fn encode_3bytes(src: &[u8], dst: &mut [u8]) {
+        debug_assert_eq!(src.len(), 3);
+        debug_assert!(dst.len() >= 4, "dst too short: {}", dst.len());
+
+        let b0 = src[0] as i16;
+        let b1 = src[1] as i16;
+        let b2 = src[2] as i16;
+
+        dst[0] = Self::encode_6bits(b0 >> 2);
+        dst[1] = Self::encode_6bits(((b0 << 4) | (b1 >> 4)) & 63);
+        dst[2] = Self::encode_6bits(((b1 << 2) | (b2 >> 6)) & 63);
+        dst[3] = Self::encode_6bits(b2 & 63);
+    }
 
     /// Encode 6-bits of a Base64 message
-    fn encode_6bits(src: i16) -> u8;
+    #[inline(always)]
+    fn encode_6bits(src: i16) -> u8 {
+        let mut diff = src + Self::BASE as i16;
+
+        for &encoder in Self::ENCODER {
+            diff += match encoder {
+                Encode::Apply(threshold, offset) => ((threshold as i16 - diff) >> 8) & offset,
+                Encode::Diff(threshold, offset) => ((threshold as i16 - src) >> 8) & offset,
+            };
+        }
+
+        diff as u8
+    }
+}
+
+/// Constant-time decoder step
+#[derive(Debug)]
+pub enum Decode {
+    /// Match the given range, offsetting the input on match
+    Range(Range<u8>, i16),
+
+    /// Match the given value, returning the associated offset on match
+    Eq(u8, i16),
+}
+
+/// Constant-time encoder step
+#[derive(Copy, Clone, Debug)]
+pub enum Encode {
+    /// Apply the given offset to the cumulative result on match
+    Apply(u8, i16),
+
+    /// Compute a difference using the given offset on match
+    Diff(u8, i16),
 }


### PR DESCRIPTION
Replaces imperative decode_6bits/encode_6bits method with declarative associated constants describing the encoding.

This method still avoids the use of lookup tables and all inputs are still processed identically without any branching.