### PR TITLE
der_derive: add choice::Alternative and duplicate tracking

### DIFF
--- a/der/derive/src/types.rs
+++ b/der/derive/src/types.rs
@@ -6,7 +6,7 @@ use quote::quote;
 
 /// ASN.1 built-in types supported by the `#[asn1(type = "...")]` attribute
 // TODO(tarcieri): support all ASN.1 types specified in `der::Tag`
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) enum Asn1Type {
     /// ASN.1 `BIT STRING`
     BitString,


### PR DESCRIPTION
Adds a `choice::Alternative` struct which includes information about how alternatives of an ASN.1 `CHOICE` map to Rust enum variants.

Uses this information to detect when duplicate ASN.1 types are specified for different variants, and panics in this case since this is invalid.