### PR TITLE
const-oid: extract `macros` module

### DIFF
--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -52,6 +52,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[macro_use]
+mod macros;
+
 mod error;
 mod parser;
 
@@ -108,15 +111,6 @@ pub struct ObjectIdentifier {
     /// Additional "lower" arcs beyond the first and second arcs
     /// (the latter are stored as [`RootArcs`]).
     lower_arcs: LowerArcs,
-}
-
-/// Constant panicking assertion.
-// TODO(tarcieri): use const panic when stable.
-// See: https://github.com/rust-lang/rust/issues/51999
-macro_rules! const_assert {
-    ($bool:expr, $msg:expr) => {
-        [$msg][!$bool as usize]
-    };
 }
 
 #[allow(clippy::len_without_is_empty)]

--- a/const-oid/src/macros.rs
+++ b/const-oid/src/macros.rs
@@ -1,0 +1,10 @@
+//! Macro definitions
+
+/// Constant panicking assertion.
+// TODO(tarcieri): use const panic when stable.
+// See: https://github.com/rust-lang/rust/issues/51999
+macro_rules! const_assert {
+    ($bool:expr, $msg:expr) => {
+        [$msg][!$bool as usize]
+    };
+}

--- a/const-oid/src/parser.rs
+++ b/const-oid/src/parser.rs
@@ -1,13 +1,6 @@
-use crate::{Arc, ObjectIdentifier, MAX_ARCS};
+//! OID parser with `const` support
 
-/// Constant panicking assertion.
-// TODO(tarcieri): use const panic when stable.
-// See: https://github.com/rust-lang/rust/issues/51999
-macro_rules! const_assert {
-    ($bool:expr, $msg:expr) => {
-        [$msg][!$bool as usize]
-    };
-}
+use crate::{Arc, ObjectIdentifier, MAX_ARCS};
 
 /// Const-friendly OID parser.
 ///


### PR DESCRIPTION
Avoids duplication of the `const_assert!` macro