### PR TITLE
pkcs5 v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes",
  "block-modes",

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2021-04-29)
+### Changed
+- Bump `aes` to v0.7 ([#388])
+- Bump `block-modes` to v0.8  ([#388])
+- Bump `hmac` to v0.11  ([#388])
+- Bump `pbkdf2` to v0.8  ([#388])
+
+[#388]: https://github.com/RustCrypto/utils/pull/388
+
 ## 0.2.0 (2021-03-22)
 ### Changed
 - Bump `der` to v0.3 ([#354])

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.2.0"
+    html_root_url = "https://docs.rs/pkcs5/0.2.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `aes` to v0.7 ([#388])
- Bump `block-modes` to v0.8  ([#388])
- Bump `hmac` to v0.11  ([#388])
- Bump `pbkdf2` to v0.8  ([#388])

[#388]: https://github.com/RustCrypto/utils/pull/388