### PR TITLE
der: add PartialOrd + Ord impls to all ASN.1 types

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -19,7 +19,7 @@ use crate::ObjectIdentifier;
 /// Nevertheless, this crate defines an [`Any`] type as it remains a familiar
 /// and useful concept which is still extensively used in things like
 /// PKI-related RFCs.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Any<'a> {
     /// Tag representing the type of the encoded value
     pub(crate) tag: Tag,

--- a/der/src/asn1/big_uint.rs
+++ b/der/src/asn1/big_uint.rs
@@ -18,7 +18,7 @@ use typenum::{NonZero, Unsigned};
 /// indicating the size of an integer in bytes.
 ///
 /// Currently supported sizes are 1 - 512 bytes.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(docsrs, doc(cfg(feature = "big-uint")))]
 pub struct BigUInt<'a, N: Unsigned + NonZero> {
     /// Inner value

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -6,7 +6,7 @@ use crate::{
 use core::convert::TryFrom;
 
 /// ASN.1 `BIT STRING` type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct BitString<'a> {
     /// Inner value
     inner: ByteSlice<'a>,

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -26,7 +26,7 @@ const MAX_UNIX_DURATION: Duration = Duration::from_secs(253_402_300_800);
 /// > is zero.  GeneralizedTime values MUST NOT include fractional seconds.
 ///
 /// [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.2
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct GeneralizedTime(Duration);
 
 impl GeneralizedTime {

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -16,7 +16,7 @@ use core::{convert::TryFrom, fmt, str};
 /// For UTF-8, use [`Utf8String`][`crate::Utf8String`].
 ///
 /// [International Alphabet No. 5 (IA5)]: https://en.wikipedia.org/wiki/T.50_%28standard%29
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Ia5String<'a> {
     /// Inner value
     inner: StrSlice<'a>,

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -4,7 +4,7 @@ use crate::{Any, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagg
 use core::convert::TryFrom;
 
 /// ASN.1 `NULL` type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Null;
 
 impl TryFrom<Any<'_>> for Null {

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -4,7 +4,7 @@ use crate::{Any, ByteSlice, Encodable, Encoder, Error, ErrorKind, Length, Result
 use core::convert::TryFrom;
 
 /// ASN.1 `OCTET STRING` type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct OctetString<'a> {
     /// Inner value
     inner: ByteSlice<'a>,

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -32,7 +32,7 @@ use core::{convert::TryFrom, fmt, str};
 /// - `:`
 /// - `=`
 /// - `?`
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PrintableString<'a> {
     /// Inner value
     inner: StrSlice<'a>,

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -6,7 +6,7 @@ use crate::{
 use core::convert::TryFrom;
 
 /// ASN.1 `SEQUENCE` type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Sequence<'a> {
     /// Inner value
     inner: ByteSlice<'a>,

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -33,7 +33,7 @@ const MAX_UNIX_DURATION: Duration = Duration::from_secs(2_524_608_000);
 /// > - Where `YY` is less than 50, the year SHALL be interpreted as `20YY`.
 ///
 /// [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct UtcTime(Duration);
 
 impl UtcTime {

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -20,7 +20,7 @@ use alloc::{borrow::ToOwned, string::String};
 /// still provided for explicitness in cases where it might be ambiguous with
 /// other ASN.1 string encodings such as
 /// [`PrintableString`][`crate::PrintableString`].
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Utf8String<'a> {
     /// Inner value
     inner: StrSlice<'a>,

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -7,7 +7,7 @@ use crate::{Error, Length, Result};
 use core::convert::TryFrom;
 
 /// Byte slice newtype which respects the `Length::max()` limit.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ByteSlice<'a> {
     /// Inner value
     inner: &'a [u8],

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -4,8 +4,8 @@
 use crate::{Length, Result};
 use core::{convert::TryFrom, str};
 
-/// String slice newtype which respects the `Length::max()` limit.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// String slice newtype which respects the [`Length::max`] limit.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct StrSlice<'a> {
     /// Inner value
     inner: &'a str,

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -19,7 +19,7 @@ pub trait Tagged {
 ///
 /// Tags are the leading byte of the Tag-Length-Value encoding used by ASN.1
 /// DER and identify the type of the subsequent value.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 #[allow(clippy::identity_op)]
 #[non_exhaustive]
 #[repr(u8)]


### PR DESCRIPTION
This permits usage in a `SetOf` context which requires ordering.