### PR TITLE
const-oid v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.3 (2021-02-24)
+### Added
+- Const-friendly OID string parser ([#312])
+
+[#312]: https://github.com/RustCrypto/utils/pull/312
+
 ## 0.4.2 (2021-02-19)
 ### Fixed
 - Bug in root arc calculation ([#284])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -40,7 +40,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.4.2"
+    html_root_url = "https://docs.rs/const-oid/0.4.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Const-friendly OID string parser ([#312])

[#312]: https://github.com/RustCrypto/utils/pull/312