### PR TITLE
pkcs8 v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2021-02-18)
+### Added
+- `pkcs5` feature ([#278])
+
+### Changed
+- Bump `spki` dependency to v0.2.0 ([#277])
+
+[#277]: https://github.com/RustCrypto/utils/pull/277
+[#278]: https://github.com/RustCrypto/utils/pull/278
+
 ## 0.5.0 (2021-02-16)
 ### Added
 - Initial `EncryptedPrivateKeyInfo` support ([#262])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -50,7 +50,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.5.0"
+    html_root_url = "https://docs.rs/pkcs8/0.5.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- `pkcs5` feature ([#278])

### Changed
- Bump `spki` dependency to v0.2.0 ([#277])

[#277]: https://github.com/RustCrypto/utils/pull/277
[#278]: https://github.com/RustCrypto/utils/pull/278