### PR TITLE
der: simplify UIntBytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,6 @@ dependencies = [
  "crypto-bigint",
  "der_derive",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "typenum",
 ]
 
 [[package]]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -18,7 +18,6 @@ readme = "README.md"
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.1", optional = true, features = ["generic-array"], path = "../crypto-bigint" }
 der_derive = { version = "0.3", optional = true, path = "derive" }
-typenum = { version = "1", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -26,7 +25,7 @@ hex-literal = "0.3"
 [features]
 alloc = []
 derive = ["der_derive"]
-bigint = ["crypto-bigint", "typenum"]
+bigint = ["crypto-bigint"]
 oid = ["const-oid"]
 std = ["alloc"]
 

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -9,7 +9,7 @@ use core::convert::TryFrom;
 /// Decode an unsigned integer of the specified size.
 ///
 /// Returns a byte array of the requested size containing a big endian integer.
-pub(crate) fn decode<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
+pub(crate) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
     any.tag().assert_eq(Tag::Integer)?;
     let mut output = [0xFFu8; N];
     let offset = N.saturating_sub(any.as_bytes().len());
@@ -18,7 +18,7 @@ pub(crate) fn decode<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
 }
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
-pub(crate) fn encode<const N: usize>(encoder: &mut Encoder<'_>, bytes: [u8; N]) -> Result<()> {
+pub(crate) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
     let bytes = strip_leading_ones(&bytes);
     let len = Length::try_from(bytes.len())?;
     Header::new(Tag::Integer, len)?.encode(encoder)?;
@@ -27,7 +27,7 @@ pub(crate) fn encode<const N: usize>(encoder: &mut Encoder<'_>, bytes: [u8; N]) 
 
 /// Get the encoded length for the given unsigned integer serialized as bytes.
 #[inline]
-pub(crate) fn encoded_len<const N: usize>(bytes: [u8; N]) -> Result<Length> {
+pub(crate) fn encoded_len(bytes: &[u8]) -> Result<Length> {
     Length::try_from(strip_leading_ones(&bytes).len())
 }
 

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -3,46 +3,46 @@
 use crate::{asn1::Any, Encodable, Encoder, ErrorKind, Header, Length, Result, Tag};
 use core::convert::TryFrom;
 
-/// Decode an unsigned integer of the specified size.
+/// Decode an unsigned integer into a big endian byte slice with all leading
+/// zeroes removed.
 ///
 /// Returns a byte array of the requested size containing a big endian integer.
 // TODO(tarcieri): consolidate this with the implementation in `bigint`.
-pub(crate) fn decode<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
-    any.tag().assert_eq(Tag::Integer)?;
-    let mut input = any.as_bytes();
-
-    // Disallow a leading byte which would overflow a signed ASN.1 integer
-    // (since we're decoding an unsigned integer).
-    //
-    // We expect all such cases to have a leading `0x00` byte
-    // (see comment below)
-    if let Some(byte) = input.get(0).cloned() {
-        if byte > 0x80 {
-            return Err(ErrorKind::Value { tag: Tag::Integer }.into());
-        }
-    }
+pub(crate) fn decode_slice(any: Any<'_>) -> Result<&[u8]> {
+    let tag = any.tag().assert_eq(Tag::Integer)?;
+    let bytes = any.as_bytes();
 
     // The `INTEGER` type always encodes a signed value, so for unsigned
     // values the leading `0x00` byte may need to be removed.
-    if input.len() > N {
-        if input.len().saturating_sub(1) != N {
-            return Err(ErrorKind::Length { tag: Tag::Integer }.into());
-        }
-
-        if input.get(0).cloned() != Some(0) {
-            return Err(ErrorKind::Value { tag: Tag::Integer }.into());
-        }
-
-        input = &input[1..];
+    //
+    // We also disallow a leading byte which would overflow a signed ASN.1
+    // integer (since we're decoding an unsigned integer).
+    // We expect all such cases to have a leading `0x00` byte.
+    match bytes.get(0).cloned() {
+        Some(byte) if byte >= 0x80 => Err(ErrorKind::Value { tag }.into()),
+        Some(0) => match bytes.get(1).cloned() {
+            Some(byte) if byte < 0x80 => Err(ErrorKind::Noncanonical { tag }.into()),
+            Some(_) => Ok(&bytes[1..]),
+            None => Ok(bytes),
+        },
+        Some(_) => Ok(bytes),
+        None => Err(ErrorKind::Value { tag: Tag::Integer }.into()),
     }
+}
 
+/// Decode an unsigned integer into a byte array of the requested size
+/// containing a big endian integer.
+pub(crate) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
+    let input = decode_slice(any)?;
+
+    // Input has leading zeroes removed, so we need to add them back
     let mut output = [0u8; N];
     output[N.saturating_sub(input.len())..].copy_from_slice(input);
     Ok(output)
 }
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
-pub(crate) fn encode<const N: usize>(encoder: &mut Encoder<'_>, bytes: [u8; N]) -> Result<()> {
+pub(crate) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
     let bytes = strip_leading_zeroes(&bytes);
     let leading_zero = needs_leading_zero(bytes);
     let len = (Length::try_from(bytes.len())? + leading_zero as u8)?;
@@ -57,13 +57,13 @@ pub(crate) fn encode<const N: usize>(encoder: &mut Encoder<'_>, bytes: [u8; N]) 
 
 /// Get the encoded length for the given unsigned integer serialized as bytes.
 #[inline]
-pub(crate) fn encoded_len<const N: usize>(bytes: [u8; N]) -> Result<Length> {
+pub(crate) fn encoded_len(bytes: &[u8]) -> Result<Length> {
     let bytes = strip_leading_zeroes(&bytes);
     Length::try_from(bytes.len())? + needs_leading_zero(bytes) as u8
 }
 
 /// Strip the leading zeroes from the given byte slice
-fn strip_leading_zeroes(mut bytes: &[u8]) -> &[u8] {
+pub(crate) fn strip_leading_zeroes(mut bytes: &[u8]) -> &[u8] {
     while let Some((byte, rest)) = bytes.split_first() {
         if *byte == 0 && !rest.is_empty() {
             bytes = rest;

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -6,9 +6,6 @@ use core::{
     convert::{TryFrom, TryInto},
 };
 
-#[cfg(feature = "bigint")]
-use typenum::{NonZero, Unsigned};
-
 /// DER decoder.
 #[derive(Debug)]
 pub struct Decoder<'a> {
@@ -112,10 +109,7 @@ impl<'a> Decoder<'a> {
     /// Attempt to decode an ASN.1 `INTEGER` as a [`UIntBytes`].
     #[cfg(feature = "bigint")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-    pub fn uint_bytes<N>(&mut self) -> Result<UIntBytes<'a, N>>
-    where
-        N: Unsigned + NonZero,
-    {
+    pub fn uint_bytes(&mut self) -> Result<UIntBytes<'a>> {
         self.decode()
     }
 


### PR DESCRIPTION
Removes the size bounds on `UIntBytes`, and makes it a simple wrapper over the decoder/encoder functions already implemented in the `der::asn1::integer::uint` module.

Since the sized (and const generic) `UInt` type can now handle the previous use cases where a size bound is necessary, it's no longer needed and can be removed.