### PR TITLE
pkcs8 v0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.5 (2021-03-17)
+### Changed
+- Bump `base64ct` dependency to v1.0 ([#335])
+
+[#335]: https://github.com/RustCrypto/utils/pull/335
+
 ## 0.5.4 (2021-02-24)
 ### Added
 - Encryption helper methods for `FromPrivateKey`/`ToPrivateKey` ([#308])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.5.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.5" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -62,7 +62,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.5.4"
+    html_root_url = "https://docs.rs/pkcs8/0.5.5"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Bump `base64ct` dependency to v1.0 ([#335])

[#335]: https://github.com/RustCrypto/utils/pull/335