### PR TITLE
der v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.1 (2021-04-01)
+## 0.3.2 (2021-04-15)
+### Fixed
+- Non-critical bug allowing `Length` to exceed the max invariant ([#367])
+
+[#367]: https://github.com/RustCrypto/utils/pull/367
+
+## 0.3.1 (2021-04-01) [YANKED]
 ### Added
 - `PartialOrd` + `Ord` impls to all ASN.1 types ([#363])
 
 [#363]: https://github.com/RustCrypto/utils/pull/363
 
-## 0.3.0 (2021-03-22)
+## 0.3.0 (2021-03-22) [YANKED]
 ### Added
 - Impl `Decode`/`Encoded`/`Tagged` for `String` ([#344])
 - `Length::one` and `Length::for_tlv` ([#351])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/README.md
+++ b/der/README.md
@@ -22,10 +22,9 @@ The core implementation avoids any heap usage (with convenience methods
 that allocate gated under the off-by-default `alloc` feature).
 
 The implementation is presently specialized for documents which are smaller
-than 64kB, as that provides a safe bound for the current use cases.
+than 64kB as that provides a safe bound for the current use cases.
 However, that may be revisited in the future depending on interest in
-support for larger documents. Please open a [GitHub Issue] if you find
-this limit constraining in practice.
+support for larger documents. See [RustCrypto/utils#370].
 
 ## License
 
@@ -59,4 +58,4 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/rustcrypto
 [`pkcs8`]: https://docs.rs/pkcs8/
-[GitHub Issue]: https://github.com/RustCrypto/utils/issues
+[RustCrypto/utils#370]: https://github.com/RustCrypto/utils/issues/370

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -13,8 +13,7 @@
 //! The implementation is presently specialized for documents which are smaller
 //! than 64kB, as that provides a safe bound for the current use cases.
 //! However, that may be revisited in the future depending on interest in
-//! support for larger documents. Please open a [GitHub Issue] if you find
-//! this limit constraining in practice.
+//! support for larger documents. See [RustCrypto/utils#370].
 //!
 //! # Minimum Supported Rust Version
 //!
@@ -322,7 +321,7 @@
 //! [X.690]: https://www.itu.int/rec/T-REC-X.690/
 //! [RustCrypto]: https://github.com/rustcrypto
 //! [`pkcs8`]: https://docs.rs/pkcs8/
-//! [GitHub Issue]: https://github.com/RustCrypto/utils/issues
+//! [RustCrypto/utils#370]: https://github.com/RustCrypto/utils/issues/370
 //! [RFC 5280 Section 4.1.1.2]: https://tools.ietf.org/html/rfc5280#section-4.1.1.2
 //! [A Layman's Guide to a Subset of ASN.1, BER, and DER]: https://luca.ntop.org/Teaching/Appunti/asn1.html
 //! [A Warm Welcome to ASN.1 and DER]: https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/
@@ -332,7 +331,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.3.1"
+    html_root_url = "https://docs.rs/der/0.3.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Fixed
- Non-critical bug allowing `Length` to exceed the max invariant ([#367])

[#367]: https://github.com/RustCrypto/utils/pull/367