### PR TITLE
der: rename OidInvalid => UnknownOid

### DIFF
--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -122,7 +122,7 @@ impl TryFrom<ObjectIdentifier> for EncryptionScheme {
             PBE_WITH_MD5_AND_RC2_CBC_OID => Ok(Self::PbeWithMd5AndRc2Cbc),
             PBE_WITH_SHA1_AND_DES_CBC_OID => Ok(Self::PbeWithSha1AndDesCbc),
             PBE_WITH_SHA1_AND_RC2_CBC_OID => Ok(Self::PbeWithSha1AndRc2Cbc),
-            _ => Err(ErrorKind::OidInvalid(oid).into()),
+            _ => Err(ErrorKind::UnknownOid { oid }.into()),
         }
     }
 }

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -78,7 +78,7 @@ impl<'a> TryFrom<AlgorithmIdentifier<'a>> for Kdf<'a> {
                 .parameters_any()
                 .and_then(TryFrom::try_from)
                 .map(Self::Pbkdf2),
-            _ => Err(ErrorKind::OidInvalid(alg.oid).into()),
+            oid => Err(ErrorKind::UnknownOid { oid }.into()),
         }
     }
 }
@@ -174,7 +174,7 @@ impl<'a> TryFrom<AlgorithmIdentifier<'a>> for Pbkdf2Prf {
 
         match alg.oid {
             HMAC_WITH_SHA256_OID => Ok(Self::HmacWithSha256),
-            _ => Err(ErrorKind::OidInvalid(alg.oid).into()),
+            oid => Err(ErrorKind::UnknownOid { oid }.into()),
         }
     }
 }
@@ -208,7 +208,7 @@ impl<'a> TryFrom<AlgorithmIdentifier<'a>> for EncryptionScheme<'a> {
 
                 Ok(Self::Aes256Cbc { iv })
             }
-            _ => Err(ErrorKind::OidInvalid(alg.oid).into()),
+            oid => Err(ErrorKind::UnknownOid { oid }.into()),
         }
     }
 }


### PR DESCRIPTION
This name does a much better job of capturing what it is attempting to report to the caller, and also nicely pairs with `UnknownTag`.