### PR TITLE
der: support `Length` of up to 1 MiB

### DIFF
--- a/der/README.md
+++ b/der/README.md
@@ -21,11 +21,6 @@ implemented as part of the [RustCrypto] project, e.g. the [`pkcs8`] crate.
 The core implementation avoids any heap usage (with convenience methods
 that allocate gated under the off-by-default `alloc` feature).
 
-The implementation is presently specialized for documents which are smaller
-than 64kB as that provides a safe bound for the current use cases.
-However, that may be revisited in the future depending on interest in
-support for larger documents. See [RustCrypto/utils#370].
-
 ## License
 
 Licensed under either of:

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -10,11 +10,6 @@
 //! The core implementation avoids any heap usage (with convenience methods
 //! that allocate gated under the off-by-default `alloc` feature).
 //!
-//! The implementation is presently specialized for documents which are smaller
-//! than 64kB, as that provides a safe bound for the current use cases.
-//! However, that may be revisited in the future depending on interest in
-//! support for larger documents. See [RustCrypto/utils#370].
-//!
 //! # Minimum Supported Rust Version
 //!
 //! This crate requires **Rust 1.47** at a minimum.


### PR DESCRIPTION
Adds support for 4-byte DER-encoded lengths.

While this could potentially support lengths up to 16 MiB (2 << 24) the library maintains a more conservative cap of 1 MiB as this should be sufficient for the security-oriented cases this library is intended to be used for.

This can be re-examined if there is a legitimate use case.

Closes #370.
