### PR TITLE
der: refactor `tag` module; add tag number helpers

### DIFF
--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -1,5 +1,10 @@
 //! ASN.1 tags.
 
+mod class;
+mod number;
+
+pub use self::{class::Class, number::TagNumber};
+
 use crate::{Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Length, Result};
 use core::{convert::TryFrom, fmt};
 
@@ -203,112 +208,6 @@ impl fmt::Display for Tag {
 impl fmt::Debug for Tag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Tag(0x{:02x}: {})", u8::from(*self), self)
-    }
-}
-
-/// ASN.1 tag numbers (i.e. lower 5 bits of a [`Tag`]).
-///
-/// From X.690 Section 8.1.2.2:
-///
-/// > bits 5 to 1 shall encode the number of the tag as a binary integer with
-/// > bit 5 as the most significant bit.
-///
-/// This library supports tag numbers ranging from zero to 30 (inclusive),
-/// which can be represented as a single identifier octet.
-///
-/// Section 8.1.2.4 describes how to support multi-byte tag numbers, which are
-/// encoded by using a leading tag number of 31 (`0b11111`). This library
-/// deliberately does not support this: tag numbers greater than 30 are
-/// disallowed.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct TagNumber(u8);
-
-impl TagNumber {
-    /// Maximum tag number supported (inclusive).
-    pub const MAX: u8 = 30;
-
-    /// Create a new tag number (const-friendly).
-    ///
-    /// Panics if the tag number is greater than [`TagNumber::MAX`]. For a fallible
-    /// conversion, use [`TryFrom`] instead.
-    #[allow(clippy::no_effect)]
-    pub const fn new(byte: u8) -> Self {
-        // TODO(tarcieri): hax! use const panic when available
-        ["tag number out of range"][(byte > Self::MAX) as usize];
-        Self(byte)
-    }
-
-    /// Get the inner value.
-    pub fn value(self) -> u8 {
-        self.0
-    }
-}
-
-impl TryFrom<u8> for TagNumber {
-    type Error = Error;
-
-    fn try_from(byte: u8) -> Result<Self> {
-        match byte {
-            0..=Self::MAX => Ok(Self(byte)),
-            _ => Err(ErrorKind::UnknownTag { byte }.into()),
-        }
-    }
-}
-
-impl From<TagNumber> for u8 {
-    fn from(tag_number: TagNumber) -> u8 {
-        tag_number.0
-    }
-}
-
-impl fmt::Display for TagNumber {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// Class of an ASN.1 [`Tag`].
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u8)]
-pub enum Class {
-    /// `UNIVERSAL`: built-in types whose meaning is the same in all
-    /// applications.
-    Universal = 0b00000000,
-
-    /// `APPLICATION`: types whose meaning is specific to an application,
-    ///
-    /// Types in two different applications may have the same
-    /// application-specific tag and different meanings.
-    Application = 0b01000000,
-
-    /// `CONTEXT-SPECIFIC`: types whose meaning is specific to a given
-    /// structured type.
-    ///
-    /// Context-specific tags are used to distinguish between component types
-    /// with the same underlying tag within the context of a given structured
-    /// type, and component types in two different structured types may have
-    /// the same tag and different meanings.
-    ContextSpecific = 0b10000000,
-
-    /// `PRIVATE`: types whose meaning is specific to a given enterprise.
-    Private = 0b11000000,
-}
-
-impl Class {
-    /// Compute the identifier octet for a tag number of this class.
-    fn octet(self, number: TagNumber, constructed: bool) -> u8 {
-        self as u8 | number.0 | (constructed as u8 * CONSTRUCTED_FLAG)
-    }
-}
-
-impl fmt::Display for Class {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Class::Universal => "UNIVERSAL",
-            Class::Application => "APPLICATION",
-            Class::ContextSpecific => "CONTEXT-SPECIFIC",
-            Class::Private => "PRIVATE",
-        })
     }
 }
 

