### PR TITLE
spki: add (back) an `AlgorithmParameters` type

### DIFF
--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -103,15 +103,18 @@ impl std::error::Error for Error {}
 /// Result type
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// Object identifier (OID)
+/// Object identifier (OID).
+///
+/// OIDs are hierarchical structures consisting of "arcs", i.e. integer
+/// identifiers.
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ObjectIdentifier {
     /// Byte containing the first and second arcs of this OID, stored
     /// separately from the others to minimize this type's size.
     root_arcs: RootArcs,
 
-    /// Additional "lower" arcs beyond the first and second arcs, which are
-    /// stored as [`RootArcs`].
+    /// Additional "lower" arcs beyond the first and second arcs
+    /// (the latter are stored as [`RootArcs`]).
     lower_arcs: LowerArcs,
 }
 

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -1,18 +1,19 @@
 //! X.509 `AlgorithmIdentifier`
 
 use core::convert::TryFrom;
-use der::{Any, Decodable, Encodable, Error, Message, ObjectIdentifier, Result};
+use der::{
+    Any, Decodable, Encodable, Encoder, Error, Length, Message, Null, ObjectIdentifier, Result, Tag,
+};
 
-/// X.509 `AlgorithmIdentifier`
-///
-/// Defined in RFC 5280 Section 4.1.1.2:
-/// <https://tools.ietf.org/html/rfc5280#section-4.1.1.2>
+/// X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2].
 ///
 /// ```text
 /// AlgorithmIdentifier  ::=  SEQUENCE  {
 ///      algorithm               OBJECT IDENTIFIER,
 ///      parameters              ANY DEFINED BY algorithm OPTIONAL  }
 /// ```
+///
+/// [RFC 5280 Section 4.1.1.2]: https://tools.ietf.org/html/rfc5280#section-4.1.1.2
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct AlgorithmIdentifier<'a> {
     /// Algorithm OID, i.e. the `algorithm` field in the `AlgorithmIdentifier`
@@ -20,15 +21,24 @@ pub struct AlgorithmIdentifier<'a> {
     pub oid: ObjectIdentifier,
 
     /// Algorithm `parameters`.
-    pub parameters: Option<Any<'a>>,
+    pub parameters: Option<AlgorithmParameters<'a>>,
 }
 
 impl<'a> AlgorithmIdentifier<'a> {
+    /// Get the `parameters` field as an [`Any`].
+    ///
+    /// This will be `None` if the parameters are an [`ObjectIdentifier`] or
+    /// [`Null`], so this method should be used for handling any other
+    /// ASN.1 type besides those two.
+    pub fn parameters_any(&self) -> Option<Any<'a>> {
+        self.parameters.and_then(AlgorithmParameters::any)
+    }
+
     /// Get the `parameters` field as an [`ObjectIdentifier`].
     ///
     /// Returns `None` if it is absent or not an OID.
     pub fn parameters_oid(&self) -> Option<ObjectIdentifier> {
-        self.parameters.and_then(|params| params.oid().ok())
+        self.parameters.and_then(AlgorithmParameters::oid)
     }
 }
 
