### PR TITLE
pkcs5: use const `ObjectIdentifier::parse`

### DIFF
--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 
 [dependencies]
-const-oid = { version = "0.4", optional = true, path = "../const-oid" }
+const-oid = { version = "0.4.3", optional = true, path = "../const-oid" }
 der_derive = { version = "0.2", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -34,7 +34,7 @@ impl<'a> Tagged for ObjectIdentifier {
 mod tests {
     use crate::{Decodable, Encodable, ObjectIdentifier};
 
-    const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 113549]);
+    const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549");
     const EXAMPLE_OID_BYTES: &[u8; 8] = &[0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d];
 
     #[test]

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -8,27 +8,27 @@ use der::{sequence, Any, Encodable, Encoder, ErrorKind, Header, Length, OctetStr
 
 /// `pbeWithMD2AndDES-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD2_AND_DES_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 1]);
+    ObjectIdentifier::parse("1.2.840.113549.1.5.1");
 
 /// `pbeWithMD2AndRC2-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD2_AND_RC2_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 4]);
+    ObjectIdentifier::parse("1.2.840.113549.1.5.4");
 
 /// `pbeWithMD5AndDES-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD5_AND_DES_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 3]);
+    ObjectIdentifier::parse("1.2.840.113549.1.5.3");
 
 /// `pbeWithMD5AndRC2-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD5_AND_RC2_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 6]);
+    ObjectIdentifier::parse("1.2.840.113549.1.5.6");
 
 /// `pbeWithSHA1AndDES-CBC` Object Identifier (OID).
 pub const PBE_WITH_SHA1_AND_DES_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 10]);
+    ObjectIdentifier::parse("1.2.840.113549.1.5.10");
 
 /// `pbeWithSHA1AndRC2-CBC` Object Identifier (OID).
 pub const PBE_WITH_SHA1_AND_RC2_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 11]);
+    ObjectIdentifier::parse("1.2.840.113549.1.5.11");
 
 /// Length of a PBES1 salt (as defined in the `PBEParameter` ASN.1 message).
 pub const SALT_LENGTH: usize = 8;

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -16,27 +16,24 @@ use alloc::vec::Vec;
 /// Password-Based Encryption Scheme 2 (PBES2) OID.
 ///
 /// <https://tools.ietf.org/html/rfc8018#section-6.2>
-pub const PBES2_OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 13]);
+pub const PBES2_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.1.5.13");
 
 /// Password-Based Key Derivation Function (PBKDF2) OID.
-pub const PBKDF2_OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 113549, 1, 5, 12]);
+pub const PBKDF2_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.1.5.12");
 
 /// HMAC-SHA1 (for use with PBKDF2)
-pub const HMAC_WITH_SHA1_OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 113549, 2, 7]);
+pub const HMAC_WITH_SHA1_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.2.7");
 
 /// HMAC-SHA-256 (for use with PBKDF2)
-pub const HMAC_WITH_SHA256_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[1, 2, 840, 113549, 2, 9]);
+pub const HMAC_WITH_SHA256_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.2.9");
 
 /// 128-bit Advanced Encryption Standard (AES) algorithm with Cipher-Block
 /// Chaining (CBC) mode of operation.
-pub const AES_128_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[2, 16, 840, 1, 101, 3, 4, 1, 2]);
+pub const AES_128_CBC_OID: ObjectIdentifier = ObjectIdentifier::parse("2.16.840.1.101.3.4.1.2");
 
 /// 256-bit Advanced Encryption Standard (AES) algorithm with Cipher-Block
 /// Chaining (CBC) mode of operation.
-pub const AES_256_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::new(&[2, 16, 840, 1, 101, 3, 4, 1, 42]);
+pub const AES_256_CBC_OID: ObjectIdentifier = ObjectIdentifier::parse("2.16.840.1.101.3.4.1.42");
 
 /// AES cipher block size
 const AES_BLOCK_SIZE: usize = 16;


### PR DESCRIPTION
Uses the new const-friendly OID string parser for all OID literals.