### PR TITLE
der v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2021-02-12)
+### Added
+- Support for `UTCTime` and `GeneralizedTime` ([#250])
+
+[#250]: https://github.com/RustCrypto/utils/pull/250
+
 ## 0.2.1 (2021-02-02)
 ### Added
 - Support for `PrintableString` and `Utf8String` ([#245])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -312,7 +312,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.2.1"
+    html_root_url = "https://docs.rs/der/0.2.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Support for `UTCTime` and `GeneralizedTime` ([#250])

[#250]: https://github.com/RustCrypto/utils/pull/250