### PR TITLE
pkcs8: return Result(s) when encoding; ASN.1 error improvements

### DIFF
--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -144,12 +144,12 @@ impl TryFrom<Vec<u8>> for EncryptedPrivateKeyDocument {
 
     fn try_from(mut bytes: Vec<u8>) -> Result<Self> {
         // Ensure document is well-formed
-        if EncryptedPrivateKeyInfo::try_from(bytes.as_slice()).is_ok() {
-            Ok(Self(Zeroizing::new(bytes)))
-        } else {
+        if let Err(err) = EncryptedPrivateKeyInfo::try_from(bytes.as_slice()) {
             bytes.zeroize();
-            Err(Error::Decode)
+            return Err(err);
         }
+
+        Ok(Self(Zeroizing::new(bytes)))
     }
 }
 

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -140,7 +140,7 @@ impl PrivateKeyDocument {
                 }
                 .into()
             })
-            .map_err(|_| Error::Encode)
+            .map_err(|_| Error::Crypto)
     }
 }
 
@@ -181,12 +181,12 @@ impl TryFrom<Vec<u8>> for PrivateKeyDocument {
 
     fn try_from(mut bytes: Vec<u8>) -> Result<Self> {
         // Ensure document is well-formed
-        if PrivateKeyInfo::try_from(bytes.as_slice()).is_ok() {
-            Ok(Self(Zeroizing::new(bytes)))
-        } else {
+        if let Err(err) = PrivateKeyInfo::try_from(bytes.as_slice()) {
             bytes.zeroize();
-            Err(Error::Decode)
+            return Err(err);
         }
+
+        Ok(Self(Zeroizing::new(bytes)))
     }
 }
 

--- a/pkcs8/src/pem.rs
+++ b/pkcs8/src/pem.rs
@@ -50,8 +50,8 @@ pub(crate) fn decode(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> 
     let s = s.trim_end();
 
     // TODO(tarcieri): handle missing newlines
-    let s = s.strip_prefix(boundary.pre).ok_or(Error::Decode)?;
-    let s = s.strip_suffix(boundary.post).ok_or(Error::Decode)?;
+    let s = s.strip_prefix(boundary.pre).ok_or(Error::Pem)?;
+    let s = s.strip_suffix(boundary.post).ok_or(Error::Pem)?;
 
     let mut s = Zeroizing::new(s.to_owned());
 
@@ -60,7 +60,7 @@ pub(crate) fn decode(s: &str, boundary: Boundary) -> Result<Zeroizing<Vec<u8>>> 
 
     Base64::decode_vec(&*s)
         .map(Zeroizing::new)
-        .map_err(|_| Error::Decode)
+        .map_err(|_| Error::Pem)
 }
 
 /// Serialize "PEM encoding" as described in RFC 7468:

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -104,6 +104,19 @@ pub struct PrivateKeyInfo<'a> {
 }
 
 impl<'a> PrivateKeyInfo<'a> {
+    /// Create a new PKCS#8 [`PrivateKeyInfo`] message.
+    ///
+    /// This is a helper method which initializes `attributes` and `public_key`
+    /// to `None`, helpful if you aren't using those.
+    pub fn new(algorithm: AlgorithmIdentifier<'a>, private_key: &'a [u8]) -> Self {
+        Self {
+            algorithm,
+            private_key,
+            attributes: None,
+            public_key: None,
+        }
+    }
+
     /// Get the PKCS#8 [`Version`] for this structure.
     ///
     /// [`Version::V1`] if `public_key` is `None`, [`Version::V2`] if `Some`.

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -149,7 +149,7 @@ pub trait FromPublicKey: Sized {
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait ToPrivateKey {
     /// Serialize a [`PrivateKeyDocument`] containing a PKCS#8-encoded private key.
-    fn to_pkcs8_der(&self) -> PrivateKeyDocument;
+    fn to_pkcs8_der(&self) -> Result<PrivateKeyDocument>;
 
     /// Create an [`EncryptedPrivateKeyDocument`] containing the ciphertext of
     /// a PKCS#8 encoded private key encrypted under the given `password`.
@@ -160,14 +160,14 @@ pub trait ToPrivateKey {
         rng: impl CryptoRng + RngCore,
         password: impl AsRef<[u8]>,
     ) -> Result<EncryptedPrivateKeyDocument> {
-        self.to_pkcs8_der().encrypt(rng, password)
+        self.to_pkcs8_der()?.encrypt(rng, password)
     }
 
     /// Serialize this private key as PEM-encoded PKCS#8.
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs8_pem(&self) -> Zeroizing<String> {
-        self.to_pkcs8_der().to_pem()
+    fn to_pkcs8_pem(&self) -> Result<Zeroizing<String>> {
+        Ok(self.to_pkcs8_der()?.to_pem())
     }
 
     /// Serialize this private key as an encrypted PEM-encoded PKCS#8 private
@@ -188,7 +188,7 @@ pub trait ToPrivateKey {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs8_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        self.to_pkcs8_der().write_der_file(path)
+        self.to_pkcs8_der()?.write_der_file(path)
     }
 
     /// Write ASN.1 DER-encoded PKCS#8 private key to the given path
@@ -196,7 +196,7 @@ pub trait ToPrivateKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs8_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        self.to_pkcs8_der().write_pem_file(path)
+        self.to_pkcs8_der()?.write_pem_file(path)
     }
 }
 
@@ -205,20 +205,20 @@ pub trait ToPrivateKey {
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait ToPublicKey {
     /// Serialize a [`PublicKeyDocument`] containing a SPKI-encoded public key.
-    fn to_public_key_der(&self) -> PublicKeyDocument;
+    fn to_public_key_der(&self) -> Result<PublicKeyDocument>;
 
     /// Serialize this public key as PEM-encoded SPKI.
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_public_key_pem(&self) -> String {
-        self.to_public_key_der().to_pem()
+    fn to_public_key_pem(&self) -> Result<String> {
+        Ok(self.to_public_key_der()?.to_pem())
     }
 
     /// Write ASN.1 DER-encoded public key to the given path
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_public_key_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        self.to_public_key_der().write_der_file(path)
+        self.to_public_key_der()?.write_der_file(path)
     }
 
     /// Write ASN.1 DER-encoded public key to the given path
@@ -226,6 +226,6 @@ pub trait ToPublicKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_public_key_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        self.to_public_key_der().write_pem_file(path)
+        self.to_public_key_der()?.write_pem_file(path)
     }
 }

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -39,7 +39,7 @@ impl TryFrom<u8> for Version {
         match byte {
             0 => Ok(Version::V1),
             1 => Ok(Version::V2),
-            _ => Err(Error::Decode),
+            _ => Err(der::ErrorKind::Value { tag: Tag::Integer }.into()),
         }
     }
 }


### PR DESCRIPTION
Changes the infallible encoding methods to be fallible.

If we want to provide infallible versions, we should wrap that up in a single place, rather than force encoders to constantly `expect()`.

Additionally this refactors the error type in order to preserve the original `der::Error`.