### PR TITLE
spki: remove AlgorithmParameters enum

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -17,8 +17,8 @@ use crate::ObjectIdentifier;
 /// Classes in X.680 in 1994, and X.690 no longer refers to it whatsoever.
 ///
 /// Nevertheless, this crate defines an [`Any`] type as it remains a familiar
-/// and useful concept, although the usage within arguably resembles the
-/// type system concept more than the original ASN.1 concept.
+/// and useful concept which is still extensively used in things like
+/// PKI-related RFCs.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Any<'a> {
     /// Tag representing the type of the encoded value

--- a/der/src/encodable.rs
+++ b/der/src/encodable.rs
@@ -22,7 +22,7 @@ pub trait Encodable {
     fn encode_to_slice<'a>(&self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
         let mut encoder = Encoder::new(buf);
         self.encode(&mut encoder)?;
-        Ok(encoder.finish()?)
+        encoder.finish()
     }
 
     /// Encode this message as ASN.1 DER, appending it to the provided

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -22,8 +22,5 @@
 mod algorithm;
 mod spki;
 
-pub use crate::{
-    algorithm::{AlgorithmIdentifier, AlgorithmParameters},
-    spki::SubjectPublicKeyInfo,
-};
+pub use crate::{algorithm::AlgorithmIdentifier, spki::SubjectPublicKeyInfo};
 pub use der::{self, ObjectIdentifier};


### PR DESCRIPTION
Now that an `&'a ObjectIdentifier` can be converted to `Any<'a>`, there is no longer a need for the workaround this enum provided and it can be removed.

This better aligns the definition of `AlgorithmIdentifier` with the ASN.1 schema.