### PR TITLE
cpufeatures v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpufeatures 0.1.1",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -94,15 +94,15 @@ dependencies = [
 [[package]]
 name = "cpufeatures"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+version = "0.1.2"
 dependencies = [
  "libc",
 ]
@@ -273,7 +273,7 @@ checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpufeatures 0.1.1",
  "digest",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2021-05-13)
+### Added
+- `neon` feature detection on `aarch64` targets ([#403])
+
+### Fixed
+- Support for `musl`-based targets ([#403])
+
+[#403]: https://github.com/RustCrypto/utils/pull/403
+
 ## 0.1.1 (2021-05-06)
 ### Added
 - `aarch64` support for Linux and macOS/M4 targets ([#393])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Lightweight and efficient no-std compatible alternative to the
 is_x86_feature_detected! macro

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/cpufeatures/0.1.1"
+    html_root_url = "https://docs.rs/cpufeatures/0.1.2"
 )]
 
 #[cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")))]


### PR DESCRIPTION
### Added
- `neon` feature detection on `aarch64` targets ([#403])

### Fixed
- Support for `musl`-based targets ([#403])

[#403]: https://github.com/RustCrypto/utils/pull/403