### PR TITLE
base64ct v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "blobby"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2021-03-07)
+### Fixed
+- MSRV docs ([#328])
+
+[#328]: https://github.com/RustCrypto/utils/pull/328
+
 ## 0.2.0 (2021-02-01)
 ### Changed
 - Refactor with `Encoding` trait ([#238])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation Base64 (RFC 4648) implemented without data-dependent
 branches/LUTs thereby providing portable "best effort" constant-time operation

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -76,7 +76,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/0.2.0"
+    html_root_url = "https://docs.rs/base64ct/0.2.1"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
### Fixed
- MSRV docs ([#328])

[#328]: https://github.com/RustCrypto/utils/pull/328