### PR TITLE
crypto-bigint

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -1,0 +1,55 @@
+name: crypto-bigint
+
+on:
+  pull_request:
+    paths:
+      - "crypto-bigint/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: crypto-bigint
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --target ${{ matrix.target }} --release
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo test --release
+      - run: cargo test --release --all-features

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.49.0 # Highest MSRV in repo
+        toolchain: 1.51.0 # Highest MSRV in repo
         components: clippy
         override: true
         profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.0.0"
+dependencies = [
+ "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "collectable",
     "const-oid",
     "cpufeatures",
+    "crypto-bigint",
     "dbl",
     "der",
     "der/derive",

--- a/crypto-bigint/CHANGELOG.md
+++ b/crypto-bigint/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "crypto-bigint"
+version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+description = """
+Pure Rust implementation of a big integer library designed from the ground-up
+for use in cryptographic applications only. Provides constant-time,
+no_std-friendly implementations of modern formulas using const generics.
+"""
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+repository = "https://github.com/RustCrypto/utils/tree/master/crypto-bigint"
+categories = ["algorithms", "cryptography", "data-structures", "mathematics", "no-std"]
+keywords = ["arbitrary", "crypto", "bignum", "integer", "precision"]
+readme = "README.md"
+
+[dependencies]
+subtle = { version = "2", default-features = false }
+
+[dev-dependencies]
+hex-literal = "0.3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto-bigint/LICENSE-APACHE
+++ b/crypto-bigint/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crypto-bigint/LICENSE-MIT
+++ b/crypto-bigint/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2020 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crypto-bigint/README.md
+++ b/crypto-bigint/README.md
@@ -1,0 +1,57 @@
+# [RustCrypto]: Cryptographic Big Integers
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+[![Build Status][build-image]][build-link]
+
+Pure Rust implementation of a big integer library designed from the ground-up
+for use in cryptographic applications only. Provides constant-time,
+no_std-friendly implementations of modern formulas using const generics.
+
+[Documentation][docs-link]
+
+## Status
+
+tl;dr: not ready to use.
+
+This is a work-in-progress prototype of what is possible in a const generics-based
+big integer library oriented towards cryptography.
+
+However, const generics support in Rust is still in a very early stage and thus
+so is this library. We intend to evolve it along with Rust's support for const
+generics until they meet our baseline requirements.
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/crypto-bigint.svg
+[crate-link]: https://crates.io/crates/crypto-bigint
+[docs-image]: https://docs.rs/crypto-bigint/badge.svg
+[docs-link]: https://docs.rs/crypto-bigint/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
+[build-image]: https://github.com/RustCrypto/utils/workflows/crypto-bigint/badge.svg?branch=master&event=push
+[build-link]: https://github.com/RustCrypto/utils/actions?query=workflow:crypto-bigint
+
+[//]: # (general links)
+
+[RustCrypto]: https://github.com/rustcrypto

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -1,0 +1,44 @@
+//! Pure Rust implementation of a big integer library designed from the ground-up
+//! for use in cryptographic applications only. Provides constant-time,
+//! no_std-friendly implementations of modern formulas using const generics.
+
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/crypto-bigint/0.0.0"
+)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+mod ops;
+mod traits;
+mod uint;
+
+pub use crate::{
+    traits::{NumBits, NumBytes},
+    uint::*,
+};
+
+/// Big integers modeled as an array of smaller integers called "limbs"
+#[cfg(target_pointer_width = "32")]
+pub type Limb = u32;
+
+/// Big integers modeled as an array of smaller integers called "limbs"
+#[cfg(target_pointer_width = "64")]
+pub type Limb = u64;
+
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("this crate builds on 32-bit and 64-bit platforms only");
+
+/// Number of bytes in a [`Limb`].
+#[cfg(target_pointer_width = "32")]
+pub const LIMB_BYTES: usize = 4;
+
+/// Number of bytes in a [`Limb`].
+#[cfg(target_pointer_width = "64")]
+pub const LIMB_BYTES: usize = 8;

--- a/crypto-bigint/src/ops.rs
+++ b/crypto-bigint/src/ops.rs
@@ -1,0 +1,19 @@
+//! Arithmetic operations designed for efficient lowering to machine code..
+
+/// Computes `a + b + carry`, returning the result along with the new carry.
+/// 32-bit version.
+#[cfg(target_pointer_width = "32")]
+#[inline(always)]
+pub const fn adc(a: u32, b: u32, carry: u32) -> (u32, u32) {
+    let ret = (a as u64) + (b as u64) + (carry as u64);
+    (ret as u32, (ret >> 32) as u32)
+}
+
+/// Computes `a + b + carry`, returning the result along with the new carry.
+/// 64-bit version.
+#[cfg(target_pointer_width = "64")]
+#[inline(always)]
+pub const fn adc(a: u64, b: u64, carry: u64) -> (u64, u64) {
+    let ret = (a as u128) + (b as u128) + (carry as u128);
+    (ret as u64, (ret >> 64) as u64)
+}

--- a/crypto-bigint/src/traits.rs
+++ b/crypto-bigint/src/traits.rs
@@ -1,0 +1,13 @@
+//! Traits provided by this crate
+
+/// Number of bits required to express a given big integer.
+pub trait NumBits {
+    /// Number of bits required to express this integer.
+    const NUM_BITS: usize;
+}
+
+/// Number of bytes required to express a given big integer.
+pub trait NumBytes {
+    /// Number of bytes required to express this integer.
+    const NUM_BYTES: usize;
+}

--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -1,0 +1,429 @@
+//! Big unsigned integers.
+
+#![allow(clippy::needless_range_loop)]
+
+use crate::{ops, Limb, NumBits, NumBytes, LIMB_BYTES};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+/// Constant panicking assertion.
+// TODO(tarcieri): use const panic when stable.
+// See: https://github.com/rust-lang/rust/issues/51999
+macro_rules! const_assert {
+    ($bool:expr, $msg:expr) => {
+        [$msg][!$bool as usize]
+    };
+}
+
+/// Big unsigned integer.
+///
+/// Generic over the given number of `LIMBS`
+// TODO(tarcieri): make generic around a specified number of bits.
+#[derive(Copy, Clone, Debug)]
+pub struct UInt<const LIMBS: usize> {
+    /// Inner limb array.
+    ///
+    /// Stored from least significant to most significant.
+    limbs: [Limb; LIMBS],
+}
+
+impl<const LIMBS: usize> UInt<LIMBS> {
+    /// The value `0`.
+    pub const ZERO: Self = Self::from_u8(0);
+
+    /// The value `1`.
+    pub const ONE: Self = Self::from_u8(1);
+
+    /// Create a [`UInt`] from a `u8` (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<u8>`
+    pub const fn from_u8(n: u8) -> Self {
+        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        let mut limbs = [0; LIMBS];
+        limbs[0] = n as Limb;
+        Self { limbs }
+    }
+
+    /// Create a [`UInt`] from a `u16` (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<u16>`
+    pub const fn from_u16(n: u16) -> Self {
+        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        let mut limbs = [0; LIMBS];
+        limbs[0] = n as Limb;
+        Self { limbs }
+    }
+
+    /// Create a [`UInt`] from a `u32` (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<u32>`
+    pub const fn from_u32(n: u32) -> Self {
+        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        let mut limbs = [0; LIMBS];
+        limbs[0] = n as Limb;
+        Self { limbs }
+    }
+
+    /// Create a [`UInt`] from a `u64` (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<u64>`
+    #[cfg(target_pointer_width = "32")]
+    pub const fn from_u64(n: u64) -> Self {
+        const_assert!(LIMBS >= 2, "number of limbs must be two or greater");
+        let mut limbs = [0; LIMBS];
+        limbs[0] = (n & 0xFFFF) as u32;
+        limbs[1] = (n >> 32) as u32;
+        Self { limbs }
+    }
+
+    /// Create a [`UInt`] from a `u64` (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<u64>`
+    #[cfg(target_pointer_width = "64")]
+    pub const fn from_u64(n: u64) -> Self {
+        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        let mut limbs = [0; LIMBS];
+        limbs[0] = n as Limb;
+        Self { limbs }
+    }
+
+    /// Create a new [`UInt`] from the provided big endian bytes.
+    pub const fn from_be_bytes(bytes: &[u8]) -> Self {
+        const_assert!(
+            bytes.len() == LIMB_BYTES * LIMBS,
+            "bytes are not the expected size"
+        );
+
+        let mut limbs = [0; LIMBS];
+        let mut i = 0;
+        let mut offset = LIMB_BYTES * LIMBS;
+
+        while i < LIMBS {
+            offset -= LIMB_BYTES;
+            let mut j = 0;
+
+            while j < LIMB_BYTES {
+                limbs[i] = (limbs[i] << 8) | bytes[offset + j] as Limb;
+                j += 1;
+            }
+
+            i += 1;
+        }
+
+        Self { limbs }
+    }
+
+    /// Create a new [`UInt`] from the provided little endian bytes.
+    pub const fn from_le_bytes(bytes: &[u8]) -> Self {
+        const_assert!(
+            bytes.len() == LIMB_BYTES * LIMBS,
+            "bytes are not the expected size"
+        );
+
+        let mut limbs = [0; LIMBS];
+        let mut i = 0;
+
+        while i < LIMBS {
+            let mut j = LIMB_BYTES;
+            let offset = i * LIMB_BYTES;
+
+            while j > 0 {
+                limbs[i] = (limbs[i] << 8) | bytes[offset + j - 1] as Limb;
+                j -= 1;
+            }
+
+            i += 1;
+        }
+
+        Self { limbs }
+    }
+
+    /// Determine if this [`UInt`] is equal to zero.
+    ///
+    /// # Returns
+    ///
+    /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    pub fn is_zero(&self) -> Choice {
+        self.ct_eq(&Self::ZERO)
+    }
+
+    /// Computes `a + b + carry`, returning the result along with the new carry.
+    /// 64-bit version.
+    #[inline(always)]
+    pub const fn adc(&self, rhs: &Self, mut carry: Limb) -> (Self, Limb) {
+        let mut limbs = [0; LIMBS];
+        let mut i = 0;
+
+        while i < LIMBS {
+            let (w, c) = ops::adc(self.limbs[i], rhs.limbs[i], carry);
+            limbs[i] = w;
+            carry = c;
+            i += 1;
+        }
+
+        (Self { limbs }, carry)
+    }
+
+    /// Perform checked addition, returning [`CtOption`] only if the operation
+    /// did not overflow.
+    pub fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
+        let (result, carry) = self.adc(rhs, 0);
+        CtOption::new(result, !Choice::from(carry as u8))
+    }
+}
+
+impl<const LIMBS: usize> ConditionallySelectable for UInt<LIMBS> {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        let mut limbs = [0; LIMBS];
+
+        for i in 0..LIMBS {
+            limbs[i] = Limb::conditional_select(&a.limbs[0], &b.limbs[0], choice);
+        }
+
+        Self { limbs }
+    }
+}
+
+impl<const LIMBS: usize> ConstantTimeEq for UInt<LIMBS> {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.limbs
+            .iter()
+            .zip(other.limbs.iter())
+            .fold(Choice::from(1), |acc, (a, b)| acc & a.ct_eq(b))
+    }
+}
+
+impl<const LIMBS: usize> Default for UInt<LIMBS> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<const LIMBS: usize> From<u8> for UInt<LIMBS> {
+    fn from(n: u8) -> Self {
+        // TODO(tarcieri): const where clause when possible
+        debug_assert!(LIMBS > 0, "limbs must be non-zero");
+        Self::from_u8(n)
+    }
+}
+
+impl<const LIMBS: usize> From<u16> for UInt<LIMBS> {
+    fn from(n: u16) -> Self {
+        // TODO(tarcieri): const where clause when possible
+        debug_assert!(LIMBS > 0, "limbs must be non-zero");
+        Self::from_u16(n)
+    }
+}
+
+impl<const LIMBS: usize> From<u32> for UInt<LIMBS> {
+    fn from(n: u32) -> Self {
+        // TODO(tarcieri): const where clause when possible
+        debug_assert!(LIMBS > 0, "limbs must be non-zero");
+        Self::from_u32(n)
+    }
+}
+
+impl<const LIMBS: usize> From<u64> for UInt<LIMBS> {
+    fn from(n: u64) -> Self {
+        // TODO(tarcieri): const where clause when possible
+        debug_assert!(LIMBS > 0, "limbs must be non-zero");
+        Self::from_u64(n)
+    }
+}
+
+impl<const LIMBS: usize> PartialEq for UInt<LIMBS> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl<const LIMBS: usize> Eq for UInt<LIMBS> {}
+
+macro_rules! impl_biguint_aliases {
+    ($(($name:ident, $bits:expr, $doc:expr)),+) => {
+        $(
+            #[doc = $doc]
+            #[doc="unsigned big integer"]
+            #[cfg(target_pointer_width = "32")]
+            pub type $name = UInt<{$bits / 32}>;
+
+            #[doc = $doc]
+            #[doc="unsigned big integer"]
+            #[cfg(target_pointer_width = "64")]
+            pub type $name = UInt<{$bits / 64}>;
+
+            impl NumBits for $name {
+                const NUM_BITS: usize = $bits;
+            }
+
+            impl NumBytes for $name {
+                const NUM_BYTES: usize = $bits / 8;
+            }
+        )+
+     };
+}
+
+// TODO(tarcieri): make generic around a specified number of bits.
+impl_biguint_aliases! {
+    (U64, 64, "64-bit"),
+    (U128, 128, "128-bit"),
+    (U192, 192, "192-bit"),
+    (U256, 256, "256-bit"),
+    (U320, 320, "320-bit"),
+    (U384, 384, "384-bit"),
+    (U448, 448, "448-bit"),
+    (U512, 512, "512-bit"),
+    (U576, 576, "576-bit"),
+    (U640, 640, "640-bit"),
+    (U704, 704, "704-bit"),
+    (U768, 768, "768-bit"),
+    (U832, 832, "832-bit"),
+    (U896, 896, "896-bit"),
+    (U960, 960, "960-bit"),
+    (U1024, 1024, "1024-bit"),
+    (U1088, 1088, "1088-bit"),
+    (U1152, 1152, "1152-bit"),
+    (U1216, 1216, "1216-bit"),
+    (U1280, 1280, "1280-bit"),
+    (U1344, 1344, "1344-bit"),
+    (U1408, 1408, "1408-bit"),
+    (U1472, 1472, "1472-bit"),
+    (U1536, 1536, "1536-bit"),
+    (U1600, 1600, "1600-bit"),
+    (U1664, 1664, "1664-bit"),
+    (U1728, 1728, "1728-bit"),
+    (U1792, 1792, "1792-bit"),
+    (U1856, 1856, "1856-bit"),
+    (U1920, 1920, "1920-bit"),
+    (U1984, 1984, "1984-bit"),
+    (U2048, 2048, "2048-bit"),
+    (U2112, 2112, "2112-bit"),
+    (U2176, 2176, "2176-bit"),
+    (U2240, 2240, "2240-bit"),
+    (U2304, 2304, "2304-bit"),
+    (U2368, 2368, "2368-bit"),
+    (U2432, 2432, "2432-bit"),
+    (U2496, 2496, "2496-bit"),
+    (U2560, 2560, "2560-bit"),
+    (U2624, 2624, "2624-bit"),
+    (U2688, 2688, "2688-bit"),
+    (U2752, 2752, "2752-bit"),
+    (U2816, 2816, "2816-bit"),
+    (U2880, 2880, "2880-bit"),
+    (U2944, 2944, "2944-bit"),
+    (U3008, 3008, "3008-bit"),
+    (U3072, 3072, "3072-bit"),
+    (U3136, 3136, "3136-bit"),
+    (U3200, 3200, "3200-bit"),
+    (U3264, 3264, "3264-bit"),
+    (U3328, 3328, "3328-bit"),
+    (U3392, 3392, "3392-bit"),
+    (U3456, 3456, "3456-bit"),
+    (U3520, 3520, "3520-bit"),
+    (U3584, 3584, "3584-bit"),
+    (U3648, 3648, "3648-bit"),
+    (U3712, 3712, "3712-bit"),
+    (U3776, 3776, "3776-bit"),
+    (U3840, 3840, "3840-bit"),
+    (U3904, 3904, "3904-bit"),
+    (U3968, 3968, "3968-bit"),
+    (U4032, 4032, "4032-bit"),
+    (U4096, 4096, "4096-bit")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::LIMB_BYTES;
+    use hex_literal::hex;
+
+    // 2-limb example that's twice as wide as the native word size
+    #[cfg(target_pointer_width = "64")]
+    use super::U128 as UIntEx;
+    #[cfg(target_pointer_width = "32")]
+    use super::U64 as UIntEx;
+
+    // Maximum value for `UIntEx`
+    #[cfg(target_pointer_width = "32")]
+    const MAX_UINT_HEX: [u8; LIMB_BYTES * 2] = hex!("FFFFFFFFFFFFFFFF");
+    #[cfg(target_pointer_width = "64")]
+    const MAX_UINT_HEX: [u8; LIMB_BYTES * 2] = hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
+    #[test]
+    fn from_u8() {
+        let n = UIntEx::from_u8(42u8);
+        assert_eq!(&n.limbs, &[42, 0]);
+    }
+
+    #[test]
+    fn from_u16() {
+        let n = UIntEx::from_u16(42u16);
+        assert_eq!(&n.limbs, &[42, 0]);
+    }
+
+    #[test]
+    fn from_u64() {
+        let n = UIntEx::from_u64(42u64);
+        assert_eq!(&n.limbs, &[42, 0]);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn from_be_bytes() {
+        let bytes = hex!("0011223344556677");
+        let n = UIntEx::from_be_bytes(&bytes);
+        assert_eq!(&n.limbs, &[0x44556677, 0x00112233]);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn from_be_bytes() {
+        let bytes = hex!("00112233445566778899aabbccddeeff");
+        let n = UIntEx::from_be_bytes(&bytes);
+        assert_eq!(&n.limbs, &[0x8899aabbccddeeff, 0x0011223344556677]);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn from_le_bytes() {
+        let bytes = hex!("7766554433221100");
+        let n = UIntEx::from_le_bytes(&bytes);
+        assert_eq!(&n.limbs, &[0x44556677, 0x00112233]);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn from_le_bytes() {
+        let bytes = hex!("ffeeddccbbaa99887766554433221100");
+        let n = UIntEx::from_le_bytes(&bytes);
+        assert_eq!(&n.limbs, &[0x8899aabbccddeeff, 0x0011223344556677]);
+    }
+
+    #[test]
+    fn is_zero() {
+        assert!(bool::from(UIntEx::ZERO.is_zero()));
+        assert!(!bool::from(UIntEx::ONE.is_zero()));
+    }
+
+    #[test]
+    fn adc_no_carry() {
+        let (res, carry) = UIntEx::ZERO.adc(&UIntEx::ONE, 0);
+        assert_eq!(res, UIntEx::ONE);
+        assert_eq!(carry, 0);
+    }
+
+    #[test]
+    fn adc_carry_out() {
+        let n = UIntEx::from_be_bytes(&MAX_UINT_HEX);
+        let (res, carry) = n.adc(&UIntEx::ONE, 0);
+
+        assert_eq!(res, UIntEx::ZERO);
+        assert_eq!(carry, 1);
+    }
+
+    #[test]
+    fn checked_add_ok() {
+        let result = UIntEx::ZERO.checked_add(&UIntEx::ONE);
+        assert_eq!(result.unwrap(), UIntEx::ONE);
+    }
+
+    #[test]
+    fn checked_add_overflow() {
+        let n = UIntEx::from_be_bytes(&MAX_UINT_HEX);
+        let result = n.checked_add(&UIntEx::ONE);
+        assert!(!bool::from(result.is_some()));
+    }
+}


### PR DESCRIPTION
This commit adds an experimental prototype const generics-based big integer library targeting cryptographic use cases.

It's an extraction of some of the code from the `elliptic-curve` crates, modified to use const generics.

The immediate intended use case is being able to use it for elliptic curve constants, such as a curve's `Order`:

https://docs.rs/elliptic-curve/0.9.11/elliptic_curve/trait.Order.html

As such, it's been written with liberal usage of `const fn`. This allows safe usage in const scenarios which isn't possible with `generic-array`.

All that said, in general I think we could benefit from a library like this for several applications, including things like `rsa` and `dsa`.