### PR TITLE
der v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.5 (2021-05-24)
+### Added
+- Helper methods for context-specific fields ([#422], [#423], [#428], [#429])
+- `ContextSpecific` field wrapper ([#428])
+- Decoder position tracking for errors during `Any<'a>` decoding ([#431])
+
+### Fixed
+- `From` conversion for `BitString` into `Any` ([#428])
+
+[#422]: https://github.com/RustCrypto/utils/pull/422
+[#423]: https://github.com/RustCrypto/utils/pull/423
+[#428]: https://github.com/RustCrypto/utils/pull/428
+[#429]: https://github.com/RustCrypto/utils/pull/429
+[#431]: https://github.com/RustCrypto/utils/pull/431
+
 ## 0.3.4 (2021-05-16)
 ### Changed
 - Support `Length` of up to 1 MiB ([#411])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.3.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.5" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -89,11 +89,6 @@ impl<'a> Any<'a> {
         self.try_into()
     }
 
-    /// Attempt to decode an `OPTIONAL` ASN.1 `CONTEXT-SPECIFIC` field.
-    pub fn context_specific_optional(self) -> Result<Option<ContextSpecific<'a>>> {
-        self.optional()
-    }
-
     /// Attempt to decode an ASN.1 `GeneralizedTime`.
     pub fn generalized_time(self) -> Result<GeneralizedTime> {
         self.try_into()

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -326,7 +326,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.3.4"
+    html_root_url = "https://docs.rs/der/0.3.5"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.3", features = ["oid"], path = "../der" }
+der = { version = "0.3.5", features = ["oid"], path = "../der" }
 spki = { version = "0.3", path = "../spki" }
 
 base64ct = { version = "1", optional = true, path = "../base64ct" }


### PR DESCRIPTION
### Added
- Helper methods for context-specific fields ([#422], [#423], [#428], [#429])
- `ContextSpecific` field wrapper ([#428])
- Decoder position tracking for errors during `Any<'a>` decoding (#431)

### Fixed
- `From` conversion for `BitString` into `Any` ([#428])

[#422]: https://github.com/RustCrypto/utils/pull/422
[#423]: https://github.com/RustCrypto/utils/pull/423
[#428]: https://github.com/RustCrypto/utils/pull/428
[#429]: https://github.com/RustCrypto/utils/pull/429