### PR TITLE
pkcs8: encryption support

### DIFF
--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -39,7 +39,9 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
+      - run: cargo build --target ${{ matrix.target }} --release --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --features pbes2
+      - run: cargo build --target ${{ matrix.target }} --release --features alloc,pbes2
 
   test:
     runs-on: ubuntu-latest
@@ -56,4 +58,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
+      - run: cargo test --release --features alloc
+      - run: cargo test --release --features pbes2
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "der",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkcs5",
+ "rand_core",
  "spki",
  "zeroize",
 ]
@@ -262,6 +263,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 
 [[package]]
 name = "sha2"

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -27,6 +27,7 @@ sha2 = { version = "0.9", optional = true, default-features = false }
 hex-literal = "0.3"
 
 [features]
+alloc = []
 pbes2 = ["aes", "block-modes", "hmac", "pbkdf2", "sha2"]
 
 [package.metadata.docs.rs]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -18,6 +18,7 @@ der = { version = "0.2", features = ["oid"], path = "../der" }
 spki = { version = "0.2", path = "../spki" }
 
 base64ct = { version = "0.2", optional = true, features = ["alloc"], path = "../base64ct" }
+rand_core = { version = "0.6", optional = true, default-features = false }
 pkcs5 = { version = "0.1", optional = true, path = "../pkcs5" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
@@ -25,7 +26,7 @@ zeroize = { version = "1", optional = true, default-features = false, features =
 hex-literal = "0.3"
 
 [features]
-encryption = ["alloc", "pkcs5/pbes2"]
+encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
 std = ["alloc", "der/std"]
 alloc = ["der/alloc", "zeroize"]
 pem = ["alloc", "base64ct"]

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -33,6 +33,20 @@ use {
 pub struct EncryptedPrivateKeyDocument(Zeroizing<Vec<u8>>);
 
 impl EncryptedPrivateKeyDocument {
+    /// Attempt to decrypt this encrypted private key using the provided
+    /// password to derive an encryption key.
+    #[cfg(feature = "encryption")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
+    pub fn decrypt(&self, password: impl AsRef<[u8]>) -> Result<PrivateKeyDocument> {
+        self.encrypted_private_key_info().decrypt(password)
+    }
+
+    /// Parse the [`EncryptedPrivateKeyInfo`] contained in this [`EncryptedPrivateKeyDocument`].
+    pub fn encrypted_private_key_info(&self) -> EncryptedPrivateKeyInfo<'_> {
+        EncryptedPrivateKeyInfo::try_from(self.0.as_ref())
+            .expect("malformed EncryptedPrivateKeyDocument")
+    }
+
     /// Parse [`EncryptedPrivateKeyDocument`] from ASN.1 DER-encoded PKCS#8.
     pub fn from_der(bytes: &[u8]) -> Result<Self> {
         bytes.try_into()
@@ -91,20 +105,6 @@ impl EncryptedPrivateKeyDocument {
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn write_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
         write_secret_file(path, self.to_pem().as_bytes())
-    }
-
-    /// Parse the [`EncryptedPrivateKeyInfo`] contained in this [`EncryptedPrivateKeyDocument`].
-    pub fn encrypted_private_key_info(&self) -> EncryptedPrivateKeyInfo<'_> {
-        EncryptedPrivateKeyInfo::try_from(self.0.as_ref())
-            .expect("malformed EncryptedPrivateKeyDocument")
-    }
-
-    /// Attempt to decrypt this encrypted private key using the provided
-    /// password to derive an encryption key.
-    #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
-    pub fn decrypt(&self, password: impl AsRef<[u8]>) -> Result<PrivateKeyDocument> {
-        self.encrypted_private_key_info().decrypt(password)
     }
 }
 

--- a/pkcs8/src/document/public_key.rs
+++ b/pkcs8/src/document/public_key.rs
@@ -24,6 +24,11 @@ use {crate::pem, alloc::string::String, core::str::FromStr};
 pub struct PublicKeyDocument(Vec<u8>);
 
 impl PublicKeyDocument {
+    /// Parse the [`SubjectPublicKeyInfo`] contained in this [`PublicKeyDocument`]
+    pub fn spki(&self) -> SubjectPublicKeyInfo<'_> {
+        SubjectPublicKeyInfo::try_from(self.0.as_slice()).expect("malformed PublicKeyDocument")
+    }
+
     /// Parse [`PublicKeyDocument`] from ASN.1 DER
     pub fn from_der(bytes: &[u8]) -> Result<Self> {
         bytes.try_into()
@@ -81,11 +86,6 @@ impl PublicKeyDocument {
     pub fn write_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
         fs::write(path, self.to_pem().as_bytes())?;
         Ok(())
-    }
-
-    /// Parse the [`SubjectPublicKeyInfo`] contained in this [`PublicKeyDocument`]
-    pub fn spki(&self) -> SubjectPublicKeyInfo<'_> {
-        SubjectPublicKeyInfo::try_from(self.0.as_slice()).expect("malformed PublicKeyDocument")
     }
 }
 

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -10,6 +10,12 @@ use der::{Decodable, Encodable, Message};
 #[cfg(feature = "alloc")]
 use crate::PrivateKeyDocument;
 
+#[cfg(feature = "encryption")]
+use {
+    crate::EncryptedPrivateKeyDocument,
+    rand_core::{CryptoRng, RngCore},
+};
+
 #[cfg(feature = "pem")]
 use {crate::pem, zeroize::Zeroizing};
 
@@ -53,6 +59,18 @@ pub struct PrivateKeyInfo<'a> {
 }
 
 impl<'a> PrivateKeyInfo<'a> {
+    /// Encrypt this private key using a symmetric encryption key derived
+    /// from the provided password.
+    #[cfg(feature = "encryption")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
+    pub fn encrypt(
+        &self,
+        rng: impl CryptoRng + RngCore,
+        password: impl AsRef<[u8]>,
+    ) -> Result<EncryptedPrivateKeyDocument> {
+        PrivateKeyDocument::from(self).encrypt(rng, password)
+    }
+
     /// Encode this [`PrivateKeyInfo`] as ASN.1 DER.
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]

