### PR TITLE
der: add support for SET OF

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -18,5 +18,6 @@ pub(crate) mod oid;
 pub(crate) mod optional;
 pub(crate) mod printable_string;
 pub(crate) mod sequence;
+pub(crate) mod set_of;
 pub(crate) mod utc_time;
 pub(crate) mod utf8_string;

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -13,14 +13,15 @@ pub struct Sequence<'a> {
 }
 
 impl<'a> Sequence<'a> {
-    /// Create a new [`Sequence`] from a slice
+    /// Create a new [`Sequence`] from a slice.
+    // TODO(tarcieri): validate `slice` is well-formed DER or make this API private
     pub fn new(slice: &'a [u8]) -> Result<Self> {
         ByteSlice::new(slice)
             .map(|inner| Self { inner })
             .map_err(|_| ErrorKind::Length { tag: Self::TAG }.into())
     }
 
-    /// Borrow the inner byte sequence
+    /// Borrow the inner byte sequence.
     pub fn as_bytes(&self) -> &'a [u8] {
         self.inner.as_bytes()
     }
@@ -47,7 +48,7 @@ impl AsRef<[u8]> for Sequence<'_> {
 impl<'a> TryFrom<Any<'a>> for Sequence<'a> {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<Sequence<'a>> {
+    fn try_from(any: Any<'a>) -> Result<Self> {
         any.tag().assert_eq(Tag::Sequence)?;
         Self::new(any.as_bytes())
     }

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -1,0 +1,179 @@
+//! ASN.1 `SET OF` support.
+
+use crate::{
+    Any, ByteSlice, Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag,
+    Tagged,
+};
+use core::{convert::TryFrom, marker::PhantomData};
+
+/// ASN.1 `SET OF` denotes a collection of zero or more occurrences of a
+/// given type.
+///
+/// When encoded as DER, `SET OF` is lexicographically ordered.
+pub trait SetOf<'a, T>: Decodable<'a> + Encodable
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    /// Iterator over the elements of the set
+    type Iter: Iterator<Item = T>;
+
+    /// Iterate over the elements of the set
+    fn elements(&self) -> Self::Iter;
+}
+
+/// ASN.1 `SET OF` backed by a byte slice containing serialized DER.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SetOfRef<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    /// DER-encoded byte slice
+    inner: ByteSlice<'a>,
+
+    /// Set element type
+    element_type: PhantomData<T>,
+}
+
+impl<'a, T> SetOfRef<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    /// Create a new [`SetOfRef`] from a slice.
+    pub fn new(slice: &'a [u8]) -> Result<Self> {
+        let inner = ByteSlice::new(slice).map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
+
+        let mut decoder = Decoder::new(slice);
+        let mut last_value = None;
+
+        // Validate that we can decode all elements in the slice, and that they
+        // are lexicographically ordered according to DER's rules
+        while !decoder.is_finished() {
+            let value: T = decoder.decode()?;
+
+            if let Some(last) = last_value.as_ref() {
+                if last >= &value {
+                    return Err(ErrorKind::Noncanonical.into());
+                }
+            }
+
+            last_value = Some(value);
+        }
+
+        Ok(Self {
+            inner,
+            element_type: PhantomData,
+        })
+    }
+
+    /// Borrow the inner byte sequence.
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl<'a, T> AsRef<[u8]> for SetOfRef<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl<'a, T> TryFrom<Any<'a>> for SetOfRef<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    type Error = Error;
+
+    fn try_from(any: Any<'a>) -> Result<Self> {
+        any.tag().assert_eq(Tag::Set)?;
+        Self::new(any.as_bytes())
+    }
+}
+
+impl<'a, T> From<SetOfRef<'a, T>> for Any<'a>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    fn from(set: SetOfRef<'a, T>) -> Any<'a> {
+        Any {
+            tag: Tag::Set,
+            value: set.inner,
+        }
+    }
+}
+
+impl<'a, T> Encodable for SetOfRef<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    fn encoded_len(&self) -> Result<Length> {
+        Any::from(self.clone()).encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Any::from(self.clone()).encode(encoder)
+    }
+}
+
+impl<'a, T> Tagged for SetOfRef<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    const TAG: Tag = Tag::Set;
+}
+
+impl<'a, T> SetOf<'a, T> for SetOfRef<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    type Iter = SetOfRefIter<'a, T>;
+
+    fn elements(&self) -> Self::Iter {
+        SetOfRefIter::new(self)
+    }
+}
+
+/// Iterator over the elements of an [`SetOfRef`].
+pub struct SetOfRefIter<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    /// Decoder which iterates over the elements of the message
+    decoder: Decoder<'a>,
+
+    /// Element type
+    element_type: PhantomData<T>,
+}
+
+impl<'a, T> SetOfRefIter<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    pub(crate) fn new(set: &SetOfRef<'a, T>) -> Self {
+        Self {
+            decoder: Decoder::new(set.as_bytes()),
+            element_type: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Iterator for SetOfRefIter<'a, T>
+where
+    T: Clone + Decodable<'a> + Encodable + Ord,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.decoder.is_finished() {
+            None
+        } else {
+            Some(
+                self.decoder
+                    .decode()
+                    .expect("SetOfRef decodable invariant violated"),
+            )
+        }
+    }
+}

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -36,7 +36,8 @@
 //! - `()`: ASN.1 `NULL` (see also [`Null`])
 //! - [`bool`]: ASN.1 `BOOLEAN`
 //! - [`i8`], [`i16`], [`u8`], [`u16`]: ASN.1 `INTEGER`
