### PR TITLE
pkcs5: support scrypt as a KDF for encryption

### DIFF
--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -41,6 +41,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release
       - run: cargo build --target ${{ matrix.target }} --release --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --features pbes2
+      - run: cargo build --target ${{ matrix.target }} --release --features scrypt
       - run: cargo build --target ${{ matrix.target }} --release --features alloc,pbes2
 
   test:
@@ -60,4 +61,5 @@ jobs:
       - run: cargo test --release
       - run: cargo test --release --features alloc
       - run: cargo test --release --features pbes2
+      - run: cargo test --release --features scrypt
       - run: cargo test --release --all-features


### PR DESCRIPTION
Adds support for encrypting keys using PKCS#5 when using scrypt as the password-based KDF.

Additionally integration tests the `pkcs8` crate against a full OpenSSL-generated scrypt + AES-256-CBC test vector, including ensuring that it's possible to reproduce the original test vector by encrypting the plaintext key using the original IV/salt/scrypt params inputs.