### PR TITLE
pkcs8: add Error::Crypto variant

### DIFF
--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -112,7 +112,7 @@ impl PrivateKeyDocument {
         let pbkdf2_iterations = 10_000;
         let pbes2_params =
             pbes2::Parameters::pbkdf2_sha256_aes256cbc(pbkdf2_iterations, &salt, &iv)
-                .map_err(|_| Error::Encode)?; // TODO(tarcieri): add `pkcs8::Error::Crypto`
+                .map_err(|_| Error::Crypto)?;
 
         self.encrypt_with_params(pbes2_params, password)
     }

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -13,6 +13,9 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
+    /// Cryptographic errors
+    Crypto,
+
     /// Decoding errors
     Decode,
 
@@ -38,6 +41,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Error::Crypto => f.write_str("PKCS#8 cryptographic error"),
             Error::Decode => f.write_str("PKCS#8 decoding error"),
             Error::Encode => f.write_str("PKCS#8 encoding error"),
             #[cfg(feature = "std")]

--- a/pkcs8/src/private_key_info/encrypted.rs
+++ b/pkcs8/src/private_key_info/encrypted.rs
@@ -62,7 +62,7 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     pub fn decrypt(&self, password: impl AsRef<[u8]>) -> Result<PrivateKeyDocument> {
         self.encryption_algorithm
             .decrypt(password, &self.encrypted_data)
-            .map_err(|_| Error::Decode) // TODO(tarcieri): add `pkcs8::Error::Crypto`
+            .map_err(|_| Error::Crypto)
             .and_then(TryInto::try_into)
     }
 


### PR DESCRIPTION
The `Error` enum is `non_exhaustive` so this is non-breaking