### PR TITLE
der: export `Header` publically

### DIFF
--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -5,7 +5,7 @@ use core::convert::TryInto;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) struct Header {
+pub struct Header {
     /// Tag representing the type of the encoded value
     pub tag: Tag,
 
@@ -16,7 +16,7 @@ pub(crate) struct Header {
 impl Header {
     /// Create a new [`Header`] from a [`Tag`] and a specified length.
     ///
-    /// Returns [`Error`] if the length exceeds the limits of [`Length`]
+    /// Returns an error if the length exceeds the limits of [`Length`].
     pub fn new(tag: Tag, length: impl TryInto<Length>) -> Result<Self> {
         let length = length.try_into().map_err(|_| ErrorKind::Overflow)?;
         Ok(Self { tag, length })

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -355,12 +355,13 @@ pub use crate::{
     decoder::Decoder,
     encoder::Encoder,
     error::{Error, ErrorKind, Result},
+    header::Header,
     length::Length,
     tag::Tag,
     traits::{Decodable, Encodable, Message, Tagged},
 };
 
-pub(crate) use crate::{byte_slice::ByteSlice, header::Header};
+pub(crate) use crate::byte_slice::ByteSlice;
 
 #[cfg(feature = "big-uint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "big-uint")))]


### PR DESCRIPTION
Advanced usages of the crate (which try to map DER-encoded data in a way that isn't 100% isomorphic to Rust struct/enum combinations) can benefit from having this available in the public interface.