### PR TITLE
pkcs8 v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.3 (2021-02-23)
+### Added
+- Support for decrypting/encrypting `EncryptedPrivateKeyInfo` ([#293], [#302])
+- PEM support for `EncryptedPrivateKeyInfo` ([#301])
+- `Error::Crypto` variant ([#305])
+
+[#293]: https://github.com/RustCrypto/utils/pull/293
+[#301]: https://github.com/RustCrypto/utils/pull/301
+[#302]: https://github.com/RustCrypto/utils/pull/302
+[#305]: https://github.com/RustCrypto/utils/pull/305
+
 ## 0.5.2 (2021-02-20)
 ### Changed
 - Use `pkcs5` crate ([#290])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.5.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 repository = "https://github.com/RustCrypto/utils/tree/master/pkcs8"
 categories = ["cryptography", "data-structures", "encoding", "no-std"]
-keywords = ["crypto", "key", "private"]
+keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 
 [dependencies]
@@ -19,7 +19,7 @@ spki = { version = "0.2", path = "../spki" }
 
 base64ct = { version = "0.2", optional = true, features = ["alloc"], path = "../base64ct" }
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "0.1", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "0.1.1", optional = true, path = "../pkcs5" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -59,7 +59,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.5.2"
+    html_root_url = "https://docs.rs/pkcs8/0.5.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Support for decrypting/encrypting `EncryptedPrivateKeyInfo` ([#293], [#302])
- PEM support for `EncryptedPrivateKeyInfo` ([#301])
- `Error::Crypto` variant (#305)

[#293]: https://github.com/RustCrypto/utils/pull/293
[#301]: https://github.com/RustCrypto/utils/pull/301
[#302]: https://github.com/RustCrypto/utils/pull/302