### PR TITLE
pkcs8 v0.6.0

### DIFF
--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-03-22)
+### Changed
+- Bump `der` dependency to v0.3 ([#354])
+- Bump `spki` dependency to v0.3 ([#355])
+- Bump `pkcs5` dependency to v0.2 ([#356])
+
+[#354]: https://github.com/RustCrypto/utils/pull/354
+[#355]: https://github.com/RustCrypto/utils/pull/355
+[#356]: https://github.com/RustCrypto/utils/pull/356
+
 ## 0.5.5 (2021-03-17)
 ### Changed
 - Bump `base64ct` dependency to v1.0 ([#335])

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -62,7 +62,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.6.0-pre"
+    html_root_url = "https://docs.rs/pkcs8/0.6.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Bump `der` dependency to v0.3 ([#354])
- Bump `spki` dependency to v0.3 ([#355])
- Bump `pkcs5` dependency to v0.2 ([#356])

[#354]: https://github.com/RustCrypto/utils/pull/354
[#355]: https://github.com/RustCrypto/utils/pull/355
[#356]: https://github.com/RustCrypto/utils/pull/356