### PR TITLE
crypto-bigint: add From impl for splitting

### DIFF
--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -553,6 +553,12 @@ macro_rules! impl_split {
                     (hi_out, lo_out)
                 }
             }
+
+            impl From<$name> for (UInt<{nlimbs!($bits) / 2}>, UInt<{nlimbs!($bits) / 2}>) {
+                fn from(num: $name) -> (UInt<{nlimbs!($bits) / 2}>, UInt<{nlimbs!($bits) / 2}>) {
+                    num.split()
+                }
+            }
         )+
      };
 }


### PR DESCRIPTION
Allows splitting by using a `From` conversion to a 2-tuple of a half-width value.