### PR TITLE
cpufeatures: fix Linux/aarch64 support

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -23,9 +23,15 @@ macro_rules! __unless_target_features {
 #[doc(hidden)]
 macro_rules! __detect_target_features {
     ($($tf:tt),+) => {{
-        let hwcaps = unsafe { libc::getauxval(libc::AT_HWCAP) };
+        let hwcaps = $crate::aarch64::getauxval_hwcap();
         $($crate::check!(hwcaps, $tf) & )+ true
     }};
+}
+
+/// Linux helper function for calling `getauxval` to get `AT_HWCAP`.
+#[cfg(target_os = "linux")]
+pub fn getauxval_hwcap() -> u64 {
+    unsafe { libc::getauxval(libc::AT_HWCAP) }
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
The `__detect_target_features` macro was expanding into code that directly referenced `libc::getauxval`.

This commit adds a small helper function for querying `AT_HWCAP` using `getauxval` similar to the `sysctlbyname` helper function used on MacOS, and then has the macro invoke it using `$crate::`.