### PR TITLE
der: add `Choice` trait

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -7,6 +7,7 @@ pub(crate) mod any;
 pub(crate) mod big_uint;
 pub(crate) mod bit_string;
 pub(crate) mod boolean;
+pub(crate) mod choice;
 pub(crate) mod generalized_time;
 pub(crate) mod integer;
 pub(crate) mod null;

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `ANY` type.
 
 use crate::{
-    BitString, ByteSlice, Decodable, Decoder, Encodable, Encoder, Error, ErrorKind,
+    BitString, ByteSlice, Choice, Decodable, Decoder, Encodable, Encoder, Error, ErrorKind,
     GeneralizedTime, Header, Length, Null, OctetString, PrintableString, Result, Sequence, Tag,
     UtcTime, Utf8String,
 };
@@ -120,6 +120,12 @@ impl<'a> Any<'a> {
             tag: self.tag,
             length: self.len(),
         }
+    }
+}
+
+impl<'a> Choice<'a> for Any<'a> {
+    fn can_decode(_: Tag) -> bool {
+        true
     }
 }
 

--- a/der/src/asn1/choice.rs
+++ b/der/src/asn1/choice.rs
@@ -1,0 +1,25 @@
+//! ASN.1 `CHOICE` support.
+
+use crate::{Decodable, Encodable, Tag, Tagged};
+
+/// ASN.1 `CHOICE` denotes a union of one or more possible alternatives.
+///
+/// The types MUST have distinct tags.
+///
+/// This crate models choice as a trait, with a blanket impl for all types
+/// which impl `Decodable + Encodable + Tagged` (i.e. they are modeled as
+/// a `CHOICE` with only one possible variant)
+// TODO(tarcieri): refactor enum custom derive to use `Choice`
+pub trait Choice<'a>: Decodable<'a> + Encodable {
+    /// Is the provided [`Tag`] decodable as a variant of this `CHOICE`?
+    fn can_decode(tag: Tag) -> bool;
+}
+
+impl<'a, T> Choice<'a> for T
+where
+    T: Decodable<'a> + Encodable + Tagged,
+{
+    fn can_decode(tag: Tag) -> bool {
+        T::TAG == tag
+    }
+}

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -1,7 +1,7 @@
 //! DER decoder.
 
 use crate::{
-    Any, BitString, Decodable, ErrorKind, GeneralizedTime, Length, Null, OctetString,
+    Any, BitString, Choice, Decodable, ErrorKind, GeneralizedTime, Length, Null, OctetString,
     PrintableString, Result, Sequence, UtcTime, Utf8String,
 };
 use core::convert::TryInto;
@@ -145,7 +145,7 @@ impl<'a> Decoder<'a> {
     }
 
     /// Attempt to decode an ASN.1 `OPTIONAL` value.
-    pub fn optional<T: Decodable<'a>>(&mut self) -> Result<Option<T>> {
+    pub fn optional<T: Choice<'a>>(&mut self) -> Result<Option<T>> {
         self.decode()
     }
 
@@ -202,6 +202,13 @@ impl<'a> Decoder<'a> {
 
         self.position = (self.position + len)?;
         Ok(result)
+    }
+
+    /// Peek at the next byte in the decoder without modifying the cursor.
+    pub(crate) fn peek(&self) -> Option<u8> {
+        self.remaining()
+            .ok()
+            .and_then(|bytes| bytes.get(0).cloned())
     }
 
     /// Obtain the remaining bytes in this decoder from the current cursor

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -346,6 +346,7 @@ pub use crate::{
     asn1::{
         any::Any,
         bit_string::BitString,
+        choice::Choice,
         generalized_time::GeneralizedTime,
         null::Null,
         octet_string::OctetString,

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -2,7 +2,8 @@
 
 use core::convert::TryFrom;
 use der::{
-    Any, Decodable, Encodable, Encoder, Error, Length, Message, Null, ObjectIdentifier, Result, Tag,
+    Any, Choice, Decodable, Encodable, Encoder, Error, Length, Message, Null, ObjectIdentifier,
+    Result, Tag,
 };
 
 /// X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2].
@@ -174,6 +175,12 @@ impl<'a> TryFrom<Any<'a>> for AlgorithmParameters<'a> {
             Tag::ObjectIdentifier => any.oid().map(Into::into),
             _ => Ok(Self::Any(any)),
         }
+    }
+}
+
+impl<'a> Choice<'a> for AlgorithmParameters<'a> {
+    fn can_decode(_: Tag) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
Closes #271

The `Choice` trait represents an ASN.1 `CHOICE` and allows types to specify which ASN.1 tags they support.

This is implemented in terms of a static `can_decode` method. Using a method for this means it's possible to impl `Choice` for `Any` (or e.g. enums that contain `Any` as a member).

A blanket impl of `Choice` is provided for all types which impl `Decodable + Encodable + Tagged`, i.e. types which can be viewed as a `Choice` between only one alternative.

This trait is also an ideal for a custom derive macro for enums (and indeed, it's necessary to support an `OPTIONAL CHOICE` which maps to `Option<MyEnum>`.