### PR TITLE
cpufeatures: support compiling on non-Linux/macOS aarch64 targets

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -134,3 +134,13 @@ pub unsafe fn sysctlbyname(name: &[u8]) -> bool {
     assert_eq!(rc, 0, "sysctlbyname returned error code: {}", rc);
     value != 0
 }
+
+// On other targets, runtime CPU feature detection is unavailable
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __detect_target_features {
+    ($($tf:tt),+) => {
+        false
+    };
+}

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -60,19 +60,15 @@
     html_root_url = "https://docs.rs/cpufeatures/0.1.3"
 )]
 
-#[cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")))]
+#[cfg(all(target_arch = "aarch64"))]
 #[doc(hidden)]
 pub mod aarch64;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
 
-#[cfg(not(any(
-    all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
-    target_arch = "x86",
-    target_arch = "x86_64"
-)))]
-compile_error!("This crate works only on `aarch64` (Linux/Mac), `x86`, and `x86-64` targets.");
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
+compile_error!("This crate works only on `aarch64`, `x86`, and `x86-64` targets.");
 
 /// Create module with CPU feature detection code.
 #[macro_export]


### PR DESCRIPTION
ARM CPU feature detection is unfortunately tied to OS APIs, as the registers containing information about CPU features are not accessible to unprivileged userspace programs.

However, the previous setup which gated support on Linux/macOS only means that OS-specific gating needs to be repeated in every downstream consumer of `cpufeatures`, and also that if support for new environments is added in `cpufeatures` that downstream consumers don't receive it automatically.

This commit adds a fallback for non-Linux/macOS aarch64 environments, similarly to how we handle SGX, which always returns `false` unless the corresponding `target_feature`(s) are explicitly enabled in `RUSTFLAGS`. This allows `cpufeatures` to provide the mechanism for `target_feature`-based gating on these other platforms, even if it can't
provide runtime feature detection support.