### PR TITLE
crypto-bigint: `to_*_byte_array`

### DIFF
--- a/crypto-bigint/README.md
+++ b/crypto-bigint/README.md
@@ -9,7 +9,7 @@
 
 Pure Rust implementation of a big integer library designed from the ground-up
 for use in cryptographic applications only. Provides constant-time,
-no_std-friendly implementations of modern formulas using const generics.
+`no_std`-friendly implementations of modern formulas using const generics.
 
 [Documentation][docs-link]
 

--- a/crypto-bigint/src/array.rs
+++ b/crypto-bigint/src/array.rs
@@ -1,7 +1,7 @@
 //! Interop support for `generic-array`
 
 use crate::uint::*;
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::{typenum, ArrayLength, GenericArray};
 
 /// Alias for a byte array whose size is defined by [`ArrayEncoding::ByteSize`].
 #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
@@ -18,14 +18,20 @@ pub trait ArrayEncoding: Sized {
 
     /// Deserialize from a little-endian byte array.
     fn from_le_byte_array(bytes: &ByteArray<Self>) -> Self;
+
+    /// Serialize to a big-endian byte array.
+    fn to_be_byte_array(&self) -> ByteArray<Self>;
+
+    /// Serialize to a little-endian byte array.
+    fn to_le_byte_array(&self) -> ByteArray<Self>;
 }
 
 macro_rules! impl_biguint_array_encoding {
-    ($(($uint:ident, $bytes:ident)),+) => {
+    ($(($uint:ident, $bytes:path)),+) => {
         $(
             #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
             impl ArrayEncoding for $uint {
-                type ByteSize = crate::consts::$bytes;
+                type ByteSize = $bytes;
 
                 #[inline]
                 fn from_be_byte_array(bytes: &ByteArray<Self>) -> Self {
@@ -36,28 +42,42 @@ macro_rules! impl_biguint_array_encoding {
                 fn from_le_byte_array(bytes: &ByteArray<Self>) -> Self {
                     Self::from_le_bytes(bytes)
                 }
+
+                #[inline]
+                fn to_be_byte_array(&self) -> ByteArray<Self> {
+                    let mut result = GenericArray::default();
+                    self.to_be_bytes(&mut result);
+                    result
+                }
+
+                #[inline]
+                fn to_le_byte_array(&self) -> ByteArray<Self> {
+                    let mut result = GenericArray::default();
+                    self.to_le_bytes(&mut result);
+                    result
+                }
             }
         )+
      };
 }
 
 impl_biguint_array_encoding! {
-    (U64, U8),
-    (U128, U16),
-    (U192, U24),
-    (U256, U32),
-    (U320, U40),
-    (U384, U48),
-    (U448, U56),
-    (U512, U64),
-    (U576, U72),
-    (U640, U80),
-    (U704, U88),
-    (U768, U96),
-    (U832, U104),
-    (U896, U112),
-    (U960, U120),
-    (U1024, U128),
-    (U2048, U256),
-    (U4096, U512)
+    (U64, typenum::U8),
+    (U128, typenum::U16),
+    (U192, typenum::U24),
+    (U256, typenum::U32),
+    (U320, typenum::U40),
+    (U384, typenum::U48),
+    (U448, typenum::U56),
+    (U512, typenum::U64),
+    (U576, typenum::U72),
+    (U640, typenum::U80),
+    (U704, typenum::U88),
+    (U768, typenum::U96),
+    (U832, typenum::U104),
+    (U896, typenum::U112),
+    (U960, typenum::U120),
+    (U1024, typenum::U128),
+    (U2048, typenum::U256),
+    (U4096, typenum::U512)
 }


### PR DESCRIPTION
Support generic array serialization which outputs `GenericArray<u8, N>`.

Unfortunately the array size bound necessary to pull this off can only be accomplished with `GenericArray` today (it requires non-min const generics at the very least)