### PR TITLE
der v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2021-02-15)
+### Added
+- Additional `rustdoc` documentation ([#252], [#256])
+
+[#252]: https://github.com/RustCrypto/utils/pull/252
+[#256]: https://github.com/RustCrypto/utils/pull/256
+
 ## 0.2.2 (2021-02-12)
 ### Added
 - Support for `UTCTime` and `GeneralizedTime` ([#250])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -312,7 +312,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.2.2"
+    html_root_url = "https://docs.rs/der/0.2.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Additional `rustdoc` documentation ([#252], [#256])

[#252]: https://github.com/RustCrypto/utils/pull/252
[#256]: https://github.com/RustCrypto/utils/pull/256