### PR TITLE
pkcs8: add `pkcs5` feature

### DIFF
--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -39,9 +39,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --release --target ${{ matrix.target }}
-      - run: cargo build --release --target ${{ matrix.target }} --features alloc
-      - run: cargo build --release --target ${{ matrix.target }} --features pem
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features alloc
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pem
 
   test:
     runs-on: ubuntu-latest
@@ -57,6 +57,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --features alloc
       - run: cargo test --release --features pem

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -24,9 +24,11 @@ zeroize = { version = "1", optional = true, default-features = false, features =
 hex-literal = "0.3"
 
 [features]
+default = ["pkcs5"]
 std = ["alloc", "der/std"]
 alloc = ["der/alloc", "zeroize"]
 pem = ["alloc", "base64ct"]
+pkcs5 = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -73,7 +73,7 @@ mod pem;
 
 pub use crate::{
     error::{Error, Result},
-    private_key_info::{encrypted::EncryptedPrivateKeyInfo, PrivateKeyInfo},
+    private_key_info::PrivateKeyInfo,
     traits::{FromPrivateKey, FromPublicKey},
 };
 pub use der::{self, ObjectIdentifier};
@@ -84,3 +84,6 @@ pub use crate::{
     document::{PrivateKeyDocument, PublicKeyDocument},
     traits::{ToPrivateKey, ToPublicKey},
 };
+
+#[cfg(feature = "pkcs5")]
+pub use crate::private_key_info::encrypted::EncryptedPrivateKeyInfo;

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -1,5 +1,6 @@
 //! PKCS#8 `PrivateKeyInfo`.
 
+#[cfg(feature = "pkcs5")]
 pub(crate) mod encrypted;
 
 use crate::{AlgorithmIdentifier, Error, Result};

--- a/pkcs8/src/private_key_info/encrypted.rs
+++ b/pkcs8/src/private_key_info/encrypted.rs
@@ -41,6 +41,7 @@ use der::{Decodable, Encodable, Message};
 /// [RFC 5208 Section 6]: https://tools.ietf.org/html/rfc5208#section-6
 /// [PKCS#5 v1.5]: https://tools.ietf.org/html/rfc2898
 /// [PKCS#5 v2]: https://tools.ietf.org/html/rfc8018
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs5")))]
 #[derive(Copy, Clone)]
 pub struct EncryptedPrivateKeyInfo<'a> {
     /// [`AlgorithmIdentifier`] for the symmetric encryption algorithm used to

--- a/pkcs8/tests/encrypted_private_key.rs
+++ b/pkcs8/tests/encrypted_private_key.rs
@@ -1,5 +1,7 @@
 //! Encrypted PKCS#8 private key tests.
 
+#![cfg(feature = "pkcs5")]
+
 use core::convert::TryFrom;
 use hex_literal::hex;
 use pkcs8::EncryptedPrivateKeyInfo;


### PR DESCRIPTION
Gates `EncryptedPrivateKeyInfo` support under a `pkcs5` feature.

This type is worthless without a PKCS#5 implementation to decrypt/encrypt the private key. This feature will allow gating the
`pkcs5` crate and the additional dependencies it needs (via `pkcs5` crate features).

To avoid introducing a new feature being a breaking change, the `pkcs5` feature is enabled by-default.