### PR TITLE
cpufeatures v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.2 (2021-05-13)
+## 0.1.3 (2021-05-13)
+### Removed
+- `neon` on `aarch64` targets: already enabled by default ([#406])
+
+[#406]: https://github.com/RustCrypto/utils/pull/406
+
+## 0.1.2 (2021-05-13) [YANKED]
 ### Added
 - `neon` feature detection on `aarch64` targets ([#403])
 

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.1.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Lightweight and efficient no-std compatible alternative to the
 is_x86_feature_detected! macro

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/cpufeatures/0.1.2"
+    html_root_url = "https://docs.rs/cpufeatures/0.1.3"
 )]
 
 #[cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")))]


### PR DESCRIPTION
### Removed
- `neon` on `aarch64` targets: already enabled by default ([#406])

[#406]: https://github.com/RustCrypto/utils/pull/406