### PR TITLE
der: add length constants

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -85,11 +85,11 @@ impl<'a> From<BitString<'a>> for &'a [u8] {
 
 impl<'a> Encodable for BitString<'a> {
     fn encoded_len(&self) -> Result<Length> {
-        (Length::one() + self.inner.len())?.for_tlv()
+        (Length::ONE + self.inner.len())?.for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, (Length::one() + self.inner.len())?)?.encode(encoder)?;
+        Header::new(Self::TAG, (Length::ONE + self.inner.len())?)?.encode(encoder)?;
         encoder.byte(0)?;
         encoder.bytes(self.as_bytes())
     }

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -28,11 +28,11 @@ impl TryFrom<Any<'_>> for bool {
 
 impl Encodable for bool {
     fn encoded_len(&self) -> Result<Length> {
-        Length::one().for_tlv()
+        Length::ONE.for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, Length::one())?.encode(encoder)?;
+        Header::new(Self::TAG, Length::ONE)?.encode(encoder)?;
         let byte = if *self { TRUE_OCTET } else { FALSE_OCTET };
         encoder.byte(byte)
     }

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -28,8 +28,12 @@ pub struct GeneralizedTime(Duration);
 
 impl GeneralizedTime {
     /// Length of an RFC 5280-flavored ASN.1 DER-encoded [`GeneralizedTime`].
+    pub const LENGTH: Length = Length::new(15);
+
+    /// Length of an RFC 5280-flavored ASN.1 DER-encoded [`GeneralizedTime`].
+    #[deprecated(since = "0.3.3", note = "please use GeneralizedTime::LENGTH")]
     pub const fn length() -> Length {
-        Length::new(15)
+        Self::LENGTH
     }
 
     /// Create a new [`GeneralizedTime`] given a [`Duration`] since `UNIX_EPOCH`
@@ -123,11 +127,11 @@ impl TryFrom<Any<'_>> for GeneralizedTime {
 
 impl Encodable for GeneralizedTime {
     fn encoded_len(&self) -> Result<Length> {
-        Self::length().for_tlv()
+        Self::LENGTH.for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, Self::length())?.encode(encoder)?;
+        Header::new(Self::TAG, Self::LENGTH)?.encode(encoder)?;
 
         let datetime =
             DateTime::from_unix_duration(self.0).ok_or(ErrorKind::Value { tag: Self::TAG })?;

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -24,11 +24,11 @@ impl TryFrom<Any<'_>> for i8 {
 
 impl Encodable for i8 {
     fn encoded_len(&self) -> Result<Length> {
-        Length::one().for_tlv()
+        Length::ONE.for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, Length::one())?.encode(encoder)?;
+        Header::new(Self::TAG, Length::ONE)?.encode(encoder)?;
         encoder.byte(*self as u8)
     }
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -70,6 +70,6 @@ mod tests {
     #[test]
     fn length() {
         // Ensure an infallible `From` conversion to `Any` will never panic
-        assert!(ObjectIdentifier::max_len() <= Length::max().try_into().unwrap());
+        assert!(ObjectIdentifier::max_len() <= Length::MAX.try_into().unwrap());
     }
 }

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -280,5 +280,5 @@ where
     T: Clone + Decodable<'a> + Encodable + Ord,
 {
     set.iter()
-        .fold(Ok(Length::zero()), |acc, val| acc? + val.encoded_len()?)
+        .fold(Ok(Length::ZERO), |acc, val| acc? + val.encoded_len()?)
 }

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -35,8 +35,12 @@ pub struct UtcTime(Duration);
 
 impl UtcTime {
     /// Length of an RFC 5280-flavored ASN.1 DER-encoded [`UtcTime`].
+    pub const LENGTH: Length = Length::new(13);
+
+    /// Length of an RFC 5280-flavored ASN.1 DER-encoded [`UtcTime`].
+    #[deprecated(since = "0.3.3", note = "please use UtcTime::LENGTH")]
     pub const fn length() -> Length {
-        Length::new(13)
+        Self::LENGTH
     }
 
     /// Create a new [`UtcTime`] given a [`Duration`] since `UNIX_EPOCH`
@@ -121,11 +125,11 @@ impl TryFrom<Any<'_>> for UtcTime {
 
 impl Encodable for UtcTime {
     fn encoded_len(&self) -> Result<Length> {
-        Self::length().for_tlv()
+        Self::LENGTH.for_tlv()
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, Self::length())?.encode(encoder)?;
+        Header::new(Self::TAG, Self::LENGTH)?.encode(encoder)?;
 
         let datetime =
             DateTime::from_unix_duration(self.0).ok_or(ErrorKind::Value { tag: Self::TAG })?;

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -38,7 +38,7 @@ impl<'a> ByteSlice<'a> {
 
     /// Is this [`ByteSlice`] empty?
     pub fn is_empty(self) -> bool {
-        self.len() == Length::zero()
+        self.len() == Length::ZERO
     }
 }
 

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -33,7 +33,7 @@ impl<'a> Decoder<'a> {
     pub fn new(bytes: &'a [u8]) -> Self {
         Self {
             bytes: Some(bytes),
-            position: Length::zero(),
+            position: Length::ZERO,
         }
     }
 
@@ -251,7 +251,7 @@ mod tests {
         let mut decoder = Decoder::new(&[]);
         let err = bool::decode(&mut decoder).err().unwrap();
         assert_eq!(ErrorKind::Truncated, err.kind());
-        assert_eq!(Some(Length::zero()), err.position());
+        assert_eq!(Some(Length::ZERO), err.position());
     }
 
     #[test]

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -24,7 +24,7 @@ impl<'a> Encoder<'a> {
     pub fn new(bytes: &'a mut [u8]) -> Self {
         Self {
             bytes: Some(bytes),
-            position: Length::zero(),
+            position: Length::ZERO,
         }
     }
 
@@ -274,6 +274,6 @@ mod tests {
         let mut encoder = Encoder::new(&mut buffer);
         let err = false.encode(&mut encoder).err().unwrap();
         assert_eq!(err.kind(), ErrorKind::Overlength);
-        assert_eq!(err.position(), Some(Length::zero()));
+        assert_eq!(err.position(), Some(Length::ZERO));
     }
 }

--- a/der/src/message.rs
+++ b/der/src/message.rs
@@ -58,7 +58,7 @@ pub fn encoded_len(fields: &[&dyn Encodable]) -> Result<Length> {
 /// [`Encodable`] fields when serialized as ASN.1 DER, including the header
 /// (i.e. tag and length)
 pub(crate) fn encoded_len_inner(fields: &[&dyn Encodable]) -> Result<Length> {
-    fields.iter().fold(Ok(Length::zero()), |sum, encodable| {
+    fields.iter().fold(Ok(Length::ZERO), |sum, encodable| {
         sum + encodable.encoded_len()?
     })
 }

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -46,7 +46,7 @@ impl<'a> StrSlice<'a> {
 
     /// Is this [`StrSlice`] empty?
     pub fn is_empty(self) -> bool {
-        self.len() == Length::zero()
+        self.len() == Length::ZERO
     }
 }
 

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -155,7 +155,7 @@ impl Decodable<'_> for Tag {
 
 impl Encodable for Tag {
     fn encoded_len(&self) -> Result<Length> {
-        Ok(Length::one())
+        Ok(Length::ONE)
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {


### PR DESCRIPTION
Adds the following constants:

- `Length::ZERO`
- `Length::ONE`
- `Length::MAX`
- `GeneralizedTime::LENGTH`
- `UtcTime::LENGTH`

Deprecates the `const fn`s that previously provided the same values.