### PR TITLE
const-oid: MSRV 1.47+; remove workarounds and deprecations

### DIFF
--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -36,14 +36,13 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
-      - run: cargo build --target ${{ matrix.target }} --release --features alloc
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -53,5 +52,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
-      - run: cargo test --release --features alloc
       - run: cargo test --release --all-features

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.5.0-pre"
 dependencies = [
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.10"
+version = "0.3.0-pre"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.1.1"
+version = "0.2.0-pre"
 dependencies = [
  "aes",
  "block-modes",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.5.5"
+version = "0.6.0-pre"
 dependencies = [
  "base64ct",
  "der",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
  "der",
 ]

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.4.5"
+version = "0.5.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
@@ -19,8 +19,7 @@ readme = "README.md"
 hex-literal = "0.3"
 
 [features]
-alloc = []
-std = ["alloc"]
+std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/const-oid/badge.svg
 [docs-link]: https://docs.rs/const-oid/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 [build-image]: https://github.com/RustCrypto/utils/workflows/const-oid/badge.svg?branch=master&event=push

--- a/const-oid/src/arcs.rs
+++ b/const-oid/src/arcs.rs
@@ -50,7 +50,7 @@ impl<'a> Iterator for Arcs<'a> {
                 let mut result = 0;
                 let mut arc_bytes = 0;
 
-                // TODO(tarcieri): consolidate this with `ObjectIdentifier::from_ber`?
+                // TODO(tarcieri): consolidate this with `ObjectIdentifier::from_bytes`?
                 loop {
                     match self.oid.as_bytes().get(offset + arc_bytes).cloned() {
                         Some(byte) => {

--- a/const-oid/src/parser.rs
+++ b/const-oid/src/parser.rs
@@ -45,15 +45,12 @@ impl Parser {
                 self
             }
             [byte @ b'0'..=b'9', remaining @ ..] => {
-                self.current_arc = self.current_arc * 10 + parse_ascii_digit(*byte);
+                let digit = byte.saturating_sub(b'0');
+                self.current_arc = self.current_arc * 10 + digit as Arc;
                 self.parse_bytes(remaining)
             }
             [b'.', remaining @ ..] => {
                 const_assert!(!remaining.is_empty(), "invalid trailing '.' in OID");
-                // const_assert!(
-                //     self.cursor < MAX_ARCS,
-                //     "maximum number of OID arcs exceeded"
-                // );
                 self.encoder = self.encoder.encode(self.current_arc);
                 self.current_arc = 0;
                 self.parse_bytes(remaining)
@@ -68,27 +65,6 @@ impl Parser {
                 // Needed for match exhaustiveness and matching types
                 self
             }
-        }
-    }
-}
-
-/// Parse a digit from an ASCII character
-// TODO(tarcieri): replace this with `byte.saturating_sub(b'0')` when MSRV 1.47+
-const fn parse_ascii_digit(char: u8) -> Arc {
-    match char {
-        b'0' => 0,
-        b'1' => 1,
-        b'2' => 2,
-        b'3' => 3,
-        b'4' => 4,
-        b'5' => 5,
-        b'6' => 6,
-        b'7' => 7,
-        b'8' => 8,
-        b'9' => 9,
-        other => {
-            const_assert!(matches!(other, b'0'..=b'9'), "invalid ASCII digit");
-            0 // Unreachable due to above `const_assert`
         }
     }
 }

--- a/const-oid/tests/lib.rs
+++ b/const-oid/tests/lib.rs
@@ -5,13 +5,13 @@
 
 use const_oid::ObjectIdentifier;
 use hex_literal::hex;
-use std::{convert::TryFrom, string::ToString};
+use std::string::ToString;
 
 /// Example OID value with a root arc of `1`
-const EXAMPLE_OID_1: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.10045.2.1");
+const EXAMPLE_OID_1: ObjectIdentifier = ObjectIdentifier::new("1.2.840.10045.2.1");
 
 /// Example OID value with a root arc of `2`
-const EXAMPLE_OID_2: ObjectIdentifier = ObjectIdentifier::parse("2.16.840.1.101.3.4.1.42");
+const EXAMPLE_OID_2: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.101.3.4.1.42");
 
 /// Example OID 1 encoded as ASN.1 BER/DER
 const EXAMPLE_OID_1_BER: &[u8] = &hex!("2A8648CE3D0201");
@@ -32,23 +32,23 @@ fn display() {
 }
 
 #[test]
-fn from_ber() {
-    let oid1 = ObjectIdentifier::from_ber(EXAMPLE_OID_1_BER).unwrap();
+fn from_bytes() {
+    let oid1 = ObjectIdentifier::from_bytes(EXAMPLE_OID_1_BER).unwrap();
     assert_eq!(oid1.arc(0).unwrap(), 1);
     assert_eq!(oid1.arc(1).unwrap(), 2);
     assert_eq!(oid1, EXAMPLE_OID_1);
 
-    let oid2 = ObjectIdentifier::from_ber(EXAMPLE_OID_2_BER).unwrap();
+    let oid2 = ObjectIdentifier::from_bytes(EXAMPLE_OID_2_BER).unwrap();
     assert_eq!(oid2.arc(0).unwrap(), 2);
     assert_eq!(oid2.arc(1).unwrap(), 16);
     assert_eq!(oid2, EXAMPLE_OID_2);
 
     // Empty
-    assert!(ObjectIdentifier::from_ber(&[]).is_err());
+    assert!(ObjectIdentifier::from_bytes(&[]).is_err());
 
     // Truncated
-    assert!(ObjectIdentifier::from_ber(&[42]).is_err());
-    assert!(ObjectIdentifier::from_ber(&[42, 134]).is_err());
+    assert!(ObjectIdentifier::from_bytes(&[42]).is_err());
+    assert!(ObjectIdentifier::from_bytes(&[42, 134]).is_err());
 }
 
 #[test]
@@ -78,24 +78,24 @@ fn from_str() {
 
 #[test]
 fn try_from_u32_slice() {
-    let oid1 = ObjectIdentifier::try_from([1, 2, 840, 10045, 2, 1].as_ref()).unwrap();
+    let oid1 = ObjectIdentifier::from_arcs(&[1, 2, 840, 10045, 2, 1]).unwrap();
     assert_eq!(oid1.arc(0).unwrap(), 1);
     assert_eq!(oid1.arc(1).unwrap(), 2);
     assert_eq!(EXAMPLE_OID_1, oid1);
 
-    let oid2 = ObjectIdentifier::try_from([2, 16, 840, 1, 101, 3, 4, 1, 42].as_ref()).unwrap();
+    let oid2 = ObjectIdentifier::from_arcs(&[2, 16, 840, 1, 101, 3, 4, 1, 42]).unwrap();
     assert_eq!(oid2.arc(0).unwrap(), 2);
     assert_eq!(oid2.arc(1).unwrap(), 16);
     assert_eq!(EXAMPLE_OID_2, oid2);
 
     // Too short
-    assert!(ObjectIdentifier::try_from([1, 2].as_ref()).is_err());
+    assert!(ObjectIdentifier::from_arcs(&[1, 2]).is_err());
 
     // Invalid first arc
-    assert!(ObjectIdentifier::try_from([3, 2, 840, 10045, 3, 1, 7].as_ref()).is_err());
+    assert!(ObjectIdentifier::from_arcs(&[3, 2, 840, 10045, 3, 1, 7]).is_err());
 
     // Invalid second arc
-    assert!(ObjectIdentifier::try_from([1, 40, 840, 10045, 3, 1, 7].as_ref()).is_err());
+    assert!(ObjectIdentifier::from_arcs(&[1, 40, 840, 10045, 3, 1, 7]).is_err());
 }
 
 #[test]
@@ -106,48 +106,24 @@ fn as_bytes() {
 
 #[test]
 #[should_panic]
-fn new_empty() {
-    ObjectIdentifier::new(&[]);
-}
-
-#[test]
-#[should_panic]
-fn new_too_short() {
-    ObjectIdentifier::new(&[1, 2]);
-}
-
-#[test]
-#[should_panic]
-fn new_invalid_first_arc() {
-    ObjectIdentifier::new(&[3, 2, 840, 10045, 3, 1, 7]);
-}
-
-#[test]
-#[should_panic]
-fn new_invalid_second_arc() {
-    ObjectIdentifier::new(&[1, 40, 840, 10045, 3, 1, 7]);
-}
-
-#[test]
-#[should_panic]
 fn parse_empty() {
-    ObjectIdentifier::parse("");
+    ObjectIdentifier::new("");
 }
 
 #[test]
 #[should_panic]
 fn parse_too_short() {
-    ObjectIdentifier::parse("1.2");
+    ObjectIdentifier::new("1.2");
 }
 
 #[test]
 #[should_panic]
 fn parse_invalid_first_arc() {
-    ObjectIdentifier::parse("3.2.840.10045.3.1.7");
+    ObjectIdentifier::new("3.2.840.10045.3.1.7");
 }
 
 #[test]
 #[should_panic]
 fn parse_invalid_second_arc() {
-    ObjectIdentifier::parse("1.40.840.10045.3.1.7");
+    ObjectIdentifier::new("1.40.840.10045.3.1.7");
 }

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.2.10" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -15,7 +15,7 @@ keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 
 [dependencies]
-const-oid = { version = "0.4.4", optional = true, path = "../const-oid" }
+const-oid = { version = "=0.5.0-pre", optional = true, path = "../const-oid" }
 der_derive = { version = "0.2", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 

--- a/der/README.md
+++ b/der/README.md
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/der/badge.svg
 [docs-link]: https://docs.rs/der/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 [build-image]: https://github.com/RustCrypto/utils/workflows/der/badge.svg?branch=master&event=push

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.46** at a minimum.
+//! This crate requires **Rust 1.47** at a minimum.
 //!
 //! We may change the MSRV in the future, but it will be accompanied by a minor
 //! version bump.
@@ -329,7 +329,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.2.10"
+    html_root_url = "https://docs.rs/der/0.3.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -14,8 +14,8 @@ keywords = ["crypto", "key", "pkcs", "password"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.2.7", features = ["oid"], path = "../der" }
-spki = { version = "0.2", path = "../spki" }
+der = { version = "=0.3.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.3.0-pre", path = "../spki" }
 
 aes = { version = "0.6", optional = true }
 block-modes = { version = "0.7", optional = true, default-features = false }

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.1.1"
+    html_root_url = "https://docs.rs/pkcs5/0.2.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -8,27 +8,27 @@ use der::{sequence, Any, Encodable, Encoder, ErrorKind, Header, Length, OctetStr
 
 /// `pbeWithMD2AndDES-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD2_AND_DES_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::parse("1.2.840.113549.1.5.1");
+    ObjectIdentifier::new("1.2.840.113549.1.5.1");
 
 /// `pbeWithMD2AndRC2-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD2_AND_RC2_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::parse("1.2.840.113549.1.5.4");
+    ObjectIdentifier::new("1.2.840.113549.1.5.4");
 
 /// `pbeWithMD5AndDES-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD5_AND_DES_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::parse("1.2.840.113549.1.5.3");
+    ObjectIdentifier::new("1.2.840.113549.1.5.3");
 
 /// `pbeWithMD5AndRC2-CBC` Object Identifier (OID).
 pub const PBE_WITH_MD5_AND_RC2_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::parse("1.2.840.113549.1.5.6");
+    ObjectIdentifier::new("1.2.840.113549.1.5.6");
 
 /// `pbeWithSHA1AndDES-CBC` Object Identifier (OID).
 pub const PBE_WITH_SHA1_AND_DES_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::parse("1.2.840.113549.1.5.10");
+    ObjectIdentifier::new("1.2.840.113549.1.5.10");
 
 /// `pbeWithSHA1AndRC2-CBC` Object Identifier (OID).
 pub const PBE_WITH_SHA1_AND_RC2_CBC_OID: ObjectIdentifier =
-    ObjectIdentifier::parse("1.2.840.113549.1.5.11");
+    ObjectIdentifier::new("1.2.840.113549.1.5.11");
 
 /// Length of a PBES1 salt (as defined in the `PBEParameter` ASN.1 message).
 pub const SALT_LENGTH: usize = 8;

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -16,24 +16,24 @@ use alloc::vec::Vec;
 /// Password-Based Encryption Scheme 2 (PBES2) OID.
 ///
 /// <https://tools.ietf.org/html/rfc8018#section-6.2>
-pub const PBES2_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.1.5.13");
+pub const PBES2_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.1.5.13");
 
 /// Password-Based Key Derivation Function (PBKDF2) OID.
-pub const PBKDF2_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.1.5.12");
+pub const PBKDF2_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.1.5.12");
 
 /// HMAC-SHA1 (for use with PBKDF2)
-pub const HMAC_WITH_SHA1_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.2.7");
+pub const HMAC_WITH_SHA1_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.2.7");
 
 /// HMAC-SHA-256 (for use with PBKDF2)
-pub const HMAC_WITH_SHA256_OID: ObjectIdentifier = ObjectIdentifier::parse("1.2.840.113549.2.9");
+pub const HMAC_WITH_SHA256_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.2.9");
 
 /// 128-bit Advanced Encryption Standard (AES) algorithm with Cipher-Block
 /// Chaining (CBC) mode of operation.
-pub const AES_128_CBC_OID: ObjectIdentifier = ObjectIdentifier::parse("2.16.840.1.101.3.4.1.2");
+pub const AES_128_CBC_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.101.3.4.1.2");
 
 /// 256-bit Advanced Encryption Standard (AES) algorithm with Cipher-Block
 /// Chaining (CBC) mode of operation.
-pub const AES_256_CBC_OID: ObjectIdentifier = ObjectIdentifier::parse("2.16.840.1.101.3.4.1.42");
+pub const AES_256_CBC_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.101.3.4.1.42");
 
 /// AES cipher block size
 const AES_BLOCK_SIZE: usize = 16;

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.5.5" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)
@@ -14,12 +14,12 @@ keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.2", features = ["oid"], path = "../der" }
-spki = { version = "0.2", path = "../spki" }
+der = { version = "=0.3.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.3.0-pre", path = "../spki" }
 
 base64ct = { version = "1", optional = true, path = "../base64ct" }
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "0.1.1", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "=0.2.0-pre", optional = true, path = "../pkcs5" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -62,7 +62,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.5.5"
+    html_root_url = "https://docs.rs/pkcs8/0.6.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -14,7 +14,7 @@ keywords = ["crypto", "x509"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.2.8", features = ["oid"], path = "../der" }
+der = { version = "=0.3.0-pre", features = ["oid"], path = "../der" }
 
 [features]
 std = ["der/std"]

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -14,7 +14,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/spki/0.2.1"
+    html_root_url = "https://docs.rs/spki/0.3.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
Every crate in RustCrypto that actually consumes `const-oid` is now MSRV 1.47+ (edit: `der` is still MSRV 1.46+ so I'll bump that too) so it makes sense to bump this one too, particularly because it presently contains workarounds for the lack of `const fn` support for certain functions which were stabilized in 1.47+.

Per our MSRV policy this comes with a minor version bump (which has been bumped to v0.5.0-pre for now, edit: also need to bump `der`), and as this is a breaking release we can go ahead and remove all of the deprecated methods.

The following changes are also included:

- Renames `ObjectIdentifier::parse` => `ObjectIdentifier::new` (going forward we can use that exclusively in const contexts)
- Adapts the former `TryFrom<&[Arc]>` impl to an inherent `ObjectIdentifier::from_arcs` method.
- Adds a new `TryFrom<&[u8]>` impl which parses BER/DER.
- Removed `alloc` feature which was only used by deprecated methods.