### PR TITLE
der: add ErrorKind::Value encoding helpers

### DIFF
--- a/const-oid/src/error.rs
+++ b/const-oid/src/error.rs
@@ -2,6 +2,9 @@
 
 use core::fmt;
 
+/// Result type
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Error type
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Error;
@@ -14,6 +17,3 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
-
-/// Result type
-pub type Result<T> = core::result::Result<T, Error>;

--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -101,11 +101,10 @@ impl DeriveChoice {
 
         {
             quote! {
-                #tag => {
-                    #decoder.ok().and_then(|val| val.try_into().ok()).ok_or_else(|| {
-                        ::der::ErrorKind::Value { tag: #tag }.into()
-                    })
-                }
+                #tag => #decoder
+                    .ok()
+                    .and_then(|val| val.try_into().ok())
+                    .ok_or_else(|| #tag.value_error()),
             }
         }
         .to_tokens(&mut self.decode_body);

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `BOOLEAN` support.
 
-use crate::{asn1::Any, Encodable, Encoder, Error, ErrorKind, Header, Length, Result, Tag, Tagged};
+use crate::{asn1::Any, Encodable, Encoder, Error, Header, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -21,7 +21,7 @@ impl TryFrom<Any<'_>> for bool {
         match any.as_bytes() {
             [FALSE_OCTET] => Ok(false),
             [TRUE_OCTET] => Ok(true),
-            _ => Err(ErrorKind::Noncanonical { tag }.into()),
+            _ => Err(tag.non_canonical_error()),
         }
     }
 }

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,8 +1,7 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, str_slice::StrSlice, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag,
-    Tagged,
+    asn1::Any, str_slice::StrSlice, Encodable, Encoder, Error, Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, fmt, str};
 
@@ -32,12 +31,12 @@ impl<'a> Ia5String<'a> {
 
         // Validate all characters are within IA5String's allowed set
         if input.iter().any(|&c| c > 0x7F) {
-            return Err(ErrorKind::Value { tag: Self::TAG }.into());
+            return Err(Self::TAG.value_error());
         }
 
         StrSlice::from_bytes(input)
             .map(|inner| Self { inner })
-            .map_err(|_| ErrorKind::Value { tag: Self::TAG }.into())
+            .map_err(|_| Self::TAG.value_error())
     }
 
     /// Borrow the string as a `str`.

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -4,7 +4,7 @@ pub(super) mod bigint;
 mod int;
 mod uint;
 
-use crate::{asn1::Any, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged};
+use crate::{asn1::Any, Encodable, Encoder, Error, Length, Result, Tag, Tagged};
 use core::convert::TryFrom;
 
 macro_rules! impl_int_encoding {
@@ -22,7 +22,7 @@ macro_rules! impl_int_encoding {
 
                     // Ensure we compute the same encoded length as the original any value
                     if any.encoded_len()? != result.encoded_len()? {
-                        return Err(ErrorKind::Noncanonical { tag: Self::TAG }.into());
+                        return Err(Self::TAG.non_canonical_error());
                     }
 
                     Ok(result)
@@ -65,7 +65,7 @@ macro_rules! impl_uint_encoding {
 
                     // Ensure we compute the same encoded length as the original any value
                     if any.encoded_len()? != result.encoded_len()? {
-                        return Err(ErrorKind::Noncanonical { tag: Self::TAG }.into());
+                        return Err(Self::TAG.non_canonical_error());
                     }
 
                     Ok(result)

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -1,6 +1,6 @@
 //! Unsigned integer decoders/encoders.
 
-use crate::{asn1::Any, Encodable, Encoder, ErrorKind, Header, Length, Result, Tag};
+use crate::{asn1::Any, Encodable, Encoder, Header, Length, Result, Tag};
 use core::convert::TryFrom;
 
 /// Decode an unsigned integer into a big endian byte slice with all leading
@@ -18,11 +18,11 @@ pub(super) fn decode_slice(any: Any<'_>) -> Result<&[u8]> {
     // integer (since we're decoding an unsigned integer).
     // We expect all such cases to have a leading `0x00` byte.
     match bytes {
-        [] => Err(ErrorKind::Noncanonical { tag }.into()),
+        [] => Err(tag.non_canonical_error()),
         [0] => Ok(bytes),
-        [0, byte, ..] if *byte < 0x80 => Err(ErrorKind::Noncanonical { tag }.into()),
+        [0, byte, ..] if *byte < 0x80 => Err(tag.non_canonical_error()),
         [0, rest @ ..] => Ok(&rest),
-        [byte, ..] if *byte >= 0x80 => Err(ErrorKind::Value { tag }.into()),
+        [byte, ..] if *byte >= 0x80 => Err(tag.value_error()),
         _ => Ok(bytes),
     }
 }

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,8 +1,7 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::Any, str_slice::StrSlice, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag,
-    Tagged,
+    asn1::Any, str_slice::StrSlice, Encodable, Encoder, Error, Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, fmt, str};
 
@@ -64,13 +63,13 @@ impl<'a> PrintableString<'a> {
                 | b':'
                 | b'='
                 | b'?' => (),
-                _ => return Err(ErrorKind::Value { tag: Self::TAG }.into()),
+                _ => return Err(Self::TAG.value_error()),
             }
         }
 
         StrSlice::from_bytes(input)
             .map(|inner| Self { inner })
-            .map_err(|_| ErrorKind::Value { tag: Self::TAG }.into())
+            .map_err(|_| Self::TAG.value_error())
     }
 
     /// Borrow the string as a `str`.

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -66,7 +66,7 @@ where
 
             if let Some(last) = last_value.as_ref() {
                 if last >= &value {
-                    return Err(ErrorKind::Noncanonical { tag: Self::TAG }.into());
+                    return Err(Self::TAG.non_canonical_error());
                 }
             }
 
