### PR TITLE
crypto-bigint: additional ArrayEncoding::ByteSize bounds

### DIFF
--- a/crypto-bigint/src/array.rs
+++ b/crypto-bigint/src/array.rs
@@ -1,6 +1,7 @@
 //! Interop support for `generic-array`
 
-use generic_array::{ArrayLength, GenericArray};
+use core::ops::Add;
+use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 /// Alias for a byte array whose size is defined by [`ArrayEncoding::ByteSize`].
 #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
@@ -10,7 +11,7 @@ pub type ByteArray<T> = GenericArray<u8, <T as ArrayEncoding>::ByteSize>;
 #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
 pub trait ArrayEncoding: Sized {
     /// Size of a byte array which encodes a big integer.
-    type ByteSize: ArrayLength<u8>;
+    type ByteSize: ArrayLength<u8> + Add + Eq + Ord + Unsigned;
 
     /// Deserialize from a big-endian byte array.
     fn from_be_byte_array(bytes: &ByteArray<Self>) -> Self;


### PR DESCRIPTION
Matches the previous bounds used by `elliptic_curve::FieldSize` so we can easily migrate the `elliptic-curve` crate to use this as the basis of all `ArrayLength` computations.