### PR TITLE
const-oid v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 (2021-02-28)
+### Added
+- `ObjectIdentifier::as_bytes` method ([#317])
+
+### Changed
+- Internal representation changed to BER/DER ([#317])
+- Deprecated `ObjectIdentifier::ber_len`, `::write_ber`, and `::to_ber` ([#317])
+
+[#317]: https://github.com/RustCrypto/utils/pull/317
+
 ## 0.4.3 (2021-02-24)
 ### Added
 - Const-friendly OID string parser ([#312])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -19,7 +19,7 @@ Object Identifiers, a.k.a. OIDs, are an International Telecommunications
 Union (ITU) and ISO/IEC standard for naming any object, concept, or "thing"
 with a globally unambiguous persistent name.
 
-OIDS are defined in the ITU's [X.660] standard.
+The ITU's [X.660] standard provides an OID specification.
 
 The following is an example of an OID, in this case identifying the
 `rsaEncryption` algorithm:

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -37,7 +37,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.4.3"
+    html_root_url = "https://docs.rs/const-oid/0.4.4"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 
 [dependencies]
-const-oid = { version = "0.4.3", optional = true, path = "../const-oid" }
+const-oid = { version = "0.4.4", optional = true, path = "../const-oid" }
 der_derive = { version = "0.2", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 


### PR DESCRIPTION
### Added
- `ObjectIdentifier::as_bytes` method ([#317])

### Changed
- Internal representation changed to BER/DER ([#317])
- Deprecated `ObjectIdentifier::ber_len`, `::write_ber`, and `::to_ber` ([#317])

[#317]: https://github.com/RustCrypto/utils/pull/317