### PR TITLE
der: make sequence constructor private

### DIFF
--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -14,8 +14,7 @@ pub struct Sequence<'a> {
 
 impl<'a> Sequence<'a> {
     /// Create a new [`Sequence`] from a slice.
-    // TODO(tarcieri): validate `slice` is well-formed DER or make this API private
-    pub fn new(slice: &'a [u8]) -> Result<Self> {
+    pub(crate) fn new(slice: &'a [u8]) -> Result<Self> {
         ByteSlice::new(slice)
             .map(|inner| Self { inner })
             .map_err(|_| ErrorKind::Length { tag: Self::TAG }.into())


### PR DESCRIPTION
It doesn't validate that the SEQUENCE is well-formed, so it should only be used in contexts where that happens as a separate step