-//! - [`str`], [`String`]: ASN.1 `UTF8String` (see also [`Utf8String`])
+//! - [`str`], [`String`][`alloc::string::String`] (latter requires `alloc` feature):
+//!   ASN.1 `UTF8String` (see also [`Utf8String`])
 //! - [`Option`]: ASN.1 `OPTIONAL`
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime` (requires `std` feature)
 //!
@@ -52,6 +53,7 @@
 //! - [`OctetString`]: ASN.1 `OCTET STRING`
 //! - [`PrintableString`]: ASN.1 `PrintableString` (ASCII subset)
 //! - [`Sequence`]: ASN.1 `SEQUENCE`
+//! - [`SetOfRef`]: ASN.1 `SET OF`
 //! - [`UtcTime`]: ASN.1 `UTCTime`
 //! - [`Utf8String`]: ASN.1 `UTF8String`
 //!
@@ -357,9 +359,17 @@ mod tag;
 
 pub use crate::{
     asn1::{
-        any::Any, bit_string::BitString, choice::Choice, generalized_time::GeneralizedTime,
-        ia5_string::Ia5String, null::Null, octet_string::OctetString,
-        printable_string::PrintableString, sequence::Sequence, utc_time::UtcTime,
+        any::Any,
+        bit_string::BitString,
+        choice::Choice,
+        generalized_time::GeneralizedTime,
+        ia5_string::Ia5String,
+        null::Null,
+        octet_string::OctetString,
+        printable_string::PrintableString,
+        sequence::Sequence,
+        set_of::{SetOf, SetOfRef, SetOfRefIter},
+        utc_time::UtcTime,
         utf8_string::Utf8String,
     },
     decodable::Decodable,

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -45,6 +45,9 @@ pub enum Tag {
     /// `UTF8String` tag.
     Utf8String = 0x0C,
 
+    /// `SET` and `SET OF` tag.
+    Set = 0x11,
+
     /// `PrintableString` tag.
     PrintableString = 0x13,
 
@@ -89,6 +92,7 @@ impl TryFrom<u8> for Tag {
             0x05 => Ok(Tag::Null),
             0x06 => Ok(Tag::ObjectIdentifier),
             0x0C => Ok(Tag::Utf8String),
+            0x11 => Ok(Tag::Set),
             0x13 => Ok(Tag::PrintableString),
             0x16 => Ok(Tag::Ia5String),
             0x17 => Ok(Tag::UtcTime),
@@ -129,6 +133,7 @@ impl Tag {
             Self::Null => "NULL",
             Self::ObjectIdentifier => "OBJECT IDENTIFIER",
             Self::Utf8String => "UTF8String",
+            Self::Set => "SET",
             Self::PrintableString => "PrintableString",
             Self::Ia5String => "IA5String",
             Self::UtcTime => "UTCTime",


### PR DESCRIPTION
Initial support for ASN.1 `SET OF`, adding the following:

- `SetOf` trait which can support multiple backing stores. The longer term goal is to support e.g. `BTreeSet`.
- `SetOfRef` which can decode `SET OF` from a byte slice (`no_std`-friendly)