### PR TITLE
pkcs8: expose Attributes

### DIFF
--- a/pkcs8/src/attributes.rs
+++ b/pkcs8/src/attributes.rs
@@ -1,31 +1,70 @@
+//! `OneAsymmetricKey` attributes.
+
 use core::convert::TryFrom;
 
-use der::{Any, Encodable, Encoder, Error, Length, Result, Tag, Tagged};
+use der::{Any, Encodable, Encoder, Error, Header, Length, Result, Tag, Tagged};
 
-// TODO: make proper attributes struct
-#[derive(Debug)]
-pub(crate) struct Attributes;
+/// Attributes as defined in [RFC 5958 Section 2]:
+///
+/// > attributes is OPTIONAL.  It contains information corresponding to
+/// > the public key (e.g., certificates).  The attributes field uses the
+/// > class `ATTRIBUTE` which is restricted by the
+/// > `OneAsymmetricKeyAttributes` information object set.
+/// > `OneAsymmetricKeyAttributes` is an open ended set in this document.
+/// > Others documents can constrain these values.  Attributes from
+/// > RFC2985 MAY be supported.
+///
+/// Attributes have the following ASN.1 schema:
+///
+/// ```text
+/// Attributes ::= SET OF Attribute { { OneAsymmetricKeyAttributes } }
+/// ```
+///
+/// [RFC 5958 Section 2]: https://datatracker.ietf.org/doc/html/rfc5958
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Attributes<'a> {
+    /// Inner ASN.1 value (i.e. `SET OF Attribute`).
+    // TODO(tarcieri): decode this as a `SetOf`?
+    inner: Any<'a>,
+}
 
-impl TryFrom<Any<'_>> for Attributes {
+impl<'a> Attributes<'a> {
+    /// Create an [`Attributes`] wrapper for the given [`Any`] value.
+    ///
+    /// Note that no validation of this value is performed. It is assumed to be
+    /// a well-structured set of `OneAsymmetricKeyAttributes`.
+    pub fn from_raw_attrs(attrs: Any<'a>) -> Self {
+        Self { inner: attrs }
+    }
+
+    /// Borrow the inner attributes value as an [`Any`].
+    // TODO(tarcieri): decode this as a `SetOf` and allow iteration?
+    pub fn as_any(&self) -> &Any<'a> {
+        &self.inner
+    }
+}
+
+impl<'a> TryFrom<Any<'a>> for Attributes<'a> {
     type Error = Error;
 
-    fn try_from(any: Any<'_>) -> Result<Attributes> {
+    fn try_from(any: Any<'a>) -> Result<Self> {
         any.tag().assert_eq(Self::TAG)?;
-
-        Ok(Attributes)
+        let inner = Any::try_from(any.as_bytes())?;
+        Ok(Self { inner })
     }
 }
 
-impl Encodable for Attributes {
+impl<'a> Encodable for Attributes<'a> {
     fn encoded_len(&self) -> Result<Length> {
-        Length::ONE.for_tlv()
+        self.inner.encoded_len()?.for_tlv()
     }
 
-    fn encode(&self, _encoder: &mut Encoder<'_>) -> Result<()> {
-        Ok(())
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Header::new(Self::TAG, self.inner.encoded_len()?)?.encode(encoder)?;
+        self.inner.encode(encoder)
     }
 }
 
-impl Tagged for Attributes {
+impl<'a> Tagged for Attributes<'a> {
     const TAG: Tag = Tag::ContextSpecific0;
 }

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -75,26 +75,30 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use der::{self, ObjectIdentifier};
-#[cfg(feature = "pkcs5")]
-pub use encrypted_private_key_info::EncryptedPrivateKeyInfo;
-#[cfg(feature = "pkcs5")]
-pub use pkcs5;
-pub use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
-
-#[cfg(all(feature = "alloc", feature = "pkcs5"))]
-pub use crate::document::encrypted_private_key::EncryptedPrivateKeyDocument;
-#[cfg(feature = "alloc")]
 pub use crate::{
-    document::{private_key::PrivateKeyDocument, public_key::PublicKeyDocument},
-    traits::{ToPrivateKey, ToPublicKey},
-};
-pub use crate::{
+    attributes::Attributes,
     error::{Error, Result},
     one_asymmetric_key::OneAsymmetricKey,
     private_key_info::PrivateKeyInfo,
     traits::{FromPrivateKey, FromPublicKey},
     version::Version,
+};
+pub use der::{self, ObjectIdentifier};
+pub use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
+
+#[cfg(feature = "pkcs5")]
+pub use encrypted_private_key_info::EncryptedPrivateKeyInfo;
+
+#[cfg(feature = "pkcs5")]
+pub use pkcs5;
+
+#[cfg(all(feature = "alloc", feature = "pkcs5"))]
+pub use crate::document::encrypted_private_key::EncryptedPrivateKeyDocument;
+
+#[cfg(feature = "alloc")]
+pub use crate::{
+    document::{private_key::PrivateKeyDocument, public_key::PublicKeyDocument},
+    traits::{ToPrivateKey, ToPublicKey},
 };
 
 mod attributes;

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -11,6 +11,7 @@ use crate::Error;
 pub enum Version {
     /// Denotes PKCS#8 v1, used for [`crate::PrivateKeyInfo`] and [`crate::OneAsymmetricKey`]
     V1 = 0,
+
     /// Denotes PKCS#8 v2, only used for [`crate::OneAsymmetricKey`]
     V2 = 1,
 }
@@ -31,6 +32,7 @@ impl TryFrom<u8> for Version {
         }
     }
 }
+
 impl<'a> TryFrom<der::Any<'a>> for Version {
     type Error = der::Error;
     fn try_from(any: der::Any<'a>) -> der::Result<Version> {


### PR DESCRIPTION
Exposes raw `Attributes` for the `OneAsymmetricKey` struct.

No attempt is made to parse them as a `SET OF Attribute`. Instead it exposes an inner `Any` value for the context-specific tag 0.

The main use case for this is likely to be an optional certificate field, possibly used in the context of PKCS#12, however we presently have no examples with attributes which makes it difficult to model them any more specifically than a wrapper for an `Any` value.

This should be enough that if someone actually needs access to the attributes that they're exposed and available.

cc @ShadowJonathan 