### PR TITLE
crypto-bigint: add `From` conversions between `UInt` and limb arrays

### DIFF
--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -42,6 +42,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     };
 
     /// Borrow the limbs of this [`UInt`].
+    // TODO(tarcieri): eventually phase this out?
     pub const fn limbs(&self) -> &[Limb; LIMBS] {
         &self.limbs
     }
@@ -56,6 +57,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
+// TODO(tarcieri): eventually phase this out?
 impl<const LIMBS: usize> AsRef<[Limb]> for UInt<LIMBS> {
     fn as_ref(&self) -> &[Limb] {
         self.limbs()

--- a/crypto-bigint/src/uint/from.rs
+++ b/crypto-bigint/src/uint/from.rs
@@ -141,6 +141,20 @@ impl From<U128> for u128 {
     }
 }
 
+// TODO(tarcieri): eventually phase this out?
+impl<const LIMBS: usize> From<[Limb; LIMBS]> for UInt<LIMBS> {
+    fn from(limbs: [Limb; LIMBS]) -> Self {
+        Self { limbs }
+    }
+}
+
+// TODO(tarcieri): eventually phase this out?
+impl<const LIMBS: usize> From<UInt<LIMBS>> for [Limb; LIMBS] {
+    fn from(n: UInt<LIMBS>) -> [Limb; LIMBS] {
+        n.limbs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::U128;


### PR DESCRIPTION
These will make it much easier to incrementally retrofit `UInt` into the `elliptic-curve` crate and the respective curve implementations.

From an encapsulation perspective, it's a bit problematic because it's exposing the internal representation used by `UInt`, so it additionally adds TODOs to eventually remove these as they're a bit of a hack.