### PR TITLE
pkcs8 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "0.3.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2021-02-01)
+### Changed
+- Bump `basec4ct` dependency to v0.2 ([#238], [#243])
+
+[#238]: https://github.com/RustCrypto/utils/pull/238
+[#243]: https://github.com/RustCrypto/utils/pull/243
+
 ## 0.4.0 (2021-01-26)
 ### Changed
 - Bump `der` crate dependency to v0.2 ([#224])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -44,7 +44,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.4.0"
+    html_root_url = "https://docs.rs/pkcs8/0.4.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Bump `basec4ct` dependency to v0.2 ([#238], [#243])

[#238]: https://github.com/RustCrypto/utils/pull/238
[#243]: https://github.com/RustCrypto/utils/pull/243