### PR TITLE
crypto-bigint: add deserialization tests for `generic-array`

### DIFF
--- a/crypto-bigint/src/array.rs
+++ b/crypto-bigint/src/array.rs
@@ -1,5 +1,6 @@
 //! Interop support for `generic-array`
 
+use crate::uint::*;
 use generic_array::{ArrayLength, GenericArray};
 
 /// Alias for a byte array whose size is defined by [`ArrayEncoding::ByteSize`].
@@ -17,4 +18,46 @@ pub trait ArrayEncoding: Sized {
 
     /// Deserialize from a little-endian byte array.
     fn from_le_byte_array(bytes: &ByteArray<Self>) -> Self;
+}
+
+macro_rules! impl_biguint_array_encoding {
+    ($(($uint:ident, $bytes:ident)),+) => {
+        $(
+            #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
+            impl ArrayEncoding for $uint {
+                type ByteSize = crate::consts::$bytes;
+
+                #[inline]
+                fn from_be_byte_array(bytes: &ByteArray<Self>) -> Self {
+                    Self::from_be_bytes(bytes)
+                }
+
+                #[inline]
+                fn from_le_byte_array(bytes: &ByteArray<Self>) -> Self {
+                    Self::from_le_bytes(bytes)
+                }
+            }
+        )+
+     };
+}
+
+impl_biguint_array_encoding! {
+    (U64, U8),
+    (U128, U16),
+    (U192, U24),
+    (U256, U32),
+    (U320, U40),
+    (U384, U48),
+    (U448, U56),
+    (U512, U64),
+    (U576, U72),
+    (U640, U80),
+    (U704, U88),
+    (U768, U96),
+    (U832, U104),
+    (U896, U112),
+    (U960, U120),
+    (U1024, U128),
+    (U2048, U256),
+    (U4096, U512)
 }

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -1,6 +1,14 @@
-//! Pure Rust implementation of a big integer library designed from the ground-up
-//! for use in cryptographic applications only. Provides constant-time,
-//! no_std-friendly implementations of modern formulas using const generics.
+//! Pure Rust implementation of a big integer library designed for cryptography.
+//!
+//! # About
+//! This library has been designed  from the ground-up for use in cryptographic
+//! applications. It provides constant-time, `no_std`-friendly implementations
+//! of modern formulas implemented using const generics.
+//!
+//! # `generic-array` interop
+//! When the optional `generic-array` feature is enabled, this library provides
+//! an [`ArrayEncoding`] trait which can be used to serialize/deserialize big
+//! integer values as `GenericArray<u8, N>`.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -36,11 +44,11 @@ pub use {
     generic_array::{self, typenum::consts},
 };
 
-/// Big integers modeled as an array of smaller integers called "limbs"
+/// Big integers are modeled as an array of smaller integers called "limbs".
 #[cfg(target_pointer_width = "32")]
 pub type Limb = u32;
 
-/// Big integers modeled as an array of smaller integers called "limbs"
+/// Big integers are modeled as an array of smaller integers called "limbs".
 #[cfg(target_pointer_width = "64")]
 pub type Limb = u64;
 


### PR DESCRIPTION
Tests deserialization from `ByteArray` when the `generic-array` crate feature is enabled.