### PR TITLE
const-oid v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "0.0.2"
 
 [[package]]
 name = "const-oid"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-06-03)
+### Changed
+- Modernize and remove deprecations; MSRV 1.51+ ([#458])
+
+[#458]: https://github.com/RustCrypto/utils/pull/458
+
 ## 0.5.2 (2021-04-20)
 ### Added
 - Expand README.md ([#376])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -56,7 +56,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.6.0-pre"
+    html_root_url = "https://docs.rs/const-oid/0.6.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 
 [dependencies]
-const-oid = { version = "=0.6.0-pre", optional = true, path = "../const-oid" }
+const-oid = { version = "0.6", optional = true, path = "../const-oid" }
 der_derive = { version = "0.3", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 


### PR DESCRIPTION
### Changed
- Modernize and remove deprecations; MSRV 1.51+ ([#458])

[#458]: https://github.com/RustCrypto/utils/pull/458