### PR TITLE
der: const generic unsigned integer decoder with u32/u64/u128 support

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -170,7 +170,7 @@ impl<'a> Decodable<'a> for Any<'a> {
             // The first octet of a BIT STRING encodes the number of unused bits.
             // We presently constrain this to 0.
             if *byte != 0 {
-                return decoder.error(ErrorKind::Noncanonical);
+                return decoder.error(ErrorKind::Noncanonical { tag });
             }
 
             value = rest;

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -16,12 +16,12 @@ impl TryFrom<Any<'_>> for bool {
     type Error = Error;
 
     fn try_from(any: Any<'_>) -> Result<bool> {
-        any.tag().assert_eq(Tag::Boolean)?;
+        let tag = any.tag().assert_eq(Tag::Boolean)?;
 
         match any.as_bytes() {
             [FALSE_OCTET] => Ok(false),
             [TRUE_OCTET] => Ok(true),
-            _ => Err(ErrorKind::Noncanonical.into()),
+            _ => Err(ErrorKind::Noncanonical { tag }.into()),
         }
     }
 }

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -1,0 +1,82 @@
+//! Unsigned integer decoders/encoders.
+
+use crate::{asn1::Any, Encodable, Encoder, ErrorKind, Header, Length, Result, Tag};
+use core::convert::TryFrom;
+
+/// Decode an unsigned integer of the specified size.
+///
+/// Returns a byte array of the requested size containing a big endian integer.
+// TODO(tarcieri): consolidate this with the implementation in `big_uint`.
+pub(crate) fn decode<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
+    any.tag().assert_eq(Tag::Integer)?;
+    let mut input = any.as_bytes();
+
+    // Disallow a leading byte which would overflow a signed ASN.1 integer
+    // (since we're decoding an unsigned integer).
+    //
+    // We expect all such cases to have a leading `0x00` byte
+    // (see comment below)
+    if let Some(byte) = input.get(0).cloned() {
+        if byte > 0x80 {
+            return Err(ErrorKind::Value { tag: Tag::Integer }.into());
+        }
+    }
+
+    // The `INTEGER` type always encodes a signed value, so for unsigned
+    // values the leading `0x00` byte may need to be removed.
+    if input.len() > N {
+        if input.len().saturating_sub(1) != N {
+            return Err(ErrorKind::Length { tag: Tag::Integer }.into());
+        }
+
+        if input.get(0).cloned() != Some(0) {
+            return Err(ErrorKind::Value { tag: Tag::Integer }.into());
+        }
+
+        input = &input[1..];
+    }
+
+    let mut output = [0u8; N];
+    output[N.saturating_sub(input.len())..].copy_from_slice(input);
+    Ok(output)
+}
+
+/// Encode the given big endian bytes representing an integer as ASN.1 DER.
+pub(crate) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
+    let bytes = strip_leading_zeroes(bytes);
+    let leading_zero = needs_leading_zero(bytes);
+    let len = (Length::try_from(bytes.len())? + leading_zero as u8)?;
+    Header::new(Tag::Integer, len)?.encode(encoder)?;
+
+    if leading_zero {
+        encoder.byte(0)?;
+    }
+
+    encoder.bytes(bytes)
+}
+
+/// Get the encoded length for the given unsigned integer serialized as bytes.
+#[inline]
+pub(crate) fn encoded_len(bytes: &[u8]) -> Result<Length> {
+    let bytes = strip_leading_zeroes(bytes);
+    Length::try_from(bytes.len())? + needs_leading_zero(bytes) as u8
+}
+
+/// Strip the leading zeroes from the given byte slice
+fn strip_leading_zeroes(mut bytes: &[u8]) -> &[u8] {
+    // Strip leading zeroes
+    while let Some((byte, rest)) = bytes.split_first() {
+        if *byte == 0 && !rest.is_empty() {
+            bytes = rest;
+        } else {
+            break;
+        }
+    }
+
+    bytes
+}
+
+/// Does the given integer need a leading zero?
+fn needs_leading_zero(bytes: &[u8]) -> bool {
+    matches!(bytes.get(0), Some(byte) if *byte >= 0x80)
+}

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -56,7 +56,6 @@ where
     /// Create a new [`SetOfRef`] from a slice.
     pub fn new(slice: &'a [u8]) -> Result<Self> {
         let inner = ByteSlice::new(slice).map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
-
         let mut decoder = Decoder::new(slice);
         let mut last_value = None;
 
@@ -67,7 +66,7 @@ where
 
             if let Some(last) = last_value.as_ref() {
                 if last >= &value {
-                    return Err(ErrorKind::Noncanonical.into());
+                    return Err(ErrorKind::Noncanonical { tag: Self::TAG }.into());
                 }
             }
 
@@ -210,7 +209,7 @@ where
 
             if let Some(last) = last_value.take() {
                 if last >= value {
-                    return Err(ErrorKind::Noncanonical.into());
+                    return Err(ErrorKind::Noncanonical { tag: Self::TAG }.into());
                 }
 
                 result.insert(last);

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -118,12 +118,15 @@ pub enum ErrorKind {
 
     /// Incorrect length for a given field.
     Length {
-        /// Tag type of the value being decoded.
+        /// Tag of the value being decoded.
         tag: Tag,
     },
 
     /// Message is not canonically encoded.
-    Noncanonical,
+    Noncanonical {
+        /// Tag of the value which is not canonically encoded.
+        tag: Tag,
+    },
 
     /// Malformed OID
     MalformedOid,
@@ -214,7 +217,9 @@ impl fmt::Display for ErrorKind {
             ErrorKind::DuplicateField { tag } => write!(f, "duplicate field for {}", tag),
             ErrorKind::Failed => write!(f, "operation failed"),
             ErrorKind::Length { tag } => write!(f, "incorrect length for {}", tag),
-            ErrorKind::Noncanonical => write!(f, "DER is not canonically encoded"),
+            ErrorKind::Noncanonical { tag } => {
+                write!(f, "ASN.1 {} not canonically encoded as DER", tag)
+            }
             ErrorKind::MalformedOid => write!(f, "malformed OID"),
             ErrorKind::Overflow => write!(f, "integer overflow"),
             ErrorKind::Overlength => write!(f, "DER message is too long"),

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -175,7 +175,7 @@ impl Decodable<'_> for Length {
                 if length.initial_octet() == Some(tag) {
                     Ok(length)
                 } else {
-                    Err(ErrorKind::Noncanonical.into())
+                    Err(ErrorKind::Overlength.into())
                 }
             }
             _ => {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! - `()`: ASN.1 `NULL` (see also [`Null`])
 //! - [`bool`]: ASN.1 `BOOLEAN`
-//! - [`i8`], [`i16`], [`u8`], [`u16`]: ASN.1 `INTEGER`
+//! - [`i8`], [`i16`], [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`
 //!   (see also [`Utf8String`]. `String` requires `alloc` feature)
 //! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF` (requires `alloc` feature)


### PR DESCRIPTION
This is another take on #325, but using const generics as a way to provide a common implementation for Rust's unsigned integer primitives.

This commit replaces the existing DER decoder/encoder implementations for integer primitives with a core const generic implementation, and uses macros to write implementations of `TryFrom<Any>`, `Encodable`, and the `Tagged` traits for each of the integer primitives.

This commit extends support to `u32`, `u64`, and `u128` using:

    impl_uint_encoding!(u8, u16, u32, u64, u128);