### PR TITLE
base64ct v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "0.2.1"
+version = "1.0.0"
 
 [[package]]
 name = "blobby"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 (2021-03-17)
+### Changed
+- Bump MSRV to 1.47+ ([#334])
+
+### Fixed
+- MSRV-dependent TODOs in implementation ([#334])
+
+[#334]: https://github.com/RustCrypto/utils/pull/334
+
 ## 0.2.1 (2021-03-07)
 ### Fixed
 - MSRV docs ([#328])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "base64ct"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "1.0.0" # Also update html_root_url in lib.rs when bumping this
 description = """
-Pure Rust implementation Base64 (RFC 4648) implemented without data-dependent
-branches/LUTs thereby providing portable "best effort" constant-time operation
-and embedded-friendly no_std support
+Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
+data-dependent branches/LUTs and thereby provides portable "best effort"
+constant-time operation and embedded-friendly no_std support
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -76,7 +76,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/0.2.1"
+    html_root_url = "https://docs.rs/base64ct/1.0.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 der = { version = "0.2", features = ["oid"], path = "../der" }
 spki = { version = "0.2", path = "../spki" }
 
-base64ct = { version = "0.2", optional = true, features = ["alloc"], path = "../base64ct" }
+base64ct = { version = "1", optional = true, path = "../base64ct" }
 rand_core = { version = "0.6", optional = true, default-features = false }
 pkcs5 = { version = "0.1.1", optional = true, path = "../pkcs5" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
@@ -29,7 +29,7 @@ hex-literal = "0.3"
 encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
 std = ["alloc", "der/std"]
 alloc = ["der/alloc", "zeroize"]
-pem = ["alloc", "base64ct"]
+pem = ["alloc", "base64ct/alloc"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
### Changed
- Bump MSRV to 1.47+ ([#334])

### Fixed
- MSRV-dependent TODOs in implementation ([#334])