### PR TITLE
pkcs5: bump `aes`, `block-modes`, `hmac`, and `pbkdf2`

### DIFF
--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -41,9 +41,33 @@ jobs:
           override: true
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features alloc
-      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features encryption
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pem
-      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pkcs5
+
+  # `pkcs5` crate is MSRV 1.49+
+  encryption:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.49.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features alloc
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pem
+      - run: cargo test --release --features encryption
+      - run: cargo test --release --features pkcs5
+      - run: cargo test --release --all-features
 
   test:
     runs-on: ubuntu-latest
@@ -62,7 +86,4 @@ jobs:
       - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --features alloc
-      - run: cargo test --release --features encryption
       - run: cargo test --release --features pem
-      - run: cargo test --release --features pkcs5
-      - run: cargo test --release --all-features

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.47.0 # Highest MSRV in repo
+        toolchain: 1.49.0 # Highest MSRV in repo
         components: clippy
         override: true
         profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,32 +4,13 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+checksum = "99446914425f48a667458b33c7fb920e24cf9e7c149a072a9fc420731b353835"
 dependencies = [
- "aes-soft",
- "aesni",
+ "cfg-if",
  "cipher",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher",
- "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher",
+ "cpufeatures 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -63,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
+checksum = "783474235dae38fb23b124e596ac32b20c4cca908ae9c7bc88d63773dded444c"
 dependencies = [
  "block-padding 0.2.1",
  "cipher",
@@ -92,9 +73,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
 ]
@@ -115,6 +96,12 @@ name = "cpufeatures"
 version = "0.1.0"
 
 [[package]]
+name = "cpufeatures"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,9 +109,9 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -194,9 +181,9 @@ checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -214,9 +201,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "crypto-mac",
 ]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -17,10 +17,10 @@ readme = "README.md"
 der = { version = "0.3", features = ["oid"], path = "../der" }
 spki = { version = "0.3", path = "../spki" }
 
-aes = { version = "0.6", optional = true }
-block-modes = { version = "0.7", optional = true, default-features = false }
-hmac = { version = "0.10", optional = true, default-features = false }
-pbkdf2 = { version = "0.7", optional = true, default-features = false }
+aes = { version = "0.7", optional = true }
+block-modes = { version = "0.8", optional = true, default-features = false }
+hmac = { version = "0.11", optional = true, default-features = false }
+pbkdf2 = { version = "0.8", optional = true, default-features = false }
 sha2 = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs5/README.md
+++ b/pkcs5/README.md
@@ -34,7 +34,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs5/badge.svg
 [docs-link]: https://docs.rs/pkcs5/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 [build-image]: https://github.com/RustCrypto/utils/workflows/pkcs5/badge.svg?branch=master&event=push

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.47** at a minimum.
+//! This crate requires **Rust 1.49** at a minimum.
 //!
 //! # Usage
 //!

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -33,11 +33,11 @@ pub fn encrypt_in_place<'b>(
 
     match params.encryption {
         EncryptionScheme::Aes128Cbc { iv } => {
-            let cipher = Aes128Cbc::new_var(key.as_slice(), iv).map_err(|_| CryptoError)?;
+            let cipher = Aes128Cbc::new_from_slices(key.as_slice(), iv).map_err(|_| CryptoError)?;
             cipher.encrypt(buffer, pos).map_err(|_| CryptoError)
         }
         EncryptionScheme::Aes256Cbc { iv } => {
-            let cipher = Aes256Cbc::new_var(key.as_slice(), iv).map_err(|_| CryptoError)?;
+            let cipher = Aes256Cbc::new_from_slices(key.as_slice(), iv).map_err(|_| CryptoError)?;
             cipher.encrypt(buffer, pos).map_err(|_| CryptoError)
         }
     }
@@ -59,11 +59,11 @@ pub fn decrypt_in_place<'a>(
 
     match params.encryption {
         EncryptionScheme::Aes128Cbc { iv } => {
-            let cipher = Aes128Cbc::new_var(key.as_slice(), iv).map_err(|_| CryptoError)?;
+            let cipher = Aes128Cbc::new_from_slices(key.as_slice(), iv).map_err(|_| CryptoError)?;
             cipher.decrypt(buffer).map_err(|_| CryptoError)
         }
         EncryptionScheme::Aes256Cbc { iv } => {
-            let cipher = Aes256Cbc::new_var(key.as_slice(), iv).map_err(|_| CryptoError)?;
+            let cipher = Aes256Cbc::new_from_slices(key.as_slice(), iv).map_err(|_| CryptoError)?;
             cipher.decrypt(buffer).map_err(|_| CryptoError)
         }
     }


### PR DESCRIPTION
Bumps the following crate dependencies:
- `aes` v0.7
- `block-modes` v0.8
- `hmac` v0.11
- `pkbdf2` v0.8