### PR TITLE
pkcs8 v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2021-05-24)
+### Added
+- Support for RFC5958's `OneAsymmetricKey` ([#424], [#425])
+
+### Changed
+- Bump `der` to v0.3.5 ([#430])
+
+[#424]: https://github.com/RustCrypto/utils/pull/424
+[#425]: https://github.com/RustCrypto/utils/pull/425
+[#430]: https://github.com/RustCrypto/utils/pull/430
+
 ## 0.6.0 (2021-03-22)
 ### Changed
 - Bump `der` dependency to v0.3 ([#354])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208)

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -64,7 +64,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.6.0"
+    html_root_url = "https://docs.rs/pkcs8/0.6.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- Support for RFC5958's `OneAsymmetricKey` ([#424], [#425])

### Changed
- Bump `der` to v0.3.5 ([#430])

[#424]: https://github.com/RustCrypto/utils/pull/424
[#425]: https://github.com/RustCrypto/utils/pull/425
[#430]: https://github.com/RustCrypto/utils/pull/430