### PR TITLE
der: rename `big-uint` feature to `bigint`; `crypto-bigint` support

### DIFF
--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -37,9 +37,9 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
-      - run: cargo build --target ${{ matrix.target }} --release --features big-uint
+      - run: cargo build --target ${{ matrix.target }} --release --features bigint
       - run: cargo build --target ${{ matrix.target }} --release --features oid
-      - run: cargo build --target ${{ matrix.target }} --release --features big-uint,oid
+      - run: cargo build --target ${{ matrix.target }} --release --features bigint,oid
 
   test:
     runs-on: ubuntu-latest
@@ -69,6 +69,6 @@ jobs:
           override: true
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features big-uint
+      - run: cargo test --target ${{ matrix.target }} --release --features bigint
       - run: cargo test --target ${{ matrix.target }} --release --features oid
       - run: cargo test --target ${{ matrix.target }} --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ name = "der"
 version = "0.4.0-pre"
 dependencies = [
  "const-oid",
+ "crypto-bigint",
  "der_derive",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 
 [dependencies]
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
+crypto-bigint = { version = "0.1", optional = true, features = ["generic-array"], path = "../crypto-bigint" }
 der_derive = { version = "0.3", optional = true, path = "derive" }
 typenum = { version = "1", optional = true }
 
@@ -25,7 +26,7 @@ hex-literal = "0.3"
 [features]
 alloc = []
 derive = ["der_derive"]
-big-uint = ["typenum"]
+bigint = ["crypto-bigint", "typenum"]
 oid = ["const-oid"]
 std = ["alloc"]
 

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -1,8 +1,8 @@
 //! ASN.1 built-in types.
 
 mod any;
-#[cfg(feature = "big-uint")]
-mod big_uint;
+#[cfg(feature = "bigint")]
+mod bigint;
 mod bit_string;
 mod boolean;
 mod context_specific;
@@ -39,6 +39,6 @@ pub use self::{
 #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 pub use const_oid::ObjectIdentifier;
 
-#[cfg(feature = "big-uint")]
-#[cfg_attr(docsrs, doc(cfg(feature = "big-uint")))]
-pub use self::big_uint::BigUInt;
+#[cfg(feature = "bigint")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
+pub use self::bigint::BigUInt;

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -6,7 +6,7 @@ use core::{
     convert::{TryFrom, TryInto},
 };
 
-#[cfg(feature = "big-uint")]
+#[cfg(feature = "bigint")]
 use typenum::{NonZero, Unsigned};
 
 /// DER decoder.
@@ -110,8 +110,8 @@ impl<'a> Decoder<'a> {
     }
 
     /// Attempt to decode an ASN.1 `INTEGER` as a [`BigUInt`].
-    #[cfg(feature = "big-uint")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "big-uint")))]
+    #[cfg(feature = "bigint")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
     pub fn big_uint<N>(&mut self) -> Result<BigUInt<'a, N>>
     where
         N: Unsigned + NonZero,

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -386,6 +386,10 @@ pub use crate::{
     tag::{Class, Tag, TagNumber, Tagged},
 };
 
+#[cfg(feature = "bigint")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
+pub use crypto_bigint as bigint;
+
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use der_derive::{Choice, Message};


### PR DESCRIPTION
Renames the previous `big-uint` feature to simply `bigint`, so as to better match the name of the `crypto-bigint` crate.

Adds impls of `TryFrom<Any>`, `Encodable`, and `Tagged` for the `crypto_bigint::UInt` type. These aren't particularly well-implemented or efficient yet, but at least PoC the functionality.

The previous `BigUInt` type is still preserved, for now, but ideally it can eventually go away and be completely replaced by
`crypto_bigint::UInt` longer-term.