### PR TITLE
der: add `Length::one` and `Length::for_tlv`

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -112,14 +112,6 @@ impl<'a> Any<'a> {
     pub fn utf8_string(self) -> Result<Utf8String<'a>> {
         self.try_into()
     }
-
-    /// Get the ASN.1 DER [`Header`] for this [`Any`] value
-    pub(crate) fn header(self) -> Header {
-        Header {
-            tag: self.tag,
-            length: self.len(),
-        }
-    }
 }
 
 impl<'a> Choice<'a> for Any<'a> {
@@ -141,11 +133,11 @@ impl<'a> Decodable<'a> for Any<'a> {
 
 impl<'a> Encodable for Any<'a> {
     fn encoded_len(&self) -> Result<Length> {
-        self.header().encoded_len()? + self.len()
+        self.len().for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.header().encode(encoder)?;
+        Header::new(self.tag, self.len())?.encode(encoder)?;
         encoder.bytes(self.as_bytes())
     }
 }

--- a/der/src/asn1/big_uint.rs
+++ b/der/src/asn1/big_uint.rs
@@ -79,14 +79,6 @@ where
                 _ => 0u8,                    // No leading `0`
             }
     }
-
-    /// Get the ASN.1 DER [`Header`] for this [`BigUint`] value
-    fn header(self) -> Result<Header> {
-        Ok(Header {
-            tag: Tag::Integer,
-            length: self.inner_len()?,
-        })
-    }
 }
 
 impl<'a, N> From<&BigUInt<'a, N>> for BigUInt<'a, N>
@@ -142,11 +134,11 @@ where
     N: Unsigned + NonZero,
 {
     fn encoded_len(&self) -> Result<Length> {
-        self.header()?.encoded_len()? + self.inner_len()?
+        self.inner_len()?.for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.header()?.encode(encoder)?;
+        Header::new(Self::TAG, self.inner_len()?)?.encode(encoder)?;
 
         // Add leading `0x00` byte if required
         if self.inner_len()? > self.len() {

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -28,21 +28,11 @@ impl TryFrom<Any<'_>> for bool {
 
 impl Encodable for bool {
     fn encoded_len(&self) -> Result<Length> {
-        Header {
-            tag: Tag::Boolean,
-            length: 1u8.into(),
-        }
-        .encoded_len()?
-            + 1u8
+        Length::one().for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header {
-            tag: Tag::Boolean,
-            length: 1u8.into(),
-        }
-        .encode(encoder)?;
-
+        Header::new(Self::TAG, Length::one())?.encode(encoder)?;
         let byte = if *self { TRUE_OCTET } else { FALSE_OCTET };
         encoder.byte(byte)
     }

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -24,20 +24,11 @@ impl TryFrom<Any<'_>> for i8 {
 
 impl Encodable for i8 {
     fn encoded_len(&self) -> Result<Length> {
-        Header {
-            tag: Tag::Integer,
-            length: 1u8.into(),
-        }
-        .encoded_len()?
-            + 1u8
+        Length::one().for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header {
-            tag: Tag::Integer,
-            length: 1u8.into(),
-        }
-        .encode(encoder)?;
+        Header::new(Self::TAG, Length::one())?.encode(encoder)?;
         encoder.byte(*self as u8)
     }
 }
@@ -71,12 +62,7 @@ impl Encodable for i16 {
             return x.encoded_len();
         }
 
-        Header {
-            tag: Tag::Integer,
-            length: 2u8.into(),
-        }
-        .encoded_len()?
-            + 2u8
+        Length::from(2u8).for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
@@ -84,12 +70,7 @@ impl Encodable for i16 {
             return x.encode(encoder);
         }
 
-        Header {
-            tag: Tag::Integer,
-            length: 2u8.into(),
-        }
-        .encode(encoder)?;
-
+        Header::new(Self::TAG, Length::from(2u8))?.encode(encoder)?;
         encoder.bytes(&self.to_be_bytes())
     }
 }
@@ -121,21 +102,11 @@ impl TryFrom<Any<'_>> for u8 {
 impl Encodable for u8 {
     fn encoded_len(&self) -> Result<Length> {
         let inner_len = if *self < 0x80 { 1u8 } else { 2u8 };
-
-        Header {
-            tag: Tag::Integer,
-            length: inner_len.into(),
-        }
-        .encoded_len()?
-            + inner_len
+        Length::from(inner_len).for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header {
-            tag: Tag::Integer,
-            length: if *self < 0x80 { 1u8 } else { 2u8 }.into(),
-        }
-        .encode(encoder)?;
+        Header::new(Self::TAG, if *self < 0x80 { 1u8 } else { 2u8 })?.encode(encoder)?;
 
         if *self >= 0x80 {
             encoder.byte(0)?;
@@ -177,13 +148,7 @@ impl Encodable for u16 {
         }
 
         let inner_len = if *self < 0x8000 { 2u16 } else { 3u16 };
-
-        Header {
-            tag: Tag::Integer,
-            length: inner_len.into(),
-        }
-        .encoded_len()?
-            + inner_len
+        Length::from(inner_len).for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
@@ -191,11 +156,7 @@ impl Encodable for u16 {
             return x.encode(encoder);
         }
 
-        Header {
-            tag: Tag::Integer,
-            length: if *self < 0x8000 { 2u16 } else { 3u16 }.into(),
-        }
-        .encode(encoder)?;
+        Header::new(Self::TAG, if *self < 0x8000 { 2u16 } else { 3u16 })?.encode(encoder)?;
 
         if *self >= 0x8000 {
             encoder.byte(0)?;

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -13,7 +13,7 @@ use core::{
 ///
 /// Presently constrained to the range `0..=65535`
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
-pub struct Length(u32);
+pub struct Length(pub(crate) u32);
 
 impl Length {
     /// Return a length of `0`.
@@ -21,9 +21,20 @@ impl Length {
         Length(0)
     }
 
+    /// Return a length of `1`.
+    pub const fn one() -> Self {
+        Length(1)
+    }
+
     /// Get the maximum length supported by this crate
     pub const fn max() -> Self {
         Self(65535)
+    }
+
+    /// Get the length of DER Tag-Length-Value (TLV) encoded data if `self`
+    /// is the length of the inner "value" portion of the message
+    pub fn for_tlv(self) -> Result<Self> {
+        Length(1) + self.encoded_len()? + self
     }
 }
 

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -155,7 +155,7 @@ impl Decodable<'_> for Tag {
 
 impl Encodable for Tag {
     fn encoded_len(&self) -> Result<Length> {
-        Ok(1u8.into())
+        Ok(Length::one())
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {


### PR DESCRIPTION
The latter specifically simplifies calculations for a TLV-encoded value (i.e. with tag byte and length prefix) given an inner length.