### PR TITLE
const-oid+der: forbid unwrap

### DIFF
--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -119,11 +119,12 @@ pub(crate) fn write_base128(bytes: &mut [u8], mut n: Arc) -> Result<usize> {
         let byte = bytes.get_mut(i).ok_or(Error)?;
         *byte = (n & 0b1111111 | mask) as u8;
         n >>= 7;
-        i = i.checked_sub(1).unwrap();
+        i = i.checked_sub(1).expect("overflow");
         mask = 0b10000000;
     }
 
-    *bytes.get_mut(0).unwrap() = (n | mask) as u8;
+    bytes[0] = (n | mask) as u8;
+
     Ok(nbytes + 1)
 }
 

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -58,7 +58,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_root_url = "https://docs.rs/const-oid/0.5.2"
 )]
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]

--- a/der/src/asn1/big_uint.rs
+++ b/der/src/asn1/big_uint.rs
@@ -114,7 +114,7 @@ where
         // values the leading `0x00` byte may need to be removed.
         // TODO(tarcieri): validate leading 0 byte was required
         if bytes.len() > N::to_usize() {
-            if bytes.len() != N::to_usize().checked_add(1).unwrap() {
+            if bytes.len() != N::to_usize().checked_add(1).expect("overflow") {
                 return Err(ErrorKind::Length { tag: Self::TAG }.into());
             }
 

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `NULL` support.
 
-use crate::{Any, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged};
+use crate::{Any, ByteSlice, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 /// ASN.1 `NULL` type.
@@ -23,7 +23,10 @@ impl TryFrom<Any<'_>> for Null {
 
 impl<'a> From<Null> for Any<'a> {
     fn from(_: Null) -> Any<'a> {
-        Any::new(Tag::Null, &[]).unwrap()
+        Any {
+            tag: Tag::Null,
+            value: ByteSlice::default(),
+        }
     }
 }
 
@@ -57,7 +60,7 @@ impl TryFrom<Any<'_>> for () {
 
 impl<'a> From<()> for Any<'a> {
     fn from(_: ()) -> Any<'a> {
-        Any::new(Tag::Null, &[]).unwrap()
+        Null.into()
     }
 }
 

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -48,6 +48,15 @@ impl AsRef<[u8]> for ByteSlice<'_> {
     }
 }
 
+impl Default for ByteSlice<'_> {
+    fn default() -> Self {
+        Self {
+            inner: &[],
+            length: Length::ZERO,
+        }
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for ByteSlice<'a> {
     type Error = Error;
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -333,7 +333,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_root_url = "https://docs.rs/der/0.3.3"
 )]
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Uses Clippy to forbid use of `unwrap()` on both `Option` and `Result`.

Also fixes the few lingering uses of unwrap (in one case replacing it with panic-free code)