### PR TITLE
der v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.9 (2021-02-24)
+### Added
+- Support for `IA5String` ([#310])
+
+[#310]: https://github.com/RustCrypto/utils/pull/310
+
 ## 0.2.8 (2021-02-22)
 ### Added
 - `Choice` trait ([#295])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.2.8" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.9" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -326,7 +326,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.2.8"
+    html_root_url = "https://docs.rs/der/0.2.9"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Support for `IA5String` ([#310])

[#310]: https://github.com/RustCrypto/utils/pull/310