### PR TITLE
der_derive v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 const-oid = { version = "0.5", optional = true, path = "../const-oid" }
-der_derive = { version = "=0.3.0-pre", optional = true, path = "derive" }
+der_derive = { version = "0.3", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-03-21)
+### Added
+- `choice::Alternative` and duplicate tracking ([#300])
+- Auto-derive `From` impls for variants when deriving `Choice` ([#345])
+
+[#300]: https://github.com/RustCrypto/utils/pull/300
+[#345]: https://github.com/RustCrypto/utils/pull/345
+
 ## 0.2.2 (2021-02-22)
 ### Added
 - Custom derive support for the `Choice` trait ([#296])

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Procedural macro for automatically deriving the `der` crate's `Choice` and
 `Message` traits

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -9,6 +9,22 @@
 //! Note that this crate shouldn't be used directly, but instead accessed
 //! by using the `derive` feature of the `der` crate.
 //!
+//! # Why not `serde`?
+//!
+//! The `der` crate is designed to be easily usable in embedded environments,
+//! including ones where code size comes at a premium.
+//!
+//! This crate (i.e. `der_derive`) is able to generate code which is
+//! significantly smaller than `serde_derive`. This is because the `der`
+//! crate has been designed with high-level abstractions which reduce
+//! code size, including trait object-based encoders which allow encoding
+//! logic which is duplicated in `serde` serializers to be implemented in
+//! a single place in the `der` crate.
+//!
+//! This is a deliberate tradeoff in terms of performance, flexibility, and
+//! code size. At least for now, the `der` crate is optimizing for leveraging
+//! as many abstractions as it can to minimize code size.
+//!
 //! # `#[asn1(type = "...")]` attribute
 //!
 //! This attribute can be used to specify the ASN.1 type for a particular


### PR DESCRIPTION
### Added
- `choice::Alternative` and duplicate tracking ([#300])
- Auto-derive `From` impls for variants when deriving `Choice` ([#345])

[#300]: https://github.com/RustCrypto/utils/pull/300
[#345]: https://github.com/RustCrypto/utils/pull/345