### PR TITLE
cpufeatures: remove `neon` on `aarch64` targets

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -67,7 +67,6 @@ macro_rules! __expand_check_macro {
 #[cfg(target_os = "linux")]
 __expand_check_macro! {
     ("aes",  HWCAP_AES),  // Enable AES support.
-    ("neon", HWCAP_NEON), // Enable Advanced SIMD instructions.
     ("sha2", HWCAP_SHA2), // Enable SHA1 and SHA256 support.
     ("sha3", HWCAP_SHA3), // Enable SHA512 and SHA3 support.
 }
@@ -100,9 +99,6 @@ pub mod hwcaps {
 #[doc(hidden)]
 macro_rules! check {
     ("aes") => {
-        true
-    };
-    ("neon") => {
         true
     };
     ("sha2") => {

--- a/cpufeatures/tests/aarch64.rs
+++ b/cpufeatures/tests/aarch64.rs
@@ -2,7 +2,7 @@
 
 #![cfg(target_arch = "aarch64")]
 
-cpufeatures::new!(armcaps, "aes", "neon", "sha2", "sha3");
+cpufeatures::new!(armcaps, "aes", "sha2", "sha3");
 
 #[test]
 fn init() {


### PR DESCRIPTION
The `neon` feature is enabled by default on all `aarch64` targets, so there is no need for runtime detection on these targets.

Runtime detection might be interesting on 32-bit ARM targets, however this crate's ARM support is presently `aarch64`-only.