### PR TITLE
der 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.7 (2021-02-20)
+### Added
+- Export `Header` publicly ([#283])
+- Make `Encoder::reserve` public ([#285])
+
+[#283]: https://github.com/RustCrypto/utils/pull/283
+[#285]: https://github.com/RustCrypto/utils/pull/285
+
 ## 0.2.6 (2021-02-19)
 ### Added
 - Make the unit type an encoding of `NULL` ([#281])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.2.6" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.7" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -317,7 +317,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.2.6"
+    html_root_url = "https://docs.rs/der/0.2.7"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "key", "pkcs", "password"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.2.5", features = ["oid"], path = "../der" }
+der = { version = "0.2.7", features = ["oid"], path = "../der" }
 spki = { version = "0.2", path = "../spki" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added
- Export `Header` publicly ([#283])
- Make `Encoder::reserve` public ([#285])

[#283]: https://github.com/RustCrypto/utils/pull/283
[#285]: https://github.com/RustCrypto/utils/pull/285