--- a/der/src/tag/class.rs
+++ b/der/src/tag/class.rs
@@ -1,0 +1,48 @@
+use super::{TagNumber, CONSTRUCTED_FLAG};
+/// Class of an ASN.1 [`Tag`].
+use core::fmt;
+
+/// Class of an ASN.1 [`Tag`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum Class {
+    /// `UNIVERSAL`: built-in types whose meaning is the same in all
+    /// applications.
+    Universal = 0b00000000,
+
+    /// `APPLICATION`: types whose meaning is specific to an application,
+    ///
+    /// Types in two different applications may have the same
+    /// application-specific tag and different meanings.
+    Application = 0b01000000,
+
+    /// `CONTEXT-SPECIFIC`: types whose meaning is specific to a given
+    /// structured type.
+    ///
+    /// Context-specific tags are used to distinguish between component types
+    /// with the same underlying tag within the context of a given structured
+    /// type, and component types in two different structured types may have
+    /// the same tag and different meanings.
+    ContextSpecific = 0b10000000,
+
+    /// `PRIVATE`: types whose meaning is specific to a given enterprise.
+    Private = 0b11000000,
+}
+
+impl Class {
+    /// Compute the identifier octet for a tag number of this class.
+    pub(super) fn octet(self, number: TagNumber, constructed: bool) -> u8 {
+        self as u8 | number.value() | (constructed as u8 * CONSTRUCTED_FLAG)
+    }
+}
+
+impl fmt::Display for Class {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Class::Universal => "UNIVERSAL",
+            Class::Application => "APPLICATION",
+            Class::ContextSpecific => "CONTEXT-SPECIFIC",
+            Class::Private => "PRIVATE",
+        })
+    }
+}

--- a/der/src/tag/number.rs
+++ b/der/src/tag/number.rs
@@ -1,0 +1,81 @@
+//! ASN.1 tag numbers
+
+use super::Tag;
+use crate::{Error, ErrorKind, Result};
+use core::{convert::TryFrom, fmt};
+
+/// ASN.1 tag numbers (i.e. lower 5 bits of a [`Tag`]).
+///
+/// From X.690 Section 8.1.2.2:
+///
+/// > bits 5 to 1 shall encode the number of the tag as a binary integer with
+/// > bit 5 as the most significant bit.
+///
+/// This library supports tag numbers ranging from zero to 30 (inclusive),
+/// which can be represented as a single identifier octet.
+///
+/// Section 8.1.2.4 describes how to support multi-byte tag numbers, which are
+/// encoded by using a leading tag number of 31 (`0b11111`). This library
+/// deliberately does not support this: tag numbers greater than 30 are
+/// disallowed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct TagNumber(pub(super) u8);
+
+impl TagNumber {
+    /// Maximum tag number supported (inclusive).
+    pub const MAX: u8 = 30;
+
+    /// Create a new tag number (const-friendly).
+    ///
+    /// Panics if the tag number is greater than [`TagNumber::MAX`]. For a fallible
+    /// conversion, use [`TryFrom`] instead.
+    #[allow(clippy::no_effect)]
+    pub const fn new(byte: u8) -> Self {
+        // TODO(tarcieri): hax! use const panic when available
+        ["tag number out of range"][(byte > Self::MAX) as usize];
+        Self(byte)
+    }
+
+    /// Create an `APPLICATION` tag with this tag number.
+    pub fn application(self) -> Tag {
+        Tag::Application(self)
+    }
+
+    /// Create a `CONTEXT-SPECIFIC` tag with this tag number.
+    pub fn context_specific(self) -> Tag {
+        Tag::ContextSpecific(self)
+    }
+
+    /// Create a `PRIVATE` tag with this tag number.
+    pub fn private(self) -> Tag {
+        Tag::Private(self)
+    }
+
+    /// Get the inner value.
+    pub fn value(self) -> u8 {
+        self.0
+    }
+}
+
+impl TryFrom<u8> for TagNumber {
+    type Error = Error;
+
+    fn try_from(byte: u8) -> Result<Self> {
+        match byte {
+            0..=Self::MAX => Ok(Self(byte)),
+            _ => Err(ErrorKind::UnknownTag { byte }.into()),
+        }
+    }
+}
+
+impl From<TagNumber> for u8 {
+    fn from(tag_number: TagNumber) -> u8 {
+        tag_number.0
+    }
+}
+
+impl fmt::Display for TagNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}


### PR DESCRIPTION
Performs some internal refactoring of the `tag` module, splitting out `class` and `number` submodules.

Adds helper methods to `TagNumber` for creating specific classes of tags with a given number.