### PR TITLE
base64ct v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "base64ct"
-version = "0.2.0-pre"
+version = "0.2.0"
 
 [[package]]
 name = "blobby"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-02-01)
+### Changed
+- Refactor with `Encoding` trait ([#238])
+- Internal refactoring ([#241], [#242])
+
+[#238]: https://github.com/RustCrypto/utils/pull/238
+[#241]: https://github.com/RustCrypto/utils/pull/241
+[#242]: https://github.com/RustCrypto/utils/pull/242
+
 ## 0.1.2 (2021-01-31)
 ### Added
 - bcrypt encoding ([#237])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation Base64 (RFC 4648) implemented without data-dependent
 branches/LUTs thereby providing portable "best effort" constant-time operation

--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -9,13 +9,20 @@
 
 Pure Rust implementation of Base64 ([RFC 4648]).
 
-Implemented without data-dependent branches or look up tables, thereby
-providing "best effort" constant-time operation.
+Implements multiple Base64 variants without data-dependent branches or lookup
+tables, thereby providing portable "best effort" constant-time operation.
 
 Supports `no_std` environments and avoids heap allocations in the core API
 (but also provides optional `alloc` support for convenience).
 
 [Documentation][docs-link]
+
+## Supported Base64 variants
+
+- Standard Base64: `[A-Z]`, `[a-z]`, `[0-9]`, `+`, `/`
+- URL-safe Base64: `[A-Z]`, `[a-z]`, `[0-9]`, `-`, `_`
+- bcrypt Base64: `.`, `/`, `[A-Z]`, `[a-z]`, `[0-9]`
+- `crypt(3)` Base64: `.`, `-`, `[0-9]`, `[A-Z]`, `[a-z]`
 
 ## License
 

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -69,7 +69,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/0.1.2"
+    html_root_url = "https://docs.rs/base64ct/0.2.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/base64ct/src/variant/bcrypt.rs
+++ b/base64ct/src/variant/bcrypt.rs
@@ -22,8 +22,8 @@ impl Variant for Base64Bcrypt {
     ];
 
     const ENCODER: &'static [Encode] = &[
-        Encode::Apply(0x2f, 17),
-        Encode::Apply(0x5a, 6),
-        Encode::Apply(0x7a, -75),
+        Encode::Apply(b'/', 17),
+        Encode::Apply(b'Z', 6),
+        Encode::Apply(b'z', -75),
     ];
 }

--- a/base64ct/src/variant/crypt.rs
+++ b/base64ct/src/variant/crypt.rs
@@ -20,5 +20,5 @@ impl Variant for Base64Crypt {
         Decode::Range(b'a'..b'z', -58),
     ];
 
-    const ENCODER: &'static [Encode] = &[Encode::Apply(0x39, 7), Encode::Apply(0x5a, 6)];
+    const ENCODER: &'static [Encode] = &[Encode::Apply(b'9', 7), Encode::Apply(b'Z', 6)];
 }

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["crypto", "key", "private"]
 readme = "README.md"
 
 [dependencies]
-base64ct = { version = "=0.2.0-pre", optional = true, features = ["alloc"], path = "../base64ct" }
+base64ct = { version = "0.2", optional = true, features = ["alloc"], path = "../base64ct" }
 der = { version = "0.2", features = ["oid"], path = "../der" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
### Changed
- Refactor with `Encoding` trait ([#238])
- Internal refactoring ([#241], [#242])

[#238]: https://github.com/RustCrypto/utils/pull/238
[#241]: https://github.com/RustCrypto/utils/pull/241
[#242]: https://github.com/RustCrypto/utils/pull/242