### PR TITLE
der v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2021-02-02)
+### Added
+- Support for `PrintableString` and `Utf8String` ([#245])
+
+[#245]: https://github.com/RustCrypto/utils/pull/245
+
 ## 0.2.0 (2021-01-22)
 ### Added
 - `BigUInt` type ([#196])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 const-oid = { version = "0.4", optional = true, path = "../const-oid" }
-der_derive = { version = "0.1", optional = true, path = "derive" }
+der_derive = { version = "0.2", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 
 [features]

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,5 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-02-02)
+### Added
+- Support for `PrintableString` and `Utf8String` (#245)
+
 ## 0.1.0 (2020-12-21)
 - Initial release

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Procedural macro for automatically deriving the `der` crate's `Message` trait
 """

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -309,7 +309,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.2.0"
+    html_root_url = "https://docs.rs/der/0.2.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Support for `PrintableString` and `Utf8String` ([#245])

[#245]: https://github.com/RustCrypto/utils/pull/245