### PR TITLE
pkcs8: use `pkcs5` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "base64ct",
  "der",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkcs5",
  "spki",
  "zeroize",
 ]

--- a/pkcs5/tests/pbes2.rs
+++ b/pkcs5/tests/pbes2.rs
@@ -28,7 +28,7 @@ const PBES2_PBKDF2_SHA256_AES256CBC_ALG_ID: &[u8] = &hex!(
 /// Decoding tests
 #[test]
 fn decode_pbes2_pbkdf2_sha1_aes128cbc() {
-    let scheme = pkcs5::Scheme::try_from(PBES2_PBKDF2_SHA1_AES128CBC_ALG_ID).unwrap();
+    let scheme = pkcs5::EncryptionScheme::try_from(PBES2_PBKDF2_SHA1_AES128CBC_ALG_ID).unwrap();
     let params = scheme.pbes2().unwrap();
 
     let pbkdf2_params = params.kdf.pbkdf2().unwrap();
@@ -48,7 +48,7 @@ fn decode_pbes2_pbkdf2_sha1_aes128cbc() {
 /// Decoding tests
 #[test]
 fn decode_pbes2_pbkdf2_sha256_aes256cbc() {
-    let scheme = pkcs5::Scheme::try_from(PBES2_PBKDF2_SHA256_AES256CBC_ALG_ID).unwrap();
+    let scheme = pkcs5::EncryptionScheme::try_from(PBES2_PBKDF2_SHA256_AES256CBC_ALG_ID).unwrap();
     let params = scheme.pbes2().unwrap();
 
     let pbkdf2_params = params.kdf.pbkdf2().unwrap();
@@ -70,7 +70,7 @@ fn decode_pbes2_pbkdf2_sha256_aes256cbc() {
 fn encode_pbes2_pbkdf2_sha1_aes128cbc() {
     let mut buffer = [0u8; 1024];
 
-    let scheme = pkcs5::Scheme::try_from(PBES2_PBKDF2_SHA1_AES128CBC_ALG_ID).unwrap();
+    let scheme = pkcs5::EncryptionScheme::try_from(PBES2_PBKDF2_SHA1_AES128CBC_ALG_ID).unwrap();
     let mut encoder = der::Encoder::new(&mut buffer);
     scheme.encode(&mut encoder).unwrap();
 
@@ -83,7 +83,7 @@ fn encode_pbes2_pbkdf2_sha1_aes128cbc() {
 fn encode_pbes2_pbkdf2_sha256_aes256cbc() {
     let mut buffer = [0u8; 1024];
 
-    let scheme = pkcs5::Scheme::try_from(PBES2_PBKDF2_SHA256_AES256CBC_ALG_ID).unwrap();
+    let scheme = pkcs5::EncryptionScheme::try_from(PBES2_PBKDF2_SHA256_AES256CBC_ALG_ID).unwrap();
     let mut encoder = der::Encoder::new(&mut buffer);
     scheme.encode(&mut encoder).unwrap();
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -18,6 +18,7 @@ der = { version = "0.2", features = ["oid"], path = "../der" }
 spki = { version = "0.2", path = "../spki" }
 
 base64ct = { version = "0.2", optional = true, features = ["alloc"], path = "../base64ct" }
+pkcs5 = { version = "0", optional = true, path = "../pkcs5" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
@@ -28,7 +29,6 @@ default = ["pkcs5"]
 std = ["alloc", "der/std"]
 alloc = ["der/alloc", "zeroize"]
 pem = ["alloc", "base64ct"]
-pkcs5 = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -88,3 +88,5 @@ pub use crate::{
 
 #[cfg(feature = "pkcs5")]
 pub use crate::private_key_info::encrypted::EncryptedPrivateKeyInfo;
+#[cfg(feature = "pkcs5")]
+pub use pkcs5;

--- a/pkcs8/src/private_key_info/encrypted.rs
+++ b/pkcs8/src/private_key_info/encrypted.rs
@@ -1,26 +1,21 @@
 //! PKCS#8 `EncryptedPrivateKeyInfo`
 
-use crate::{AlgorithmIdentifier, Error, Result};
+use crate::{Error, Result};
 use core::convert::TryFrom;
 use der::{Decodable, Encodable, Message};
+use pkcs5::EncryptionScheme;
 
 /// PKCS#8 `EncryptedPrivateKeyInfo`.
 ///
-/// ASN.1 structure containing an [`AlgorithmIdentifier`] identifying a
-/// symmetric encryption scheme and encrypted private key data.
+/// ASN.1 structure containing a PKCS#5 [`EncryptionScheme`] identifier for a
+/// password-based symmetric encryption scheme and encrypted private key data.
 ///
 /// ## Encryption algorithm support
 ///
 /// tl;dr: none yet!
 ///
 /// This crate does not (yet) support decrypting/encrypting private key data.
-/// However, support for the following may be added in future releases:
-///
-/// - [PKCS#5 v1.5] supports several password-based encryption algorithms,
-///   including `PBE-SHA1-3DES`.
-/// - [PKCS#5 v2] adds support for AES-CBC encryption with iterated PRFs
-///   such as `hmacWithSHA256`.
-///
+/// However, support for the following may be added in future releases.
 /// Please see the following GitHub issue for tracking information:
 ///
 /// <https://github.com/RustCrypto/utils/issues/263>
@@ -39,14 +34,12 @@ use der::{Decodable, Encodable, Message};
 /// ```
 ///
 /// [RFC 5208 Section 6]: https://tools.ietf.org/html/rfc5208#section-6
-/// [PKCS#5 v1.5]: https://tools.ietf.org/html/rfc2898
-/// [PKCS#5 v2]: https://tools.ietf.org/html/rfc8018
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs5")))]
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct EncryptedPrivateKeyInfo<'a> {
-    /// [`AlgorithmIdentifier`] for the symmetric encryption algorithm used to
-    /// encrypt the `encrypted_data` field.
-    pub encryption_algorithm: AlgorithmIdentifier<'a>,
+    /// Algorithm identifier describing a password-based symmetric encryption
+    /// scheme used to encrypt the `encrypted_data` field.
+    pub encryption_algorithm: EncryptionScheme<'a>,
 
     /// Private key data
     pub encrypted_data: &'a [u8],


### PR DESCRIPTION
Adds the `pkcs5` crate as an optional dependency (replacing the previous `pkcs5` feature with an optional crate).

Uses the `pkcs5` crate for parsing the `AlgorithmIdentifier` of `EncryptedPrivateKeyInfo`.