### PR TITLE
der: remove `bigint` feature gating on `UIntBytes`

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -1,8 +1,6 @@
 //! ASN.1 built-in types.
 
 mod any;
-#[cfg(feature = "bigint")]
-mod bigint;
 mod bit_string;
 mod boolean;
 mod context_specific;
@@ -26,6 +24,7 @@ pub use self::{
     context_specific::ContextSpecific,
     generalized_time::GeneralizedTime,
     ia5_string::Ia5String,
+    integer::bigint::UIntBytes,
     null::Null,
     octet_string::OctetString,
     printable_string::PrintableString,
@@ -38,7 +37,3 @@ pub use self::{
 #[cfg(feature = "oid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 pub use const_oid::ObjectIdentifier;
-
-#[cfg(feature = "bigint")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-pub use self::bigint::UIntBytes;

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -1,7 +1,8 @@
 //! ASN.1 `INTEGER` support.
 
-pub(crate) mod int;
-pub(crate) mod uint;
+pub(super) mod bigint;
+mod int;
+mod uint;
 
 use crate::{asn1::Any, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -1,13 +1,16 @@
 //! "Big" ASN.1 `INTEGER` types.
-// TODO(tarcieri): completely replace `UIntBytes` with `crypto_bigint::UInt`
-// It should be possible to leverage the encoding logic in `asn1::integer::uint`
 
+use super::uint;
 use crate::{
-    asn1::{integer::uint, Any},
-    ByteSlice, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag, Tagged,
+    asn1::Any, ByteSlice, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag, Tagged,
 };
-use core::convert::{TryFrom, TryInto};
-use crypto_bigint::{generic_array::GenericArray, ArrayEncoding, UInt};
+use core::convert::TryFrom;
+
+#[cfg(feature = "bigint")]
+use {
+    core::convert::TryInto,
+    crypto_bigint::{generic_array::GenericArray, ArrayEncoding, UInt},
+};
 
 /// "Big" unsigned ASN.1 `INTEGER` type.
 ///
@@ -16,13 +19,7 @@ use crypto_bigint::{generic_array::GenericArray, ArrayEncoding, UInt};
 ///
 /// Intended for use cases like very large integers that are used in
 /// cryptographic applications (e.g. keys, signatures).
-///
-/// Generic over a `Size` value (e.g. [`der::consts::U64`][`typenum::U64`]),
-/// indicating the size of an integer in bytes.
-///
-/// Currently supported sizes are 1 - 512 bytes.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
-#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
 pub struct UIntBytes<'a> {
     /// Inner value
     inner: ByteSlice<'a>,
@@ -94,6 +91,8 @@ impl<'a> Tagged for UIntBytes<'a> {
     const TAG: Tag = Tag::Integer;
 }
 
+#[cfg(feature = "bigint")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
 impl<'a, const LIMBS: usize> TryFrom<Any<'a>> for UInt<LIMBS>
 where
     UInt<LIMBS>: ArrayEncoding,
@@ -105,6 +104,8 @@ where
     }
 }
 
+#[cfg(feature = "bigint")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
 impl<'a, const LIMBS: usize> TryFrom<UIntBytes<'a>> for UInt<LIMBS>
 where
     UInt<LIMBS>: ArrayEncoding,
@@ -119,6 +120,8 @@ where
     }
 }
 
+#[cfg(feature = "bigint")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
 impl<'a, const LIMBS: usize> Encodable for UInt<LIMBS>
 where
     UInt<LIMBS>: ArrayEncoding,
@@ -135,6 +138,8 @@ where
     }
 }
 
+#[cfg(feature = "bigint")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
 impl<'a, const LIMBS: usize> Tagged for UInt<LIMBS>
 where
     UInt<LIMBS>: ArrayEncoding,

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -7,7 +7,7 @@ use core::convert::TryFrom;
 /// Decode an unsigned integer of the specified size.
 ///
 /// Returns a byte array of the requested size containing a big endian integer.
-pub(crate) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
+pub(super) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
     any.tag().assert_eq(Tag::Integer)?;
     let mut output = [0xFFu8; N];
     let offset = N.saturating_sub(any.as_bytes().len());
@@ -16,7 +16,7 @@ pub(crate) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
 }
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
-pub(crate) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
+pub(super) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
     let bytes = strip_leading_ones(&bytes);
     let len = Length::try_from(bytes.len())?;
     Header::new(Tag::Integer, len)?.encode(encoder)?;
@@ -25,7 +25,7 @@ pub(crate) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
 
 /// Get the encoded length for the given unsigned integer serialized as bytes.
 #[inline]
-pub(crate) fn encoded_len(bytes: &[u8]) -> Result<Length> {
+pub(super) fn encoded_len(bytes: &[u8]) -> Result<Length> {
     Length::try_from(strip_leading_ones(&bytes).len())
 }
 

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -7,7 +7,7 @@ use core::convert::TryFrom;
 /// zeroes removed.
 ///
 /// Returns a byte array of the requested size containing a big endian integer.
-pub(crate) fn decode_slice(any: Any<'_>) -> Result<&[u8]> {
+pub(super) fn decode_slice(any: Any<'_>) -> Result<&[u8]> {
     let tag = any.tag().assert_eq(Tag::Integer)?;
     let bytes = any.as_bytes();
 
@@ -29,7 +29,7 @@ pub(crate) fn decode_slice(any: Any<'_>) -> Result<&[u8]> {
 
 /// Decode an unsigned integer into a byte array of the requested size
 /// containing a big endian integer.
-pub(crate) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
+pub(super) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
     let input = decode_slice(any)?;
 
     // Input has leading zeroes removed, so we need to add them back
@@ -39,7 +39,7 @@ pub(crate) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
 }
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
-pub(crate) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
+pub(super) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
     let bytes = strip_leading_zeroes(&bytes);
     let leading_zero = needs_leading_zero(bytes);
     let len = (Length::try_from(bytes.len())? + leading_zero as u8)?;
@@ -54,13 +54,13 @@ pub(crate) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
 
 /// Get the encoded length for the given unsigned integer serialized as bytes.
 #[inline]
-pub(crate) fn encoded_len(bytes: &[u8]) -> Result<Length> {
+pub(super) fn encoded_len(bytes: &[u8]) -> Result<Length> {
     let bytes = strip_leading_zeroes(&bytes);
     Length::try_from(bytes.len())? + needs_leading_zero(bytes) as u8
 }
 
 /// Strip the leading zeroes from the given byte slice
-pub(crate) fn strip_leading_zeroes(mut bytes: &[u8]) -> &[u8] {
+pub(super) fn strip_leading_zeroes(mut bytes: &[u8]) -> &[u8] {
     while let Some((byte, rest)) = bytes.split_first() {
         if *byte == 0 && !rest.is_empty() {
             bytes = rest;


### PR DESCRIPTION
Now that typenum is only being used as a transitive dependency of `crypto-bigint` (which is conditionally gated on the `bigint` feature) it's possible for `UIntBytes` to always be available.

Also factors `bigint` under `asn1::integer::bigint`.