### PR TITLE
der: make Length use u32 internally

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -132,8 +132,9 @@ impl<'a> Decodable<'a> for Any<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> Result<Any<'a>> {
         let header = Header::decode(decoder)?;
         let tag = header.tag;
-        let len = header.length.to_usize();
-        let value = decoder.bytes(len).map_err(|_| ErrorKind::Length { tag })?;
+        let value = decoder
+            .bytes(header.length)
+            .map_err(|_| ErrorKind::Length { tag })?;
         Self::new(tag, value)
     }
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -47,6 +47,7 @@ impl<'a> Tagged for ObjectIdentifier {
 #[cfg(test)]
 mod tests {
     use crate::{Decodable, Encodable, Length, ObjectIdentifier};
+    use core::convert::TryInto;
 
     const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549");
     const EXAMPLE_OID_BYTES: &[u8; 8] = &[0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d];
@@ -69,6 +70,6 @@ mod tests {
     #[test]
     fn length() {
         // Ensure an infallible `From` conversion to `Any` will never panic
-        assert!(ObjectIdentifier::max_len() <= Length::max());
+        assert!(ObjectIdentifier::max_len() <= Length::max().try_into().unwrap());
     }
 }

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -4,7 +4,7 @@ use crate::{
     Any, BitString, Choice, Decodable, ErrorKind, GeneralizedTime, Ia5String, Length, Null,
     OctetString, PrintableString, Result, Sequence, UtcTime, Utf8String,
 };
-use core::convert::TryInto;
+use core::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "big-uint")]
 use {
@@ -205,7 +205,7 @@ impl<'a> Decoder<'a> {
 
         let result = self
             .remaining()?
-            .get(..len.to_usize())
+            .get(..len.try_into()?)
             .ok_or(ErrorKind::Truncated)?;
 
         self.position = (self.position + len)?;
@@ -222,8 +222,10 @@ impl<'a> Decoder<'a> {
     /// Obtain the remaining bytes in this decoder from the current cursor
     /// position.
     fn remaining(&self) -> Result<&'a [u8]> {
+        let pos = usize::try_from(self.position)?;
+
         self.bytes
-            .and_then(|b| b.get(self.position.into()..))
+            .and_then(|b| b.get(pos..))
             .ok_or_else(|| ErrorKind::Truncated.at(self.position))
     }
 

--- a/der/src/encodable.rs
+++ b/der/src/encodable.rs
@@ -6,7 +6,10 @@ use crate::{Encoder, Length, Result};
 use {
     crate::ErrorKind,
     alloc::vec::Vec,
-    core::{convert::TryInto, iter},
+    core::{
+        convert::{TryFrom, TryInto},
+        iter,
+    },
 };
 
 /// Encoding trait.
@@ -30,7 +33,7 @@ pub trait Encodable {
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn encode_to_vec(&self, buf: &mut Vec<u8>) -> Result<Length> {
-        let expected_len = self.encoded_len()?.to_usize();
+        let expected_len = usize::try_from(self.encoded_len()?)?;
         buf.reserve(expected_len);
         buf.extend(iter::repeat(0).take(expected_len));
 


### PR DESCRIPTION
The current restriction of `Length` being at most 65535 is actually just an artifact of its inability to decode/encode lengths which are greater than that limit, rather than an explicit design decision.

It would still be good to maintain a maximum document length, but ideally it would be larger than 65535 (e.g. 128kB or 256kB).

This commit keeps the maximum length at its present value, but changes the internal representation of the `Length` type to use `u32` to futureproof it for a potential increase whenever the work is done to support decoding/encoding larger lengths.