@@ -209,7 +209,7 @@ where
 
             if let Some(last) = last_value.take() {
                 if last >= value {
-                    return Err(ErrorKind::Noncanonical { tag: Self::TAG }.into());
+                    return Err(Self::TAG.non_canonical_error());
                 }
 
                 result.insert(last);

--- a/der/src/datetime.rs
+++ b/der/src/datetime.rs
@@ -5,7 +5,7 @@
 // Copyright (c) 2016 The humantime Developers
 // Released under the MIT OR Apache 2.0 licenses
 
-use crate::{Encoder, ErrorKind, Result, Tag};
+use crate::{Encoder, Result, Tag};
 use core::time::Duration;
 
 /// Minimum year allowed in [`DateTime`] values.
@@ -20,7 +20,7 @@ pub(crate) fn decode_decimal(tag: Tag, hi: u8, lo: u8) -> Result<u16> {
     if (b'0'..=b'9').contains(&hi) && (b'0'..=b'9').contains(&lo) {
         Ok((hi - b'0') as u16 * 10 + (lo - b'0') as u16)
     } else {
-        Err(ErrorKind::Value { tag }.into())
+        Err(tag.value_error())
     }
 }
 
@@ -29,7 +29,7 @@ pub(crate) fn encode_decimal(encoder: &mut Encoder<'_>, tag: Tag, value: u16) ->
     let hi_val = value / 10;
 
     if hi_val >= 10 {
-        return Err(ErrorKind::Value { tag }.into());
+        return Err(tag.value_error());
     }
 
     encoder.byte(hi_val as u8 + b'0')?;

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -1,6 +1,6 @@
 //! DER decoder.
 
-use crate::{asn1::*, Choice, Decodable, ErrorKind, Length, Result, Tag, TagNumber};
+use crate::{asn1::*, Choice, Decodable, Error, ErrorKind, Length, Result, Tag, TagNumber};
 use core::{
     cmp::Ordering,
     convert::{TryFrom, TryInto},
@@ -42,9 +42,17 @@ impl<'a> Decoder<'a> {
 
     /// Return an error with the given [`ErrorKind`], annotating it with
     /// context about where the error occurred.
+    // TODO(tarcieri): change return type to `Error`
     pub fn error<T>(&mut self, kind: ErrorKind) -> Result<T> {
         self.bytes.take();
         Err(kind.at(self.position))
+    }
+
+    /// Return an error for an invalid value with the given tag.
+    // TODO(tarcieri): compose this with `Decoder::error` after changing its return type
+    pub fn value_error(&mut self, tag: Tag) -> Error {
+        self.bytes.take();
+        tag.value_error().kind().at(self.position)
     }
 
     /// Did the decoding operation fail due to an error?

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -106,6 +106,18 @@ impl Tag {
             }
         }
     }
+
+    /// Create an [`Error`] for an non-canonical value with the ASN.1 type
+    /// identified by this tag.
+    pub fn non_canonical_error(self) -> Error {
+        ErrorKind::Value { tag: self }.into()
+    }
+
+    /// Create an [`Error`] for an invalid value with the ASN.1 type identified
+    /// by this tag.
+    pub fn value_error(self) -> Error {
+        ErrorKind::Value { tag: self }.into()
+    }
 }
 
 impl TryFrom<u8> for Tag {

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -80,19 +80,15 @@ impl<'a> TryFrom<AlgorithmIdentifier<'a>> for Parameters {
 
     fn try_from(alg: AlgorithmIdentifier<'a>) -> Result<Self> {
         // Ensure that we have a supported PBES1 algorithm identifier
-        let encryption = EncryptionScheme::try_from(alg.oid).map_err(|_| ErrorKind::Value {
-            tag: der::Tag::ObjectIdentifier,
-        })?;
+        let encryption = EncryptionScheme::try_from(alg.oid)
+            .map_err(|_| der::Tag::ObjectIdentifier.value_error())?;
 
         alg.parameters_any()?.sequence(|params| {
-            let salt =
-                params
-                    .octet_string()?
-                    .as_bytes()
-                    .try_into()
-                    .map_err(|_| ErrorKind::Value {
-                        tag: der::Tag::OctetString,
-                    })?;
+            let salt = params
+                .octet_string()?
+                .as_bytes()
+                .try_into()
+                .map_err(|_| der::Tag::OctetString.value_error())?;
 
             let iteration_count = params.decode()?;
 

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -266,9 +266,7 @@ impl<'a> TryFrom<AlgorithmIdentifier<'a>> for EncryptionScheme<'a> {
             .octet_string()?
             .as_bytes()
             .try_into()
-            .map_err(|_| ErrorKind::Value {
-                tag: der::Tag::OctetString,
-            })?;
+            .map_err(|_| der::Tag::OctetString.value_error())?;
 
         match alg.oid {
             AES_128_CBC_OID => Ok(Self::Aes128Cbc { iv }),

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -258,7 +258,7 @@ impl<'a> TryFrom<AlgorithmIdentifier<'a>> for Pbkdf2Prf {
         if let Some(params) = alg.parameters {
             // TODO(tarcieri): support non-NULL parameters?
             if !params.is_null() {
-                return Err(ErrorKind::Value { tag: params.tag() }.into());
+                return Err(params.tag().value_error());
             }
         } else {
             // TODO(tarcieri): support OPTIONAL parameters?

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -70,7 +70,7 @@
     html_root_url = "https://docs.rs/pkcs8/0.7.0-pre"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -190,9 +190,7 @@ impl<'a> TryFrom<Any<'a>> for PrivateKeyInfo<'a> {
                 .map(|bs| bs.as_bytes());
 
             if version.has_public_key() != public_key.is_some() {
-                return decoder.error(der::ErrorKind::Value {
-                    tag: der::Tag::ContextSpecific(PUBLIC_KEY_TAG),
-                });
+                return Err(decoder.value_error(der::Tag::ContextSpecific(PUBLIC_KEY_TAG)));
             }
 
             // Ignore any remaining extension fields

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -131,7 +131,7 @@ pub trait FromPublicKey: Sized {
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_public_key_der_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
+    fn read_public_key_der_file(path: impl AsRef<Path>) -> Result<Self> {
         PublicKeyDocument::read_der_file(path).and_then(|doc| Self::from_public_key_doc(&doc))
     }
 
@@ -139,7 +139,7 @@ pub trait FromPublicKey: Sized {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_public_key_pem_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
+    fn read_public_key_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         PublicKeyDocument::read_pem_file(path).and_then(|doc| Self::from_public_key_doc(&doc))
     }
 }

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -39,7 +39,7 @@ impl TryFrom<u8> for Version {
         match byte {
             0 => Ok(Version::V1),
             1 => Ok(Version::V2),
-            _ => Err(der::ErrorKind::Value { tag: Tag::Integer }.into()),
+            _ => Err(Self::TAG.value_error().into()),
         }
     }
 }
@@ -49,7 +49,7 @@ impl<'a> TryFrom<Any<'a>> for Version {
     fn try_from(any: Any<'a>) -> der::Result<Version> {
         u8::try_from(any)?
             .try_into()
-            .map_err(|_| der::ErrorKind::Value { tag: Tag::Integer }.into())
+            .map_err(|_| Self::TAG.value_error())
     }
 }
 
@@ -65,5 +65,5 @@ impl Encodable for Version {
 }
 
 impl Tagged for Version {
-    const TAG: der::Tag = der::Tag::Integer;
+    const TAG: Tag = Tag::Integer;
 }


### PR DESCRIPTION
Adds a `Tag::value_error()` helper method which simplifies returning errors about invalid values for a given tag.