### PR TITLE
crypto-bigint: add `nlimbs!` macro

### DIFF
--- a/crypto-bigint/src/macros.rs
+++ b/crypto-bigint/src/macros.rs
@@ -8,3 +8,33 @@ macro_rules! const_assert {
         [$msg][!$bool as usize]
     };
 }
+
+/// Calculate the number of limbs required to represent the given number of bits.
+// TODO(tarcieri): replace with `const_evaluatable_checked` (e.g. a `const fn`) when stable
+#[macro_export]
+macro_rules! nlimbs {
+    ($bits:expr) => {
+        $bits / 8 / $crate::LIMB_BYTES
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn nlimbs_for_bits_macro() {
+        assert_eq!(nlimbs!(64), 2);
+        assert_eq!(nlimbs!(128), 4);
+        assert_eq!(nlimbs!(192), 6);
+        assert_eq!(nlimbs!(256), 8);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn nlimbs_for_bits_macro() {
+        assert_eq!(nlimbs!(64), 1);
+        assert_eq!(nlimbs!(128), 2);
+        assert_eq!(nlimbs!(192), 3);
+        assert_eq!(nlimbs!(256), 4);
+    }
+}

--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -499,13 +499,7 @@ macro_rules! impl_biguint_aliases {
         $(
             #[doc = $doc]
             #[doc="unsigned big integer"]
-            #[cfg(target_pointer_width = "32")]
-            pub type $name = UInt<{$bits / 32}>;
-
-            #[doc = $doc]
-            #[doc="unsigned big integer"]
-            #[cfg(target_pointer_width = "64")]
-            pub type $name = UInt<{$bits / 64}>;
+            pub type $name = UInt<{nlimbs!($bits)}>;
 
             impl NumBits for $name {
                 const NUM_BITS: usize = $bits;
@@ -523,10 +517,7 @@ macro_rules! impl_concat {
     ($(($name:ident, $bits:expr)),+) => {
         $(
             impl Concat for $name {
-                #[cfg(target_pointer_width = "32")]
-                type Output = UInt<{($bits / 32) * 2}>;
-                #[cfg(target_pointer_width = "64")]
-                type Output = UInt<{($bits / 64) * 2}>;
+                type Output = UInt<{nlimbs!($bits) * 2}>;
 
                 fn concat(&self, rhs: &Self) -> Self::Output {
                     let mut output = Self::Output::default();
@@ -537,16 +528,8 @@ macro_rules! impl_concat {
                 }
             }
 
-            #[cfg(target_pointer_width = "32")]
-            impl From<($name, $name)> for UInt<{($bits / 32) * 2}> {
-                fn from(nums: ($name, $name)) -> UInt<{($bits / 32) * 2}> {
-                    nums.0.concat(&nums.1)
-                }
-            }
-
-            #[cfg(target_pointer_width = "64")]
-            impl From<($name, $name)> for UInt<{($bits / 64) * 2}> {
-                fn from(nums: ($name, $name)) -> UInt<{($bits / 64) * 2}> {
+            impl From<($name, $name)> for UInt<{nlimbs!($bits) * 2}> {
+                fn from(nums: ($name, $name)) -> UInt<{nlimbs!($bits) * 2}> {
                     nums.0.concat(&nums.1)
                 }
             }
@@ -559,10 +542,7 @@ macro_rules! impl_split {
     ($(($name:ident, $bits:expr)),+) => {
         $(
             impl Split for $name {
-                #[cfg(target_pointer_width = "32")]
-                type Output = UInt<{($bits / 32) / 2}>;
-                #[cfg(target_pointer_width = "64")]
-                type Output = UInt<{($bits / 64) / 2}>;
+                type Output = UInt<{nlimbs!($bits) / 2}>;
 
                 fn split(&self) -> (Self::Output, Self::Output) {
                     let mut hi_out = Self::Output::default();


### PR DESCRIPTION
Adds a macro which can compute the number of limbs required to store an n-bit number at compile time.

This is intended as a stop gap until a forthcoming Rust feature like `const_evaluatable_checked` allows it to be replaced with something such as a `const fn`.

For now it's needed to compute various const generic parameters however, so a macro is the only option available.