### PR TITLE
pkcs5 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "aes",
  "block-modes",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "base64ct",
  "der",

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -36,8 +36,8 @@
 //! - `()`: ASN.1 `NULL` (see also [`Null`])
 //! - [`bool`]: ASN.1 `BOOLEAN`
 //! - [`i8`], [`i16`], [`u8`], [`u16`]: ASN.1 `INTEGER`
-//! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String` (see also [`Utf8String`])
-//!   (`String` requires `alloc` feature)
+//! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`
+//!   (see also [`Utf8String`]. `String` requires `alloc` feature)
 //! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF` (requires `alloc` feature)
 //! - [`Option`]: ASN.1 `OPTIONAL`
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime` (requires `std` feature)

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-03-22)
+### Changed
+- Bump `der` to v0.3 ([#354])
+- Bump `spki` to v0.3 ([#355])
+
+[#354]: https://github.com/RustCrypto/utils/pull/354
+[#355]: https://github.com/RustCrypto/utils/pull/355
+
 ## 0.1.1 (2021-02-23)
 ### Added
 - Encryption support ([#293], [#295])

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.2.0-pre"
+    html_root_url = "https://docs.rs/pkcs5/0.2.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)
@@ -19,7 +19,7 @@ spki = { version = "0.3", path = "../spki" }
 
 base64ct = { version = "1", optional = true, path = "../base64ct" }
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.2.0-pre", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "0.2", optional = true, path = "../pkcs5" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
### Changed
- Bump `der` to v0.3 ([#354])
- Bump `spki` to v0.3 ([#355])

[#354]: https://github.com/RustCrypto/utils/pull/354
[#355]: https://github.com/RustCrypto/utils/pull/355