### PR TITLE
const-oid v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2021-04-15)
+### Added
+- `ObjectIdentifier::MAX_LENGTH` constant ([#372])
+
+### Changed
+- Deprecate `ObjectIdentifier::max_len()` function ([#372])
+
+[#372]: https://github.com/RustCrypto/utils/pull/372
+
 ## 0.5.0 (2021-03-21)
 ### Added
 - `TryFrom<&[u8]>` impl on `ObjectIdentifier` ([#338])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -56,7 +56,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.5.0"
+    html_root_url = "https://docs.rs/const-oid/0.5.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 
 [dependencies]
-const-oid = { version = "0.5", optional = true, path = "../const-oid" }
+const-oid = { version = "0.5.1", optional = true, path = "../const-oid" }
 der_derive = { version = "0.3", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 


### PR DESCRIPTION
### Added
- `ObjectIdentifier::MAX_LENGTH` constant ([#372])

### Changed
- Deprecate `ObjectIdentifier::max_len()` function ([#372])

[#372]: https://github.com/RustCrypto/utils/pull/372