### PR TITLE
der: separate `sequence` and `message`

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -17,6 +17,6 @@ pub(crate) mod octet_string;
 pub(crate) mod oid;
 pub(crate) mod optional;
 pub(crate) mod printable_string;
-pub mod sequence;
+pub(crate) mod sequence;
 pub(crate) mod utc_time;
 pub(crate) mod utf8_string;

--- a/der/src/asn1/choice.rs
+++ b/der/src/asn1/choice.rs
@@ -9,7 +9,6 @@ use crate::{Decodable, Encodable, Tag, Tagged};
 /// This crate models choice as a trait, with a blanket impl for all types
 /// which impl `Decodable + Encodable + Tagged` (i.e. they are modeled as
 /// a `CHOICE` with only one possible variant)
-// TODO(tarcieri): refactor enum custom derive to use `Choice`
 pub trait Choice<'a>: Decodable<'a> + Encodable {
     /// Is the provided [`Tag`] decodable as a variant of this `CHOICE`?
     fn can_decode(tag: Tag) -> bool;

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -1,27 +1,9 @@
 //! ASN.1 `SEQUENCE` support.
 
 use crate::{
-    Any, ByteSlice, Decoder, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag,
-    Tagged,
+    Any, ByteSlice, Decoder, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged,
 };
 use core::convert::TryFrom;
-
-/// Obtain the length of an ASN.1 `SEQUENCE` of [`Encodable`] values when
-/// serialized as ASN.1 DER, including the `SEQUENCE` tag and length prefix.
-pub fn encoded_len(encodables: &[&dyn Encodable]) -> Result<Length> {
-    let inner_len = encoded_len_inner(encodables)?;
-    Header::new(Tag::Sequence, inner_len)?.encoded_len() + inner_len
-}
-
-/// Obtain the inner length of an ASN.1 `SEQUENCE` of [`Encodable`] values
-/// excluding the tag and length.
-pub(crate) fn encoded_len_inner(encodables: &[&dyn Encodable]) -> Result<Length> {
-    encodables
-        .iter()
-        .fold(Ok(Length::zero()), |sum, encodable| {
-            sum + encodable.encoded_len()?
-        })
-}
 
 /// ASN.1 `SEQUENCE` type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -340,6 +340,8 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod message;
+
 mod asn1;
 mod byte_slice;
 mod datetime;
@@ -350,22 +352,14 @@ mod encoder;
 mod error;
 mod header;
 mod length;
-mod message;
 mod str_slice;
 mod tag;
 
 pub use crate::{
     asn1::{
-        any::Any,
-        bit_string::BitString,
-        choice::Choice,
-        generalized_time::GeneralizedTime,
-        ia5_string::Ia5String,
-        null::Null,
-        octet_string::OctetString,
-        printable_string::PrintableString,
-        sequence::{self, Sequence},
-        utc_time::UtcTime,
+        any::Any, bit_string::BitString, choice::Choice, generalized_time::GeneralizedTime,
+        ia5_string::Ia5String, null::Null, octet_string::OctetString,
+        printable_string::PrintableString, sequence::Sequence, utc_time::UtcTime,
         utf8_string::Utf8String,
     },
     decodable::Decodable,

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -38,7 +38,7 @@ use core::{
     convert::{TryFrom, TryInto},
     fmt,
 };
-use der::{sequence, Any, Encodable, Encoder, Length};
+use der::{message, Any, Encodable, Encoder, Length};
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 use alloc::vec::Vec;
@@ -205,14 +205,14 @@ impl<'a> Encodable for EncryptionScheme<'a> {
     fn encoded_len(&self) -> der::Result<Length> {
         match self {
             Self::Pbes1(pbes1) => pbes1.encoded_len(),
-            Self::Pbes2(pbes2) => sequence::encoded_len(&[&pbes2::PBES2_OID, pbes2]),
+            Self::Pbes2(pbes2) => message::encoded_len(&[&pbes2::PBES2_OID, pbes2]),
         }
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
         match self {
             Self::Pbes1(pbes1) => pbes1.encode(encoder),
-            Self::Pbes2(pbes2) => encoder.sequence(&[&pbes2::PBES2_OID, pbes2]),
+            Self::Pbes2(pbes2) => encoder.message(&[&pbes2::PBES2_OID, pbes2]),
         }
     }
 }


### PR DESCRIPTION
Closes #286

Adds a lower-level `SEQUENCE` API to `Encoder` which spawns a nested encoder and passes it to a closure, similar to the corresponding `Decoder` API.

Renames the previous "sequence"-related functionality which acts on a slice of `Encodable` trait objects which represent the fields to `message`.

Finally, removes `reserve` as part of the public API of `Encoder`, since the new `SEQUENCE` API handles the previous use cases that required it.