### PR TITLE
der: impl SetOf for BTreeSet

### DIFF
--- a/der/src/asn1/choice.rs
+++ b/der/src/asn1/choice.rs
@@ -14,6 +14,8 @@ pub trait Choice<'a>: Decodable<'a> + Encodable {
     fn can_decode(tag: Tag) -> bool;
 }
 
+/// This blanket impl allows any [`Tagged`] type to function as a [`Choice`]
+/// with a single alternative.
 impl<'a, T> Choice<'a> for T
 where
     T: Decodable<'a> + Encodable + Tagged,

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -36,8 +36,9 @@
 //! - `()`: ASN.1 `NULL` (see also [`Null`])
 //! - [`bool`]: ASN.1 `BOOLEAN`
 //! - [`i8`], [`i16`], [`u8`], [`u16`]: ASN.1 `INTEGER`
-//! - [`str`], [`String`][`alloc::string::String`] (latter requires `alloc` feature):
-//!   ASN.1 `UTF8String` (see also [`Utf8String`])
+//! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String` (see also [`Utf8String`])
+//!   (`String` requires `alloc` feature)
+//! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF` (requires `alloc` feature)
 //! - [`Option`]: ASN.1 `OPTIONAL`
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime` (requires `std` feature)
 //!


### PR DESCRIPTION
When `alloc` is available, `BTreeSet` is an ideal data structure for DER-encoded ASN.1 `SET OF`, as DER carries the canonicalization requirement that the elements are ordered, and `BTreeSet` is bounded on an `Ord` impl and provides ordering as a first-class property.