### PR TITLE
cpufeatures v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4 (2021-05-14)
+### Added
+- Support compiling on non-Linux/macOS aarch64 targets ([#408])
+
+[#408]: https://github.com/RustCrypto/utils/pull/408
+
 ## 0.1.3 (2021-05-13)
 ### Removed
 - `neon` on `aarch64` targets: already enabled by default ([#406])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.1.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.4" # Also update html_root_url in lib.rs when bumping this
 description = """
 Lightweight and efficient no-std compatible alternative to the
 is_x86_feature_detected! macro

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/cpufeatures/0.1.3"
+    html_root_url = "https://docs.rs/cpufeatures/0.1.4"
 )]
 
 #[cfg(all(target_arch = "aarch64"))]


### PR DESCRIPTION
### Added
- Support compiling on non-Linux/macOS aarch64 targets ([#408])

[#408]: https://github.com/RustCrypto/utils/pull/408