### PR TITLE
pkcs8 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "0.3.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-02-16)
+### Added
+- Initial `EncryptedPrivateKeyInfo` support ([#262])
+
+### Changed
+- Extract SPKI-related types into the `spki` crate ([#261], [#268])
+
+[#261]: https://github.com/RustCrypto/utils/pull/261
+[#262]: https://github.com/RustCrypto/utils/pull/262
+[#268]: https://github.com/RustCrypto/utils/pull/268
+
 ## 0.4.1 (2021-02-01)
 ### Changed
 - Bump `basec4ct` dependency to v0.2 ([#238], [#243])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -50,7 +50,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.5.0-pre"
+    html_root_url = "https://docs.rs/pkcs8/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Initial `EncryptedPrivateKeyInfo` support ([#262])

### Changed
- Extract SPKI-related types into the `spki` crate ([#261], [#268])

[#261]: https://github.com/RustCrypto/utils/pull/261
[#262]: https://github.com/RustCrypto/utils/pull/262
[#268]: https://github.com/RustCrypto/utils/pull/268