--- a/pkcs8/src/private_key_info/encrypted.rs
+++ b/pkcs8/src/private_key_info/encrypted.rs
@@ -60,16 +60,10 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     #[cfg(feature = "encryption")]
     #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn decrypt(&self, password: impl AsRef<[u8]>) -> Result<PrivateKeyDocument> {
-        let mut buffer = self.encrypted_data.to_vec();
-
-        let pt_len = self
-            .encryption_algorithm
-            .decrypt_in_place(password, &mut buffer)
-            .map_err(|_| Error::Decode)? // TODO(tarcieri): add `pkcs8::Error::Crypto`
-            .len();
-
-        buffer.truncate(pt_len);
-        buffer.try_into()
+        self.encryption_algorithm
+            .decrypt(password, &self.encrypted_data)
+            .map_err(|_| Error::Decode) // TODO(tarcieri): add `pkcs8::Error::Crypto`
+            .and_then(TryInto::try_into)
     }
 
     /// Encode this [`EncryptedPrivateKeyInfo`] as ASN.1 DER.

--- a/pkcs8/tests/encrypted_private_key.rs
+++ b/pkcs8/tests/encrypted_private_key.rs
@@ -6,6 +6,9 @@ use core::convert::TryFrom;
 use hex_literal::hex;
 use pkcs8::{pkcs5::pbes2, EncryptedPrivateKeyInfo};
 
+#[cfg(feature = "encryption")]
+use pkcs8::PrivateKeyDocument;
+
 #[cfg(feature = "pem")]
 use pkcs8::EncryptedPrivateKeyDocument;
 
@@ -125,6 +128,23 @@ fn decrypt_ed25519_der_encpriv_aes256_sha256() {
     let enc_pk = EncryptedPrivateKeyInfo::try_from(ED25519_DER_AES256_SHA256_EXAMPLE).unwrap();
     let pk = enc_pk.decrypt(PASSWORD).unwrap();
     assert_eq!(pk.as_ref(), ED25519_DER_PLAINTEXT_EXAMPLE);
+}
+
+#[cfg(feature = "encryption")]
+#[test]
+fn encrypt_ed25519_der_encpriv_aes256_sha256() {
+    let pbes2_params = pkcs5::pbes2::Parameters::pbkdf2_sha256_aes256cbc(
+        2048,
+        &hex!("79d982e70df91a88"),
+        &hex!("b2d02d78b2efd9dff694cf8e0af40925"),
+    )
+    .unwrap();
+
+    let pk_plaintext = PrivateKeyDocument::try_from(ED25519_DER_PLAINTEXT_EXAMPLE).unwrap();
+    let pk_encrypted = pk_plaintext
+        .encrypt_with_params(pbes2_params, PASSWORD)
+        .unwrap();
+    assert_eq!(pk_encrypted.as_ref(), ED25519_DER_AES256_SHA256_EXAMPLE);
 }
 
 #[test]


### PR DESCRIPTION
Following up on #293 which added PKCS#8 decryption support, this adds the corresponding support for encrypting `PrivateKeyInfo` as `EncryptedPrivateKeyInfo`.

It provides a simple API which generates a random salt and IV using a provided `CryptoRng`, then uses PBES2 with PBKDF2-SHA256 and AES-256-CBC.

It also provides a parameterized `encrypt_with_params` which allows for supplying a `pbes2::Parameters` structure.