### PR TITLE
const-oid: change internal repr to BER/DER w\ const encoder

### DIFF
--- a/const-oid/src/arcs.rs
+++ b/const-oid/src/arcs.rs
@@ -1,0 +1,126 @@
+//! Arcs are integer values which exist within an OID's hierarchy.
+
+use crate::{Error, ObjectIdentifier, Result};
+use core::convert::TryFrom;
+
+/// Type used to represent an "arc" (i.e. integer identifier value)
+pub type Arc = u32;
+
+/// Maximum value of the first arc in an OID
+pub(crate) const FIRST_ARC_MAX: Arc = 2;
+
+/// Maximum value of the second arc in an OID
+pub(crate) const SECOND_ARC_MAX: Arc = 39;
+
+/// [`Iterator`] over arcs (a.k.a. nodes) in an [`ObjectIdentifier`].
+///
+/// This iterates over all arcs in an OID, including the root.
+pub struct Arcs<'a> {
+    /// OID we're iterating over
+    oid: &'a ObjectIdentifier,
+
+    /// Current position within the serialized DER bytes of this OID
+    cursor: Option<usize>,
+}
+
+impl<'a> Arcs<'a> {
+    /// Create a new iterator over the arcs of this OID
+    pub(crate) fn new(oid: &'a ObjectIdentifier) -> Self {
+        Self { oid, cursor: None }
+    }
+}
+
+impl<'a> Iterator for Arcs<'a> {
+    type Item = Arc;
+
+    fn next(&mut self) -> Option<Arc> {
+        match self.cursor {
+            // Indicates we're on the root OID
+            None => {
+                let root = RootArcs(self.oid.as_bytes()[0]);
+                self.cursor = Some(0);
+                Some(root.first_arc())
+            }
+            Some(0) => {
+                let root = RootArcs(self.oid.as_bytes()[0]);
+                self.cursor = Some(1);
+                Some(root.second_arc())
+            }
+            Some(offset) => {
+                let mut result = 0;
+                let mut arc_bytes = 0;
+
+                // TODO(tarcieri): consolidate this with `ObjectIdentifier::from_ber`?
+                loop {
+                    match self.oid.as_bytes().get(offset + arc_bytes).cloned() {
+                        Some(byte) => {
+                            arc_bytes += 1;
+                            assert!(
+                                arc_bytes < 4 || byte & 0b11110000 == 0,
+                                "OID arc overflowed"
+                            );
+                            result = result << 7 | (byte & 0b1111111) as Arc;
+
+                            if byte & 0b10000000 == 0 {
+                                self.cursor = Some(offset + arc_bytes);
+                                return Some(result);
+                            }
+                        }
+                        None => {
+                            assert_eq!(arc_bytes, 0, "truncated OID");
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Byte containing the first and second arcs of an OID.
+///
+/// This is represented this way in order to reduce the overall size of the
+/// [`ObjectIdentifier`] struct.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RootArcs(u8);
+
+impl RootArcs {
+    /// Create [`RootArcs`] from the first and second arc values represented
+    /// as `Arc` integers.
+    pub(crate) fn new(first_arc: Arc, second_arc: Arc) -> Result<Self> {
+        if first_arc > FIRST_ARC_MAX || second_arc > SECOND_ARC_MAX {
+            return Err(Error);
+        }
+
+        let byte = (first_arc * (SECOND_ARC_MAX + 1)) as u8 + second_arc as u8;
+        Ok(Self(byte))
+    }
+
+    /// Get the value of the first arc
+    pub(crate) fn first_arc(self) -> Arc {
+        self.0 as Arc / (SECOND_ARC_MAX + 1)
+    }
+
+    /// Get the value of the second arc
+    pub(crate) fn second_arc(self) -> Arc {
+        self.0 as Arc % (SECOND_ARC_MAX + 1)
+    }
+}
+
+impl TryFrom<u8> for RootArcs {
+    type Error = Error;
+
+    fn try_from(octet: u8) -> Result<Self> {
+        let first = octet as Arc / (SECOND_ARC_MAX + 1);
+        let second = octet as Arc % (SECOND_ARC_MAX + 1);
+        let result = Self::new(first, second)?;
+        debug_assert_eq!(octet, result.0);
+        Ok(result)
+    }
+}
+
+impl From<RootArcs> for u8 {
+    fn from(root_arcs: RootArcs) -> u8 {
+        root_arcs.0
+    }
+}

--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -1,0 +1,163 @@
+//! OID encoder with `const` support.
+
+use crate::{
+    arcs::{FIRST_ARC_MAX, SECOND_ARC_MAX},
+    Arc, Error, ObjectIdentifier, Result, MAX_LEN,
+};
+
+/// BER/DER encoder
+pub(crate) struct Encoder {
+    /// Current state
+    state: State,
+
+    /// Bytes of the OID being encoded in-progress
+    bytes: [u8; MAX_LEN],
+
+    /// Current position within the byte buffer
+    cursor: usize,
+}
+
+/// Current state of the encoder
+enum State {
+    /// Initial state - no arcs yet encoded
+    Initial,
+
+    /// First arc parsed
+    FirstArc(Arc),
+
+    /// Encoding base 128 body of the OID
+    Body,
+}
+
+impl Encoder {
+    /// Create a new encoder initialized to an empty default state
+    pub(crate) const fn new() -> Self {
+        Self {
+            state: State::Initial,
+            bytes: [0u8; MAX_LEN],
+            cursor: 0,
+        }
+    }
+
+    /// Encode an [`Arc`] as base 128 into the internal buffer
+    pub(crate) const fn encode(mut self, arc: Arc) -> Self {
+        match self.state {
+            State::Initial => {
+                const_assert!(arc <= FIRST_ARC_MAX, "invalid first arc (must be 0-2)");
+                self.state = State::FirstArc(arc);
+                self
+            }
+            State::FirstArc(first_arc) => {
+                const_assert!(arc <= SECOND_ARC_MAX, "invalid second arc (must be 0-39)");
+                self.state = State::Body;
+                self.bytes[0] = (first_arc * (SECOND_ARC_MAX + 1)) as u8 + arc as u8;
+                self.cursor = 1;
+                self
+            }
+            State::Body => {
+                // Total number of bytes in encoded arc - 1
+                let nbytes = base128_len(arc);
+
+                const_assert!(
+                    self.cursor + nbytes + 1 < MAX_LEN,
+                    "OID too long (exceeded max DER bytes)"
+                );
+                let new_cursor = self.cursor + nbytes + 1;
+
+                let mut result = self.encode_base128_byte(arc, nbytes, false);
+                result.cursor = new_cursor;
+                result
+            }
+        }
+    }
+
+    /// Finish encoding an OID
+    pub(crate) const fn finish(self) -> ObjectIdentifier {
+        const_assert!(self.cursor >= 2, "OID too short (minimum 3 arcs)");
+        ObjectIdentifier {
+            bytes: self.bytes,
+            length: self.cursor as u8,
+        }
+    }
+
+    /// Encode a single byte of a base128 value
+    const fn encode_base128_byte(mut self, mut n: u32, i: usize, continued: bool) -> Self {
+        let mask = if continued { 0b10000000 } else { 0 };
+
+        if n > 0x80 {
+            self.bytes[self.cursor + i] = (n & 0b1111111) as u8 | mask;
+            n >>= 7;
+
+            const_assert!(i > 0, "Base 128 offset miscalculation");
+            self.encode_base128_byte(n, index_sub(i), true)
+        } else {
+            self.bytes[self.cursor] = n as u8 | mask;
+            self
+        }
+    }
+}
+
+// TODO(tarcieri): replace this with `saturating_sub` when MSRV is 1.47+
+const fn index_sub(index: usize) -> usize {
+    match index {
+        4 => 3,
+        3 => 2,
+        2 => 1,
+        1 => 0,
+        _ => {
+            const_assert!(index <= 4, "index too large");
+            0
+        }
+    }
+}
+
+/// Compute the length - 1 of an arc when encoded in base 128
+const fn base128_len(arc: Arc) -> usize {
+    match arc {
+        0..=0x7f => 0,
+        0x80..=0x3fff => 1,
+        0x4000..=0x1fffff => 2,
+        0x200000..=0x1fffffff => 3,
+        _ => 4,
+    }
+}
+
+/// Write the given unsigned integer in base 128
+// TODO(tarcieri): consolidate encoding logic with `encode_base128_byte`
+pub(crate) fn write_base128(bytes: &mut [u8], mut n: Arc) -> Result<usize> {
+    let nbytes = base128_len(n);
+    let mut i = nbytes;
+    let mut mask = 0;
+
+    while n > 0x80 {
+        let byte = bytes.get_mut(i).ok_or(Error)?;
+        *byte = (n & 0b1111111 | mask) as u8;
+        n >>= 7;
+        i = i.checked_sub(1).unwrap();
+        mask = 0b10000000;
+    }
+
+    *bytes.get_mut(0).unwrap() = (n | mask) as u8;
+    Ok(nbytes + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Encoder;
+    use hex_literal::hex;
+
+    /// OID `1.2.840.10045.2.1` encoded as ASN.1 BER/DER
+    const EXAMPLE_OID_BER: &[u8] = &hex!("2A8648CE3D0201");
+
+    #[test]
+    fn encode() {
+        let encoder = Encoder::new();
+        let encoder = encoder.encode(1);
+        let encoder = encoder.encode(2);
+        let encoder = encoder.encode(840);
+        let encoder = encoder.encode(10045);
+        let encoder = encoder.encode(2);
+        let encoder = encoder.encode(1);
+        assert_eq!(&encoder.bytes[..encoder.cursor], EXAMPLE_OID_BER);
+    }
+}

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -20,11 +20,8 @@
 //!
 //! # Limits
 //!
-//! This library stores OIDs using a compact fixed-size layout and enforces
-//! the following constraints on the number of arcs:
-//!
-//! - Minimum number of arcs: **3** (i.e. [`MIN_ARCS`])
-//! - Maximum number of arcs: **12** (i.e. [`MAX_ARCS`])
+//! The BER/DER encoding of OIDs supported by this library MUST be shorter than
+//! the [`MAX_LEN`] constant.
 //!
 //! # Minimum Supported Rust Version
 //!
@@ -46,7 +43,6 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "alloc")]
-#[macro_use]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -55,19 +51,18 @@ extern crate std;
 #[macro_use]
 mod macros;
 
+mod arcs;
+mod encoder;
 mod error;
 mod parser;
 
-pub use crate::error::{Error, Result};
-
-use core::{
-    convert::TryFrom,
-    fmt,
-    str::{FromStr, Split},
+pub use crate::{
+    arcs::{Arc, Arcs},
+    error::{Error, Result},
 };
 
-/// Type used to represent an "arc" (i.e. integer identifier value)
-pub type Arc = u32;
+use crate::arcs::RootArcs;
+use core::{convert::TryFrom, fmt, str::FromStr};
 
 /// Minimum number of arcs in an OID.
 ///
@@ -75,28 +70,11 @@ pub type Arc = u32;
 pub const MIN_ARCS: usize = 3;
 
 /// Maximum number of arcs in an OID.
-///
-/// Note: this limit is not defined in OID standards, but instead represents an
-/// internal size constraint of this library determined as an upper bound for
-/// this library's intended use cases (i.e. [RustCrypto projects][1]).
-///
-/// It can potentially be raised as part of a breaking release if there is a
-/// legitimate use case. If you have such a use case for increasing this limit
-/// in practice, please [file a GitHub issue][2].
-///
-/// [1]: https://github.com/RustCrypto/
-/// [2]: https://github.com/RustCrypto/utils/issues
+#[deprecated(since = "0.4.4", note = "Please use the `MAX_LEN` instead")]
 pub const MAX_ARCS: usize = 12;
 
-/// Maximum number of "lower" arcs, which does not include the first and second
-/// arcs, which are stored as [`RootArcs`].
-const MAX_LOWER_ARCS: usize = MAX_ARCS - 2;
-
-/// Maximum value of the first arc in an OID
-const FIRST_ARC_MAX: Arc = 2;
-
-/// Maximum value of the second arc in an OID
-const SECOND_ARC_MAX: Arc = 39;
+/// Maximum length of a DER-encoded OID in bytes.
+pub const MAX_LEN: usize = 23;
 
 /// Object identifier (OID).
 ///
@@ -104,13 +82,11 @@ const SECOND_ARC_MAX: Arc = 39;
 /// identifiers.
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ObjectIdentifier {
-    /// Byte containing the first and second arcs of this OID, stored
-    /// separately from the others to minimize this type's size.
-    root_arcs: RootArcs,
+    /// Array containing BER/DER-serialized bytes (no header)
+    bytes: [u8; MAX_LEN],
 
-    /// Additional "lower" arcs beyond the first and second arcs
-    /// (the latter are stored as [`RootArcs`]).
-    lower_arcs: LowerArcs,
+    /// Length in bytes
+    length: u8,
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -135,87 +111,27 @@ impl ObjectIdentifier {
     /// In order for an OID to be valid, it must meet the following criteria:
     ///
     /// - The OID MUST have at least 3 arcs
-    /// - The OID MUST NOT have more arcs than the [`MAX_ARCS`] constant
     /// - The first arc MUST be within the range 0-2
     /// - The second arc MUST be within the range 0-39
+    /// - The BER/DER encoding of the OID MUST be shorter than the [`MAX_LEN`] constant
     ///
     /// [1]: ./struct.ObjectIdentifier.html#impl-TryFrom%3C%26%27_%20%5BArc%5D%3E
     pub const fn new(arcs: &[Arc]) -> Self {
         const_assert!(arcs.len() >= MIN_ARCS, "OID too short (minimum 3 arcs)");
-        const_assert!(
-            arcs.len() <= MAX_ARCS,
-            "OID too long (too may arcs; internal limit reached)"
-        );
+        let mut encoder = encoder::Encoder::new();
 
-        let first_arc = arcs[0];
-        const_assert!(
-            first_arc <= FIRST_ARC_MAX,
-            "invalid first arc (must be 0-2)"
-        );
-
-        let second_arc = arcs[1];
-        const_assert!(
-            second_arc <= SECOND_ARC_MAX,
-            "invalid second arc (must be 0-39)"
-        );
-
-        let root_arcs = RootArcs((first_arc * (SECOND_ARC_MAX + 1)) as u8 + second_arc as u8);
-
-        // TODO(tarcieri): use `const_mut_ref` when stable.
-        // See: <https://github.com/rust-lang/rust/issues/57349>
-        #[rustfmt::skip]
-        let lower_arcs = match arcs.len() {
-            3 => [
-                arcs[2], 0, 0, 0, 0,
-                0, 0, 0, 0, 0
-            ],
-            4 => [
-                arcs[2], arcs[3], 0, 0, 0,
-                0, 0, 0, 0, 0
-            ],
-            5 => [
-                arcs[2], arcs[3], arcs[4], 0, 0,
-                0, 0, 0, 0, 0
-            ],
-            6 => [
-                arcs[2], arcs[3], arcs[4], arcs[5], 0,
-                0, 0, 0, 0, 0
-            ],
-            7 => [
-                arcs[2], arcs[3], arcs[4], arcs[5], arcs[6],
-                0, 0, 0, 0, 0,
-            ],
-            8 => [
-                arcs[2], arcs[3], arcs[4], arcs[5], arcs[6],
-                arcs[7], 0, 0, 0, 0,
-            ],
-            9 => [
-                arcs[2], arcs[3], arcs[4], arcs[5], arcs[6],
-                arcs[7], arcs[8], 0, 0, 0,
-            ],
-            10 => [
-                arcs[2], arcs[3], arcs[4], arcs[5], arcs[6],
-                arcs[7], arcs[8], arcs[9], 0, 0,
-            ],
-            11 => [
-                arcs[2], arcs[3], arcs[4], arcs[5], arcs[6],
-                arcs[7], arcs[8], arcs[9], arcs[10], 0,
-            ],
-            12 => [
-                arcs[2], arcs[3], arcs[4], arcs[5], arcs[6],
-                arcs[7], arcs[8], arcs[9], arcs[10], arcs[11],
-            ],
-            _ => [0; MAX_LOWER_ARCS], // Checks above prevent this case, but makes Miri happy
-        };
-
-        // TODO(tarcieri): use `LowerArcs::new` when `const fn`-friendly
-        Self {
-            root_arcs,
-            lower_arcs: LowerArcs {
-                length: (arcs.len() - 2) as u8,
-                arcs: lower_arcs,
-            },
+        macro_rules! encode_arc {
+            ($($n:expr),+) => {
+                $(
+                    if arcs.len() > $n {
+                        encoder = encoder.encode(arcs[$n]);
+                    }
+                )+
+             };
         }
+
+        encode_arc!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+        encoder.finish()
     }
 
     /// Parse an [`ObjectIdentifier`] from the dot-delimited string form, e.g.:
@@ -234,92 +150,142 @@ impl ObjectIdentifier {
     /// will panic with a bad error message. However, this type also has a
     /// [`FromStr`] impl that can be used for fallible parsing.
     pub const fn parse(s: &str) -> Self {
-        parser::Parser::parse(s).result()
+        parser::Parser::parse(s).finish()
+    }
+
+    /// Get the BER/DER serialization of this OID as bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.length as usize]
     }
 
     /// Return the arc with the given index, if it exists.
     pub fn arc(&self, index: usize) -> Option<Arc> {
-        match index {
-            0 => Some(self.root_arcs.first_arc()),
-            1 => Some(self.root_arcs.second_arc()),
-            n => self.lower_arcs.as_ref().get(n - 2).cloned(),
-        }
+        self.arcs().nth(index)
     }
 
     /// Iterate over the arcs (a.k.a. nodes) in an [`ObjectIdentifier`].
     ///
     /// Returns [`Arcs`], an iterator over `Arc` values representing the value
     /// of each arc/node.
-    pub fn arcs(&self) -> Arcs {
-        Arcs {
-            oid: *self,
-            index: 0,
-        }
+    pub fn arcs(&self) -> Arcs<'_> {
+        Arcs::new(self)
     }
 
     /// Number of arcs in this [`ObjectIdentifier`].
     pub fn len(&self) -> usize {
-        2 + self.lower_arcs.len()
+        self.arcs().count()
     }
 
     /// Parse an OID from from its BER/DER encoding.
-    pub fn from_ber(mut bytes: &[u8]) -> Result<Self> {
-        let root_arcs = parse_byte(&mut bytes).and_then(RootArcs::try_from)?;
-        let lower_arcs = LowerArcs::from_ber(bytes)?;
+    pub fn from_ber(ber_bytes: &[u8]) -> Result<Self> {
+        let len = ber_bytes.len();
+
+        if !(2..=MAX_LEN).contains(&len) {
+            return Err(Error);
+        }
+
+        // Validate root arcs are in range
+        ber_bytes
+            .get(0)
+            .cloned()
+            .ok_or(Error)
+            .and_then(RootArcs::try_from)?;
+
+        // Validate lower arcs are well-formed
+        let mut arc_offset = 1;
+        let mut arc_bytes = 0;
+
+        // TODO(tarcieri): consolidate this with `Arcs::next`?
+        while arc_offset < len {
+            match ber_bytes.get(arc_offset + arc_bytes).cloned() {
+                Some(byte) => {
+                    arc_bytes += 1;
+
+                    if arc_bytes == 4 && byte & 0b11110000 != 0 {
+                        // Overflowed `Arc` (u32)
+                        return Err(Error);
+                    }
+
+                    if byte & 0b10000000 == 0 {
+                        arc_offset += arc_bytes;
+                        arc_bytes = 0;
+                    }
+                }
+                None => return Err(Error), // truncated OID
+            }
+        }
+
+        let mut bytes = [0u8; MAX_LEN];
+        bytes[..len].copy_from_slice(ber_bytes);
 
         Ok(Self {
-            root_arcs,
-            lower_arcs,
+            bytes,
+            length: len as u8,
         })
     }
 
     /// Get the length of this OID when serialized as ASN.1 BER.
+    #[deprecated(since = "0.4.4", note = "Please use the `as_bytes()` function instead")]
     pub fn ber_len(&self) -> usize {
-        // 1-byte from serialized `RootArcs`
-        1 + self.lower_arcs.ber_len()
+        self.as_bytes().len()
     }
 
     /// Write the BER encoding of this OID into the given slice, returning
     /// a new slice containing the written data.
+    #[deprecated(since = "0.4.4", note = "Please use the `as_bytes()` function instead")]
     pub fn write_ber<'a>(&self, bytes: &'a mut [u8]) -> Result<&'a [u8]> {
-        if bytes.is_empty() {
+        let len = self.as_bytes().len();
+
+        if bytes.len() < len {
             return Err(Error);
         }
 
-        bytes[0] = self.root_arcs.into();
-        let mut offset = 1;
-
-        for &arc in self.lower_arcs.as_ref() {
-            offset += write_base128(&mut bytes[offset..], arc)?;
-        }
-
-        Ok(&bytes[..offset])
+        bytes[..len].copy_from_slice(self.as_bytes());
+        Ok(&bytes[..len])
     }
 
     /// Serialize this OID as ASN.1 BER.
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[deprecated(since = "0.4.4", note = "Please use the `as_bytes()` function instead")]
     pub fn to_ber(&self) -> alloc::vec::Vec<u8> {
-        let mut output = vec![0u8; self.ber_len()];
-        self.write_ber(&mut output).expect("bad buffer size");
-        output
+        self.as_bytes().to_vec()
+    }
+}
+
+impl AsRef<[u8]> for ObjectIdentifier {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
     }
 }
 
 impl FromStr for ObjectIdentifier {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self> {
-        let mut split = s.split('.');
+    fn from_str(string: &str) -> Result<Self> {
+        let mut split = string.split('.');
         let first_arc = split.next().and_then(|s| s.parse().ok()).ok_or(Error)?;
         let second_arc = split.next().and_then(|s| s.parse().ok()).ok_or(Error)?;
-        let root_arcs = RootArcs::new(first_arc, second_arc)?;
-        let lower_arcs = LowerArcs::from_split(&mut split)?;
 
-        Ok(Self {
-            root_arcs,
-            lower_arcs,
-        })
+        let mut bytes = [0u8; MAX_LEN];
+        bytes[0] = RootArcs::new(first_arc, second_arc)?.into();
+
+        let mut offset = 1;
+
+        for s in split {
+            let arc = s.parse().map_err(|_| Error)?;
+            offset += encoder::write_base128(&mut bytes[offset..], arc)?;
+        }
+
+        if offset > 1 {
+            Ok(Self {
+                bytes,
+                length: offset as u8,
+            })
+        } else {
+            // Minimum 3 arcs
+            Err(Error)
+        }
     }
 }
 
@@ -327,16 +293,22 @@ impl TryFrom<&[Arc]> for ObjectIdentifier {
     type Error = Error;
 
     fn try_from(arcs: &[Arc]) -> Result<Self> {
-        if arcs.len() < MIN_ARCS || arcs.len() > MAX_ARCS {
+        if arcs.len() < MIN_ARCS {
             return Err(Error);
         }
 
-        let root_arcs = RootArcs::new(arcs[0], arcs[1])?;
-        let lower_arcs = LowerArcs::try_from(&arcs[2..])?;
+        let mut bytes = [0u8; MAX_LEN];
+        bytes[0] = RootArcs::new(arcs[0], arcs[1])?.into();
+
+        let mut offset = 1;
+
+        for &arc in &arcs[2..] {
+            offset += encoder::write_base128(&mut bytes[offset..], arc)?;
+        }
 
         Ok(Self {
-            root_arcs,
-            lower_arcs,
+            bytes,
+            length: offset as u8,
         })
     }
 }
@@ -355,229 +327,16 @@ impl fmt::Debug for ObjectIdentifier {
 
 impl fmt::Display for ObjectIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.len();
+
         for (i, arc) in self.arcs().enumerate() {
             write!(f, "{}", arc)?;
 
-            if i < self.len() - 1 {
+            if i < len - 1 {
                 write!(f, ".")?;
             }
         }
 
         Ok(())
-    }
-}
-
-/// [`Iterator`] over arcs (a.k.a. nodes) in an [`ObjectIdentifier`].
-///
-/// This iterates over all arcs in an OID, including the root.
-pub struct Arcs {
-    /// OID we're iterating over
-    oid: ObjectIdentifier,
-
-    /// Current arc
-    index: usize,
-}
-
-impl Iterator for Arcs {
-    type Item = Arc;
-
-    fn next(&mut self) -> Option<Arc> {
-        let arc = self.oid.arc(self.index)?;
-        self.index = self.index.checked_add(1).unwrap();
-        Some(arc)
-    }
-}
-
-/// Byte containing the first and second arcs of an OID.
-///
-/// This is represented this way in order to reduce the overall size of the
-/// [`ObjectIdentifier`] struct.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-struct RootArcs(u8);
-
-impl RootArcs {
-    /// Create [`RootArcs`] from the first and second arc values represented
-    /// as `Arc` integers.
-    fn new(first_arc: Arc, second_arc: Arc) -> Result<Self> {
-        if first_arc > FIRST_ARC_MAX || second_arc > SECOND_ARC_MAX {
-            return Err(Error);
-        }
-
-        let byte = (first_arc * (SECOND_ARC_MAX + 1)) as u8 + second_arc as u8;
-        Ok(Self(byte))
-    }
-
-    /// Get the value of the first arc
-    fn first_arc(self) -> Arc {
-        self.0 as Arc / (SECOND_ARC_MAX + 1)
-    }
-
-    /// Get the value of the second arc
-    fn second_arc(self) -> Arc {
-        self.0 as Arc % (SECOND_ARC_MAX + 1)
-    }
-}
-
-impl TryFrom<u8> for RootArcs {
-    type Error = Error;
-
-    fn try_from(octet: u8) -> Result<Self> {
-        let first = octet as Arc / (SECOND_ARC_MAX + 1);
-        let second = octet as Arc % (SECOND_ARC_MAX + 1);
-        let result = Self::new(first, second)?;
-        debug_assert_eq!(octet, result.0);
-        Ok(result)
-    }
-}
-
-impl From<RootArcs> for u8 {
-    fn from(root_arcs: RootArcs) -> u8 {
-        root_arcs.0
-    }
-}
-
-/// "Lower" arcs beyond the first and second arcs in an OID.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-struct LowerArcs {
-    /// Number of additional "lower" arcs.
-    length: u8,
-
-    /// "Lower" arc values.
-    arcs: [Arc; MAX_LOWER_ARCS],
-}
-
-impl LowerArcs {
-    /// Create new [`LowerArcs`] from an array and length, validating length
-    /// is in range (1..MAX_LOWER_ARCS)
-    fn new(arcs: [Arc; MAX_LOWER_ARCS], length: usize) -> Result<Self> {
-        if length > 0 && length < MAX_LOWER_ARCS {
-            Ok(Self {
-                arcs,
-                length: length as u8,
-            })
-        } else {
-            Err(Error)
-        }
-    }
-
-    /// Parse [`LowerArcs`] from ASN.1 BER.
-    fn from_ber(mut bytes: &[u8]) -> Result<Self> {
-        let mut arcs = [Arc::default(); MAX_LOWER_ARCS];
-        let mut index = 0;
-
-        while !bytes.is_empty() {
-            let byte = arcs.get_mut(index).ok_or(Error)?;
-            *byte = parse_base128(&mut bytes)?;
-            index = index.checked_add(1).unwrap();
-        }
-
-        Self::new(arcs, index)
-    }
-
-    /// Helper for parsing [`LowerArcs`] from a string
-    fn from_split(split: &mut Split<'_, char>) -> Result<Self> {
-        let mut arcs = [Arc::default(); MAX_LOWER_ARCS];
-        let mut length = 0;
-
-        for (i, n) in split.enumerate() {
-            let arc = arcs.get_mut(i).ok_or(Error)?;
-            *arc = n.parse().map_err(|_| Error)?;
-            length += 1;
-        }
-
-        Self::new(arcs, length)
-    }
-
-    /// Get the number of lower arcs
-    pub fn len(&self) -> usize {
-        self.length as usize
-    }
-
-    /// Get the length of the lower arcs when serialized as ASN.1 BER.
-    pub fn ber_len(&self) -> usize {
-        self.as_ref().iter().fold(0, |sum, n| sum + base128_len(*n))
-    }
-}
-
-impl AsRef<[Arc]> for LowerArcs {
-    fn as_ref(&self) -> &[Arc] {
-        &self.arcs[..self.len()]
-    }
-}
-
-impl TryFrom<&[Arc]> for LowerArcs {
-    type Error = Error;
-
-    fn try_from(arcs: &[Arc]) -> Result<Self> {
-        if arcs.len() > MAX_LOWER_ARCS {
-            return Err(Error);
-        }
-
-        let mut lower_arcs = [Arc::default(); MAX_LOWER_ARCS];
-        lower_arcs[..arcs.len()].copy_from_slice(arcs);
-
-        Ok(Self {
-            arcs: lower_arcs,
-            length: arcs.len() as u8,
-        })
-    }
-}
-
-/// Parse a single byte from a slice
-fn parse_byte(bytes: &mut &[u8]) -> Result<u8> {
-    let byte = *bytes.get(0).ok_or(Error)?;
-    *bytes = &bytes[1..];
-    Ok(byte)
-}
-
-/// Parse a base 128 (big endian) integer from a bytestring
-fn parse_base128(bytes: &mut &[u8]) -> Result<Arc> {
-    let mut result = 0;
-    let mut shift = 0;
-
-    loop {
-        let byte = parse_byte(bytes)?;
-
-        if shift == 28 && byte & 0b11110000 != 0 {
-            // Overflow
-            return Err(Error);
-        }
-
-        result = result << 7 | (byte & 0b1111111) as Arc;
-
-        if byte & 0b10000000 == 0 {
-            return Ok(result);
-        }
-
-        shift += 7;
-    }
-}
-
-/// Write the given unsigned integer in base 128
-fn write_base128(bytes: &mut [u8], mut n: Arc) -> Result<usize> {
-    let nbytes = base128_len(n);
-    let mut i = nbytes.checked_sub(1).expect("length underflow");
-    let mut mask = 0;
-
-    while n > 0x80 {
-        let byte = bytes.get_mut(i).ok_or(Error)?;
-        *byte = (n & 0b1111111 | mask) as u8;
-        n >>= 7;
-        i = i.checked_sub(1).unwrap();
-        mask = 0b10000000;
-    }
-
-    *bytes.get_mut(0).unwrap() = (n | mask) as u8;
-    Ok(nbytes)
-}
-
-/// Compute the length of a value when encoded in base 128
-fn base128_len(n: Arc) -> usize {
-    match n {
-        0..=0x7f => 1,
-        0x80..=0x3fff => 2,
-        0x4000..=0x1fffff => 3,
-        0x200000..=0x1fffffff => 4,
-        _ => 5,
     }
 }

--- a/const-oid/tests/lib.rs
+++ b/const-oid/tests/lib.rs
@@ -1,5 +1,8 @@
 //! `const-oid` crate tests
 
+// TODO(tarcieri): test full set of OID encoding constraints specified here:
+// <https://misc.daniel-marschall.de/asn.1/oid_facts.html>
+
 use const_oid::ObjectIdentifier;
 use hex_literal::hex;
 use std::{convert::TryFrom, string::ToString};
@@ -96,21 +99,9 @@ fn try_from_u32_slice() {
 }
 
 #[test]
-fn write_ber() {
-    let mut buffer = [0u8; 16];
-
-    let oid1_ber = EXAMPLE_OID_1.write_ber(&mut buffer).unwrap();
-    assert_eq!(oid1_ber, EXAMPLE_OID_1_BER);
-
-    let oid2_ber = EXAMPLE_OID_2.write_ber(&mut buffer).unwrap();
-    assert_eq!(oid2_ber, EXAMPLE_OID_2_BER);
-}
-
-#[cfg(feature = "alloc")]
-#[test]
-fn to_ber() {
-    assert_eq!(EXAMPLE_OID_1.to_ber(), EXAMPLE_OID_1_BER);
-    assert_eq!(EXAMPLE_OID_2.to_ber(), EXAMPLE_OID_2_BER);
+fn as_bytes() {
+    assert_eq!(EXAMPLE_OID_1.as_bytes(), EXAMPLE_OID_1_BER);
+    assert_eq!(EXAMPLE_OID_2.as_bytes(), EXAMPLE_OID_2_BER);
 }
 
 #[test]

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -3,7 +3,7 @@
 //!
 //! This limit is presently 65,535 bytes.
 
-use crate::{Length, Result};
+use crate::{Error, Length, Result};
 use core::convert::TryFrom;
 
 /// Byte slice newtype which respects the `Length::max()` limit.
@@ -45,5 +45,13 @@ impl<'a> ByteSlice<'a> {
 impl AsRef<[u8]> for ByteSlice<'_> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for ByteSlice<'a> {
+    type Error = Error;
+
+    fn try_from(slice: &'a [u8]) -> Result<Self> {
+        Self::new(slice)
     }
 }

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -121,24 +121,15 @@ impl<'a> Encoder<'a> {
     /// Encode an ASN.1 [`ObjectIdentifier`]
     #[cfg(feature = "oid")]
     #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
-    pub fn oid(&mut self, oid: impl TryInto<ObjectIdentifier>) -> Result<()> {
-        let oid: ObjectIdentifier = oid.try_into().or_else(|_| {
-            self.error(ErrorKind::Value {
-                tag: Tag::ObjectIdentifier,
+    pub fn oid(&mut self, value: impl TryInto<ObjectIdentifier>) -> Result<()> {
+        value
+            .try_into()
+            .or_else(|_| {
+                self.error(ErrorKind::Value {
+                    tag: Tag::ObjectIdentifier,
+                })
             })
-        })?;
-
-        let expected_len = oid.ber_len();
-        Header::new(Tag::ObjectIdentifier, expected_len).and_then(|header| header.encode(self))?;
-        let buffer = self.reserve(expected_len)?;
-
-        if oid.write_ber(buffer)?.len() == expected_len {
-            Ok(())
-        } else {
-            self.error(ErrorKind::Length {
-                tag: Tag::ObjectIdentifier,
-            })
-        }
+            .and_then(|value| self.encode(&value))
     }
 
     /// Encode the provided value as an ASN.1 `PrintableString`


### PR DESCRIPTION
This commit changes the internal representation of `ObjectIdentifier` to be the BER/DER encoding, rather than the root OID byte plus an array of decoded arc values (i.e. u32).

The `Arcs` iterator is likewise changed to decode the BER/DER representation on-the-fly.

Since the BER/DER encoding uses base 128, it's much more compact, allowing the representation of more potential OIDs while simultaneously reducing the total size in memory (now 24 bytes).

Making this work also involved the addition of a `const fn` OID encoder which is also included in this commit. From a `const fn` context OIDs are now parsed from strings and then subsequently BER/DER encoded into a byte array.