### PR TITLE
der: name Decodable::from_bytes => Decodable::from_der

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -159,6 +159,6 @@ impl<'a> TryFrom<&'a [u8]> for Any<'a> {
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Any<'a>> {
-        Any::from_bytes(bytes)
+        Any::from_der(bytes)
     }
 }

--- a/der/src/asn1/big_uint.rs
+++ b/der/src/asn1/big_uint.rs
@@ -217,27 +217,27 @@ mod tests {
 
     #[test]
     fn decode_bigu8() {
-        assert!(BigU8::from_bytes(I0_BYTES).unwrap().is_empty());
-        assert_eq!(&[127], BigU8::from_bytes(I127_BYTES).unwrap().as_bytes());
-        assert_eq!(&[128], BigU8::from_bytes(I128_BYTES).unwrap().as_bytes());
-        assert_eq!(&[255], BigU8::from_bytes(I255_BYTES).unwrap().as_bytes());
+        assert!(BigU8::from_der(I0_BYTES).unwrap().is_empty());
+        assert_eq!(&[127], BigU8::from_der(I127_BYTES).unwrap().as_bytes());
+        assert_eq!(&[128], BigU8::from_der(I128_BYTES).unwrap().as_bytes());
+        assert_eq!(&[255], BigU8::from_der(I255_BYTES).unwrap().as_bytes());
     }
 
     #[test]
     fn decode_bigu16() {
-        assert!(BigU16::from_bytes(I0_BYTES).unwrap().is_empty());
-        assert_eq!(&[127], BigU16::from_bytes(I127_BYTES).unwrap().as_bytes());
-        assert_eq!(&[128], BigU16::from_bytes(I128_BYTES).unwrap().as_bytes());
-        assert_eq!(&[255], BigU16::from_bytes(I255_BYTES).unwrap().as_bytes());
+        assert!(BigU16::from_der(I0_BYTES).unwrap().is_empty());
+        assert_eq!(&[127], BigU16::from_der(I127_BYTES).unwrap().as_bytes());
+        assert_eq!(&[128], BigU16::from_der(I128_BYTES).unwrap().as_bytes());
+        assert_eq!(&[255], BigU16::from_der(I255_BYTES).unwrap().as_bytes());
 
         assert_eq!(
             &[0x01, 0x00],
-            BigU16::from_bytes(I256_BYTES).unwrap().as_bytes()
+            BigU16::from_der(I256_BYTES).unwrap().as_bytes()
         );
 
         assert_eq!(
             &[0x7F, 0xFF],
-            BigU16::from_bytes(I32767_BYTES).unwrap().as_bytes()
+            BigU16::from_der(I32767_BYTES).unwrap().as_bytes()
         );
     }
 

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -58,8 +58,8 @@ mod tests {
 
     #[test]
     fn decode() {
-        assert_eq!(true, bool::from_bytes(&[0x01, 0x01, 0xFF]).unwrap());
-        assert_eq!(false, bool::from_bytes(&[0x01, 0x01, 0x00]).unwrap());
+        assert_eq!(true, bool::from_der(&[0x01, 0x01, 0xFF]).unwrap());
+        assert_eq!(false, bool::from_der(&[0x01, 0x01, 0x00]).unwrap());
     }
 
     #[test]
@@ -77,6 +77,6 @@ mod tests {
 
     #[test]
     fn reject_non_canonical() {
-        assert!(bool::from_bytes(&[0x01, 0x01, 0x01]).is_err());
+        assert!(bool::from_der(&[0x01, 0x01, 0x01]).is_err());
     }
 }

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn round_trip() {
         let example_bytes = hex!("18 0f 31 39 39 31 30 35 30 36 32 33 34 35 34 30 5a");
-        let utc_time = GeneralizedTime::from_bytes(&example_bytes).unwrap();
+        let utc_time = GeneralizedTime::from_der(&example_bytes).unwrap();
         assert_eq!(utc_time.unix_duration().as_secs(), 673573540);
 
         let mut buf = [0u8; 128];

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn parse_bytes() {
         let example_bytes = hex!("16 0d 74 65 73 74 31 40 72 73 61 2e 63 6f 6d");
-        let printable_string = Ia5String::from_bytes(&example_bytes).unwrap();
+        let printable_string = Ia5String::from_der(&example_bytes).unwrap();
         assert_eq!(printable_string.as_str(), "test1@rsa.com");
     }
 }

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -230,39 +230,39 @@ pub(crate) mod tests {
 
     #[test]
     fn decode_i8() {
-        assert_eq!(0, i8::from_bytes(I0_BYTES).unwrap());
-        assert_eq!(127, i8::from_bytes(I127_BYTES).unwrap());
-        assert_eq!(-128, i8::from_bytes(INEG128_BYTES).unwrap());
+        assert_eq!(0, i8::from_der(I0_BYTES).unwrap());
+        assert_eq!(127, i8::from_der(I127_BYTES).unwrap());
+        assert_eq!(-128, i8::from_der(INEG128_BYTES).unwrap());
     }
 
     #[test]
     fn decode_i16() {
-        assert_eq!(0, i16::from_bytes(I0_BYTES).unwrap());
-        assert_eq!(127, i16::from_bytes(I127_BYTES).unwrap());
-        assert_eq!(128, i16::from_bytes(I128_BYTES).unwrap());
-        assert_eq!(255, i16::from_bytes(I255_BYTES).unwrap());
-        assert_eq!(256, i16::from_bytes(I256_BYTES).unwrap());
-        assert_eq!(32767, i16::from_bytes(I32767_BYTES).unwrap());
-        assert_eq!(-128, i16::from_bytes(INEG128_BYTES).unwrap());
-        assert_eq!(-129, i16::from_bytes(INEG129_BYTES).unwrap());
-        assert_eq!(-32768, i16::from_bytes(INEG32768_BYTES).unwrap());
+        assert_eq!(0, i16::from_der(I0_BYTES).unwrap());
+        assert_eq!(127, i16::from_der(I127_BYTES).unwrap());
+        assert_eq!(128, i16::from_der(I128_BYTES).unwrap());
+        assert_eq!(255, i16::from_der(I255_BYTES).unwrap());
+        assert_eq!(256, i16::from_der(I256_BYTES).unwrap());
+        assert_eq!(32767, i16::from_der(I32767_BYTES).unwrap());
+        assert_eq!(-128, i16::from_der(INEG128_BYTES).unwrap());
+        assert_eq!(-129, i16::from_der(INEG129_BYTES).unwrap());
+        assert_eq!(-32768, i16::from_der(INEG32768_BYTES).unwrap());
     }
 
     #[test]
     fn decode_u8() {
-        assert_eq!(0, u8::from_bytes(I0_BYTES).unwrap());
-        assert_eq!(127, u8::from_bytes(I127_BYTES).unwrap());
-        assert_eq!(255, u8::from_bytes(I255_BYTES).unwrap());
+        assert_eq!(0, u8::from_der(I0_BYTES).unwrap());
+        assert_eq!(127, u8::from_der(I127_BYTES).unwrap());
+        assert_eq!(255, u8::from_der(I255_BYTES).unwrap());
     }
 
     #[test]
     fn decode_u16() {
-        assert_eq!(0, u16::from_bytes(I0_BYTES).unwrap());
-        assert_eq!(127, u16::from_bytes(I127_BYTES).unwrap());
-        assert_eq!(255, u16::from_bytes(I255_BYTES).unwrap());
-        assert_eq!(256, u16::from_bytes(I256_BYTES).unwrap());
-        assert_eq!(32767, u16::from_bytes(I32767_BYTES).unwrap());
-        assert_eq!(65535, u16::from_bytes(I65535_BYTES).unwrap());
+        assert_eq!(0, u16::from_der(I0_BYTES).unwrap());
+        assert_eq!(127, u16::from_der(I127_BYTES).unwrap());
+        assert_eq!(255, u16::from_der(I255_BYTES).unwrap());
+        assert_eq!(256, u16::from_der(I256_BYTES).unwrap());
+        assert_eq!(32767, u16::from_der(I32767_BYTES).unwrap());
+        assert_eq!(65535, u16::from_der(I65535_BYTES).unwrap());
     }
 
     #[test]
@@ -327,9 +327,9 @@ pub(crate) mod tests {
     /// Integers must be encoded with a minimum number of octets
     #[test]
     fn reject_non_canonical() {
-        assert!(i8::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
-        assert!(i16::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
-        assert!(u8::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
-        assert!(u16::from_bytes(&[0x02, 0x02, 0x00, 0x00]).is_err());
+        assert!(i8::from_der(&[0x02, 0x02, 0x00, 0x00]).is_err());
+        assert!(i16::from_der(&[0x02, 0x02, 0x00, 0x00]).is_err());
+        assert!(u8::from_der(&[0x02, 0x02, 0x00, 0x00]).is_err());
+        assert!(u16::from_der(&[0x02, 0x02, 0x00, 0x00]).is_err());
     }
 }

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn decode() {
-        assert!(Null::from_bytes(&[0x05, 0x00]).is_ok());
+        assert!(Null::from_der(&[0x05, 0x00]).is_ok());
     }
 
     #[test]
@@ -94,6 +94,6 @@ mod tests {
 
     #[test]
     fn reject_non_canonical() {
-        assert!(Null::from_bytes(&[0x05, 0x81, 0x00]).is_err());
+        assert!(Null::from_der(&[0x05, 0x81, 0x00]).is_err());
     }
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -46,18 +46,14 @@ impl<'a> Tagged for ObjectIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Any, Decodable, Encodable, Length, ObjectIdentifier};
-    use core::convert::TryFrom;
+    use crate::{Decodable, Encodable, Length, ObjectIdentifier};
 
     const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549");
     const EXAMPLE_OID_BYTES: &[u8; 8] = &[0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d];
 
     #[test]
     fn decode() {
-        // TODO(tarcieri): use `Decodable::from_der` directly after renamed
-        let any = Any::from_bytes(EXAMPLE_OID_BYTES).unwrap();
-        let oid = ObjectIdentifier::try_from(any).unwrap();
-
+        let oid = ObjectIdentifier::from_der(EXAMPLE_OID_BYTES).unwrap();
         assert_eq!(EXAMPLE_OID, oid);
     }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -173,7 +173,7 @@ mod tests {
             0x13, 0x0b, 0x54, 0x65, 0x73, 0x74, 0x20, 0x55, 0x73, 0x65, 0x72, 0x20, 0x31,
         ];
 
-        let printable_string = PrintableString::from_bytes(example_bytes).unwrap();
+        let printable_string = PrintableString::from_der(example_bytes).unwrap();
         assert_eq!(printable_string.as_str(), "Test User 1");
     }
 }

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn round_trip() {
         let example_bytes = hex!("17 0d 39 31 30 35 30 36 32 33 34 35 34 30 5a");
-        let utc_time = UtcTime::from_bytes(&example_bytes).unwrap();
+        let utc_time = UtcTime::from_der(&example_bytes).unwrap();
         assert_eq!(utc_time.unix_duration().as_secs(), 673573540);
 
         let mut buf = [0u8; 128];

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -154,14 +154,14 @@ mod tests {
             0x0c, 0x0b, 0x54, 0x65, 0x73, 0x74, 0x20, 0x55, 0x73, 0x65, 0x72, 0x20, 0x31,
         ];
 
-        let utf8_string = Utf8String::from_bytes(example_bytes).unwrap();
+        let utf8_string = Utf8String::from_der(example_bytes).unwrap();
         assert_eq!(utf8_string.as_str(), "Test User 1");
     }
 
     #[test]
     fn parse_utf8_bytes() {
         let example_bytes = &[0x0c, 0x06, 0x48, 0x65, 0x6c, 0x6c, 0xc3, 0xb3];
-        let utf8_string = Utf8String::from_bytes(example_bytes).unwrap();
+        let utf8_string = Utf8String::from_der(example_bytes).unwrap();
         assert_eq!(utf8_string.as_str(), "Helló");
     }
 }

--- a/der/src/decodable.rs
+++ b/der/src/decodable.rs
@@ -17,8 +17,8 @@ pub trait Decodable<'a>: Sized {
     /// Attempt to decode this message using the provided decoder.
     fn decode(decoder: &mut Decoder<'a>) -> Result<Self>;
 
-    /// Parse `Self` from the provided byte slice.
-    fn from_bytes(bytes: &'a [u8]) -> Result<Self> {
+    /// Parse `Self` from the provided DER-encoded byte slice.
+    fn from_der(bytes: &'a [u8]) -> Result<Self> {
         let mut decoder = Decoder::new(bytes);
         let result = Self::decode(&mut decoder)?;
         decoder.finish(result)

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -180,23 +180,23 @@ mod tests {
 
     #[test]
     fn decode() {
-        assert_eq!(Length::zero(), Length::from_bytes(&[0x00]).unwrap());
+        assert_eq!(Length::zero(), Length::from_der(&[0x00]).unwrap());
 
-        assert_eq!(Length::from(0x7Fu8), Length::from_bytes(&[0x7F]).unwrap());
+        assert_eq!(Length::from(0x7Fu8), Length::from_der(&[0x7F]).unwrap());
 
         assert_eq!(
             Length::from(0x80u8),
-            Length::from_bytes(&[0x81, 0x80]).unwrap()
+            Length::from_der(&[0x81, 0x80]).unwrap()
         );
 
         assert_eq!(
             Length::from(0xFFu8),
-            Length::from_bytes(&[0x81, 0xFF]).unwrap()
+            Length::from_der(&[0x81, 0xFF]).unwrap()
         );
 
         assert_eq!(
             Length::from(0x100u16),
-            Length::from_bytes(&[0x82, 0x01, 0x00]).unwrap()
+            Length::from_der(&[0x82, 0x01, 0x00]).unwrap()
         );
     }
 
@@ -232,6 +232,6 @@ mod tests {
 
     #[test]
     fn reject_indefinite_lengths() {
-        assert!(Length::from_bytes(&[0x80]).is_err());
+        assert!(Length::from_der(&[0x80]).is_err());
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -210,7 +210,7 @@
 //!
 //! // Deserialize the `AlgorithmIdentifier` we just serialized from ASN.1 DER
 //! // using `der::Decodable::from_bytes`.
-//! let decoded_algorithm_identifier = AlgorithmIdentifier::from_bytes(
+//! let decoded_algorithm_identifier = AlgorithmIdentifier::from_der(
 //!     &der_encoded_algorithm_identifier
 //! ).unwrap();
 //!
@@ -266,7 +266,7 @@
 //! let der_encoded_algorithm_identifier = algorithm_identifier.to_vec().unwrap();
 //!
 //! // Decode
-//! let decoded_algorithm_identifier = AlgorithmIdentifier::from_bytes(
+//! let decoded_algorithm_identifier = AlgorithmIdentifier::from_der(
 //!     &der_encoded_algorithm_identifier
 //! ).unwrap();
 //!

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -54,10 +54,10 @@ const GENERAL_TIMESTAMP: &[u8] = &hex!("18 0f 31 39 39 31 30 35 30 36 32 33 34 3
 
 #[test]
 fn decode_enum_variants() {
-    let utc_time = Time::from_bytes(UTC_TIMESTAMP).unwrap();
+    let utc_time = Time::from_der(UTC_TIMESTAMP).unwrap();
     assert_eq!(utc_time.unix_duration().as_secs(), 673573540);
 
-    let general_time = Time::from_bytes(GENERAL_TIMESTAMP).unwrap();
+    let general_time = Time::from_der(GENERAL_TIMESTAMP).unwrap();
     assert_eq!(general_time.unix_duration().as_secs(), 673573540);
 }
 
@@ -65,12 +65,12 @@ fn decode_enum_variants() {
 fn encode_enum_variants() {
     let mut buf = [0u8; 128];
 
-    let utc_time = Time::from_bytes(UTC_TIMESTAMP).unwrap();
+    let utc_time = Time::from_der(UTC_TIMESTAMP).unwrap();
     let mut encoder = Encoder::new(&mut buf);
     utc_time.encode(&mut encoder).unwrap();
     assert_eq!(UTC_TIMESTAMP, encoder.finish().unwrap());
 
-    let general_time = Time::from_bytes(GENERAL_TIMESTAMP).unwrap();
+    let general_time = Time::from_der(GENERAL_TIMESTAMP).unwrap();
     let mut encoder = Encoder::new(&mut buf);
     general_time.encode(&mut encoder).unwrap();
     assert_eq!(GENERAL_TIMESTAMP, encoder.finish().unwrap());

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -78,7 +78,7 @@ impl<'a> TryFrom<&'a [u8]> for EncryptedPrivateKeyInfo<'a> {
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
-        Ok(Self::from_bytes(bytes)?)
+        Ok(Self::from_der(bytes)?)
     }
 }
 

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -89,7 +89,7 @@ impl<'a> TryFrom<&'a [u8]> for PrivateKeyInfo<'a> {
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
-        Ok(Self::from_bytes(bytes)?)
+        Ok(Self::from_der(bytes)?)
     }
 }
 

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -63,7 +63,7 @@ impl<'a> TryFrom<&'a [u8]> for AlgorithmIdentifier<'a> {
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
-        Self::from_bytes(bytes)
+        Self::from_der(bytes)
     }
 }
 

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -30,7 +30,7 @@ impl<'a> TryFrom<&'a [u8]> for SubjectPublicKeyInfo<'a> {
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
-        Self::from_bytes(bytes)
+        Self::from_der(bytes)
     }
 }
 


### PR DESCRIPTION
Use a more specific name to avoid potential conflicts with e.g. inherent methods (which came up in practice with `ObjectIdentifier::from_der`)