### PR TITLE
const-oid v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-03-21)
+### Added
+- `TryFrom<&[u8]>` impl on `ObjectIdentifier` ([#338])
+
+## Changed
+- MSRV 1.47+ ([#338])
+- Renamed the following methods ([#338]):
+  - `ObjectIdentifier::new` => `ObjectIdentifier::from_arcs`
+  - `ObjectIdentifier::parse` => `ObjectIdentifier::new`
+  - `ObjectIdentifier::from_ber` => `ObjectIdentifier::from_bytes`
+
+### Removed
+- Deprecated methods ([#338])
+- `alloc` feature - only used by aforementioned deprecated methods ([#338])
+- `TryFrom<&[Arc]>` impl on `ObjectIdentifier` - use `::from_arcs` ([#338])
+
+[#338]: https://github.com/RustCrypto/utils/pull/338
+
 ## 0.4.5 (2021-03-04)
 ### Added
 - `Hash` and `Ord` impls on `ObjectIdentifier` ([#323])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.5.0-pre"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -30,6 +30,29 @@ The following is an example of an OID, in this case identifying the
 
 For more information, see: <https://en.wikipedia.org/wiki/Object_identifier>
 
+## Implementation
+
+This library supports parsing OIDs in const contexts, e.g.:
+
+```rust
+use const_oid::ObjectIdentifier;
+
+pub const MY_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.1.1.1");
+```
+
+The OID parser is implemented entirely in terms of `const fn` and without the
+use of proc macros.
+
+Additionally, it also includes a `const fn` OID serializer, and stores the OIDs
+parsed from const contexts encoded using the BER/DER serialization
+(sans header).
+
+This allows `ObjectIdentifier` to impl `AsRef<[u8]>` which can be used to
+obtain the BER/DER serialization of an OID, even one declared `const`.
+
+Additionally, it impls `FromStr` and `TryFrom<&[u8]>` and functions just as
+well as a runtime OID library.
+
 ## License
 
 Licensed under either of:

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -19,6 +19,29 @@
 //!
 //! For more information, see: <https://en.wikipedia.org/wiki/Object_identifier>
 //!
+//! ## Implementation
+//!
+//! This library supports parsing OIDs in const contexts, e.g.:
+//!
+//! ```rust
+//! use const_oid::ObjectIdentifier;
+//!
+//! pub const MY_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.1.1.1");
+//! ```
+//!
+//! The OID parser is implemented entirely in terms of `const fn` and without the
+//! use of proc macros.
+//!
+//! Additionally, it also includes a `const fn` OID serializer, and stores the OIDs
+//! parsed from const contexts encoded using the BER/DER serialization
+//! (sans header).
+//!
+//! This allows [`ObjectIdentifier`] to impl `AsRef<[u8]>` which can be used to
+//! obtain the BER/DER serialization of an OID, even one declared `const`.
+//!
+//! Additionally, it impls `FromStr` and `TryFrom<&[u8]>` and functions just as
+//! well as a runtime OID library.
+//!
 //! # Minimum Supported Rust Version
 //!
 //! This crate requires **Rust 1.47** at a minimum.
@@ -33,7 +56,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.5.0-pre"
+    html_root_url = "https://docs.rs/const-oid/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
@@ -93,7 +116,7 @@ impl ObjectIdentifier {
     /// ```
     /// use const_oid::ObjectIdentifier;
     ///
-    /// const MY_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.1.1.1");
+    /// pub const MY_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.1.1.1");
     /// ```
     ///
     /// # Panics

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 
 [dependencies]
-const-oid = { version = "=0.5.0-pre", optional = true, path = "../const-oid" }
+const-oid = { version = "0.5", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.3.0-pre", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 


### PR DESCRIPTION
### Added
- `TryFrom<&[u8]>` impl on `ObjectIdentifier` ([#338])

## Changed
- MSRV 1.47+ ([#338])
- Renamed the following methods ([#338]):
  - `ObjectIdentifier::new` => `ObjectIdentifier::from_arcs`
  - `ObjectIdentifier::parse` => `ObjectIdentifier::new`
  - `ObjectIdentifier::from_ber` => `ObjectIdentifier::from_bytes`

### Removed
- Deprecated methods ([#338])
- `alloc` feature - only used by aforementioned deprecated methods ([#338])
- `TryFrom<&[Arc]>` impl on `ObjectIdentifier` - use `::from_arcs` ([#338])

[#338]: https://github.com/RustCrypto/utils/pull/338