### PR TITLE
der: make inner integer wrapped by Length fully private

### DIFF
--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -9,9 +9,6 @@ use core::{convert::TryFrom, time::Duration};
 #[cfg(feature = "std")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Length of an RFC 5280-flavored ASN.1 DER-encoded `GeneralizedTime`
-const LENGTH: usize = 15;
-
 /// Maximum duration since `UNIX_EPOCH` allowable as `GeneralizedTime`.
 const MAX_UNIX_DURATION: Duration = Duration::from_secs(253_402_300_800);
 
@@ -30,9 +27,9 @@ const MAX_UNIX_DURATION: Duration = Duration::from_secs(253_402_300_800);
 pub struct GeneralizedTime(Duration);
 
 impl GeneralizedTime {
-    /// Get the length of a [`GeneralizedTime`].
+    /// Length of an RFC 5280-flavored ASN.1 DER-encoded [`GeneralizedTime`].
     pub const fn length() -> Length {
-        Length(LENGTH as u32)
+        Length::new(15)
     }
 
     /// Create a new [`GeneralizedTime`] given a [`Duration`] since `UNIX_EPOCH`

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -9,9 +9,6 @@ use core::{convert::TryFrom, time::Duration};
 #[cfg(feature = "std")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Length of an RFC 5280-flavored ASN.1 DER-encoded `UTCTime`
-const LENGTH: usize = 13;
-
 /// Maximum duration since `UNIX_EPOCH` which can be represented as a `UTCTime`
 /// (non-inclusive) according to RFC 5280 rules.
 ///
@@ -37,9 +34,9 @@ const MAX_UNIX_DURATION: Duration = Duration::from_secs(2_524_608_000);
 pub struct UtcTime(Duration);
 
 impl UtcTime {
-    /// Get the length of a [`UtcTime`].
+    /// Length of an RFC 5280-flavored ASN.1 DER-encoded [`UtcTime`].
     pub const fn length() -> Length {
-        Length(LENGTH as u32)
+        Length::new(13)
     }
 
     /// Create a new [`UtcTime`] given a [`Duration`] since `UNIX_EPOCH`

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -13,9 +13,16 @@ use core::{
 ///
 /// Presently constrained to the range `0..=65535`
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
-pub struct Length(pub(crate) u32);
+pub struct Length(u32);
 
 impl Length {
+    /// Create a new [`Length`] for any value which fits inside of a [`u16`].
+    ///
+    /// This function is const-safe and therefore useful for [`Length`] constants.
+    pub const fn new(value: u16) -> Self {
+        Length(value as u32)
+    }
+
     /// Return a length of `0`.
     pub const fn zero() -> Self {
         Length(0)


### PR DESCRIPTION
Removes `pub(crate)` from the inner `u32` which the `Length` type wraps.

This ensures upholding the invariant that the inner length is less than `Length::max` only needs to happen in the `length` module, and builds on the work from #367 to ensure that `TryFrom<u32> for Length` is the one place where this check occurs.