### PR TITLE
base64ct: MSRV 1.47 and TODO fixes it enables

### DIFF
--- a/.github/workflows/base64ct.yml
+++ b/.github/workflows/base64ct.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/base64ct/badge.svg
 [docs-link]: https://docs.rs/base64ct/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 [build-image]: https://github.com/RustCrypto/utils/workflows/base64ct/badge.svg?branch=master&event=push

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.46** at a minimum.
+//! This crate requires **Rust 1.47** at a minimum.
 //!
 //! We may change the MSRV in the future, but it will be accompanied by a minor
 //! version bump.


### PR DESCRIPTION
All of the TODOs except for one are because `const fn` support for various methods isn't available until 1.47, and the previous MSRV was 1.46 instead.

Therefore, this commit bumps MSRV from 1.46 to 1.47 (which will entail a minor version bump too)