### PR TITLE
cpufeatures v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "99446914425f48a667458b33c7fb920e24cf9e7c149a072a9fc420731b353835"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpufeatures 0.1.0",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -94,15 +94,15 @@ dependencies = [
 [[package]]
 name = "cpufeatures"
 version = "0.1.0"
-dependencies = [
- "libc",
-]
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
+version = "0.1.1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -270,7 +270,7 @@ checksum = "d8f6b75b17576b792bef0db1bcc4b8b8bcdf9506744cf34b974195487af6cff2"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpufeatures 0.1.0",
  "digest",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,5 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2021-05-06)
+### Added
+- `aarch64` support for Linux and macOS/M4 targets ([#393])
+
+[#393]: https://github.com/RustCrypto/utils/pull/393
+
 ## 0.1.0 (2021-04-29)
 - Initial release

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Lightweight and efficient no-std compatible alternative to the
 is_x86_feature_detected! macro

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/cpufeatures/0.1.0"
+    html_root_url = "https://docs.rs/cpufeatures/0.1.1"
 )]
 
 #[cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")))]


### PR DESCRIPTION
### Added
- `aarch64` support for Linux and macOS/M4 targets ([#393])

[#393]: https://github.com/RustCrypto/utils/pull/393