@@ -58,5 +68,104 @@ impl<'a> Message<'a> for AlgorithmIdentifier<'a> {
         F: FnOnce(&[&dyn Encodable]) -> Result<T>,
     {
         f(&[&self.oid, &self.parameters])
+    }
+}
+
+/// The `parameters` field of `AlgorithmIdentifier`.
+///
+/// This is an algorithm-defined `ANY` field, but we map it into an `enum`
+/// for now to simplify the [`ObjectIdentifier`] use case.
+///
+/// Ideally this type can eventually go away and be replaced by [`Any`]
+/// with the assistance of OID reference types. See the following tracking
+/// issue for more info:
+///
+/// <https://github.com/RustCrypto/utils/issues/266>
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AlgorithmParameters<'a> {
+    /// Catch-all ASN.1 `ANY` type.
+    ///
+    /// Types which don't map to the other variants of this enum will be mapped
+    /// to this one instead.
+    Any(Any<'a>),
+
+    /// ASN.1 `NULL` value
+    Null,
+
+    /// [`ObjectIdentifier`] that names a specific algorithm within a larger
+    /// algorithm family.
+    Oid(ObjectIdentifier),
+}
+
+impl<'a> AlgorithmParameters<'a> {
+    /// Get the [`Any`] value if applicable.
+    ///
+    /// Note that this will return [`None`] in the event the parameter is an
+    /// OID or `NULL`.
+    pub fn any(self) -> Option<Any<'a>> {
+        match self {
+            AlgorithmParameters::Any(any) => Some(any),
+            _ => None,
+        }
+    }
+
+    /// Get the OID value if applicable
+    pub fn oid(self) -> Option<ObjectIdentifier> {
+        match self {
+            AlgorithmParameters::Oid(oid) => Some(oid),
+            _ => None,
+        }
+    }
+
+    /// Is this parameter value NULL?
+    pub fn is_null(self) -> bool {
+        self == AlgorithmParameters::Null
+    }
+
+    /// Is this parameter value an OID?
+    pub fn is_oid(self) -> bool {
+        self.oid().is_some()
+    }
+}
+
+impl<'a> From<Null> for AlgorithmParameters<'a> {
+    fn from(_: Null) -> AlgorithmParameters<'a> {
+        AlgorithmParameters::Null
+    }
+}
+
+impl<'a> From<ObjectIdentifier> for AlgorithmParameters<'a> {
+    fn from(oid: ObjectIdentifier) -> AlgorithmParameters<'a> {
+        AlgorithmParameters::Oid(oid)
+    }
+}
+
+impl<'a> TryFrom<Any<'a>> for AlgorithmParameters<'a> {
+    type Error = Error;
+
+    fn try_from(any: Any<'a>) -> Result<AlgorithmParameters<'a>> {
+        match any.tag() {
+            Tag::Null => Null::try_from(any).map(Into::into),
+            Tag::ObjectIdentifier => any.oid().map(Into::into),
+            _ => Ok(Self::Any(any)),
+        }
+    }
+}
+
+impl<'a> Encodable for AlgorithmParameters<'a> {
+    fn encoded_len(&self) -> Result<Length> {
+        match self {
+            Self::Any(any) => any.encoded_len(),
+            Self::Null => Null.encoded_len(),
+            Self::Oid(oid) => oid.encoded_len(),
+        }
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        match self {
+            Self::Any(any) => any.encode(encoder),
+            Self::Null => encoder.null(),
+            Self::Oid(oid) => encoder.oid(*oid),
+        }
     }
 }

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -22,5 +22,8 @@
 mod algorithm;
 mod spki;
 
-pub use crate::{algorithm::AlgorithmIdentifier, spki::SubjectPublicKeyInfo};
+pub use crate::{
+    algorithm::{AlgorithmIdentifier, AlgorithmParameters},
+    spki::SubjectPublicKeyInfo,
+};
 pub use der::{self, ObjectIdentifier};

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -4,7 +4,7 @@ use crate::AlgorithmIdentifier;
 use core::convert::TryFrom;
 use der::{Decodable, Encodable, Error, Message, Result};
 
-/// X.509 `SubjectPublicKeyInfo` (SPKI)
+/// X.509 `SubjectPublicKeyInfo` (SPKI).
 ///
 /// ASN.1 structure containing an [`AlgorithmIdentifier`] and public key
 /// data in an algorithm specific format.


### PR DESCRIPTION
Adds an enum representing `ANY`, `NULL`, and `Objectidentifier` cases for the `parameters` field of `AlgorithmIdentifier`.

Ideally this enum would be unnecessary and we could just use the `der::Any` type for this field, however to make that possible in all relevant use cases we'd need a reference-based type for `ObjectIdentifier` backed by a byte slice containing the DER serialization of the OID. See #266.

Until we have such a type, this enum suffices to make it possible to decode and encode an owned OID value which stores the decoded arcs that comprise it, rather than the DER serialization.