### PR TITLE
cpufeatures: add iOS support (static ARM64 capabilities only)

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -135,8 +135,31 @@ pub unsafe fn sysctlbyname(name: &[u8]) -> bool {
     value != 0
 }
 
+// iOS `check!` macro.
+//
+// Unfortunately iOS does not provide access to the `sysctl(3)` API which means
+// we can only return static values for CPU features which  can be assumed to
+// be present on all Apple ARM64 hardware.
+//
+// See discussion on this issue for more information:
+// <https://github.com/RustCrypto/utils/issues/378>
+#[cfg(target_os = "ios")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! check {
+    ("aes") => {
+        true
+    };
+    ("sha2") => {
+        true
+    };
+    ("sha3") => {
+        false
+    };
+}
+
 // On other targets, runtime CPU feature detection is unavailable
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "linux", target_os = "macos")))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __detect_target_features {


### PR DESCRIPTION
All Apple ARM64 hardware has the same baseline set of statically known capabilities which can be assumed on all iOS (and macOS) platforms.

This commit adds support for those statically known capabilities on iOS.

Unfortunately it does not appear to be possible to access the `sysctl(3)` namespace on iOS in order to determine the availability of other CPU features which aren't part of this baseline set the same way we can on macOS, so a static capability set is the best we can do.

See this issue for more information: #378 