### PR TITLE
pkcs8 v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.1 (2021-02-18)
+## 0.5.2 (2021-02-20)
+### Changed
+- Use `pkcs5` crate ([#290])
+
+[#290]: https://github.com/RustCrypto/utils/pull/290
+
+## 0.5.1 (2021-02-18) [YANKED]
 ### Added
 - `pkcs5` feature ([#278])
 
@@ -14,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#277]: https://github.com/RustCrypto/utils/pull/277
 [#278]: https://github.com/RustCrypto/utils/pull/278
 
-## 0.5.0 (2021-02-16)
+## 0.5.0 (2021-02-16) [YANKED]
 ### Added
 - Initial `EncryptedPrivateKeyInfo` support ([#262])
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.5.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -51,7 +51,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.5.1"
+    html_root_url = "https://docs.rs/pkcs8/0.5.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Use `pkcs5` crate ([#290])

[#290]: https://github.com/RustCrypto/utils/pull/290