### PR TITLE
der: rename `BigUInt` => `UIntBytes`

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -41,4 +41,4 @@ pub use const_oid::ObjectIdentifier;
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-pub use self::bigint::BigUInt;
+pub use self::bigint::UIntBytes;

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -6,7 +6,7 @@ use core::convert::TryFrom;
 /// Decode an unsigned integer of the specified size.
 ///
 /// Returns a byte array of the requested size containing a big endian integer.
-// TODO(tarcieri): consolidate this with the implementation in `big_uint`.
+// TODO(tarcieri): consolidate this with the implementation in `bigint`.
 pub(crate) fn decode<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
     any.tag().assert_eq(Tag::Integer)?;
     let mut input = any.as_bytes();

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -109,10 +109,10 @@ impl<'a> Decoder<'a> {
         self.decode()
     }
 
-    /// Attempt to decode an ASN.1 `INTEGER` as a [`BigUInt`].
+    /// Attempt to decode an ASN.1 `INTEGER` as a [`UIntBytes`].
     #[cfg(feature = "bigint")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-    pub fn big_uint<N>(&mut self) -> Result<BigUInt<'a, N>>
+    pub fn uint_bytes<N>(&mut self) -> Result<UIntBytes<'a, N>>
     where
         N: Unsigned + NonZero,
     {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -41,7 +41,6 @@
 //! The following ASN.1 types provided by this crate also impl these traits:
 //!
 //! - [`Any`]: ASN.1 `ANY`
-//! - [`BigUInt`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
 //! - [`BitString`]: ASN.1 `BIT STRING`
 //! - [`GeneralizedTime`]: ASN.1 `GeneralizedTime`
 //! - [`Ia5String`]: ASN.1 `IA5String`
@@ -51,6 +50,7 @@
 //! - [`PrintableString`]: ASN.1 `PrintableString` (ASCII subset)
 //! - [`Sequence`]: ASN.1 `SEQUENCE`
 //! - [`SetOfRef`]: ASN.1 `SET OF`
+//! - [`UIntBytes`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
 //! - [`UtcTime`]: ASN.1 `UTCTime`
 //! - [`Utf8String`]: ASN.1 `UTF8String`
 //!
@@ -328,7 +328,7 @@
 //! [A Warm Welcome to ASN.1 and DER]: https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/
 //!
 //! [`Any`]: asn1::Any
-//! [`BigUInt`]: asn1::BigUInt
+//! [`UIntBytes`]: asn1::UIntBytes
 //! [`BitString`]: asn1::BitString
 //! [`GeneralizedTime`]: asn1::GeneralizedTime
 //! [`Ia5String`]: asn1::Ia5String


### PR DESCRIPTION
Previously the following names were used:

- `BigUInt`: serialized big integer
- `UInt`: big integer type from the `crypto-bigint` crate

This is a bit confusing because the "Big" prefix didn't really disambiguate what `BigUInt` was: a serialized big endian integer.

This commit changes its name to reflect that.