### PR TITLE
crypto-bigint: add UInt::into_limbs

### DIFF
--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -50,6 +50,12 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         &self.limbs
     }
 
+    /// Convert this [`UInt`] into its inner limbs.
+    // TODO(tarcieri): eventually phase this out?
+    pub const fn into_limbs(self) -> [Limb; LIMBS] {
+        self.limbs
+    }
+
     /// Determine if this [`UInt`] is equal to zero.
     ///
     /// # Returns


### PR DESCRIPTION
The intended use case is initializing the existing `MODULUS` constants for the various `Scalar` impls in the elliptic curve crates.

Longer term we should be able to migrate to an entirely `UInt`-based implementation of scalar (ideally adding reusable `Field` types as well), but for now this is being added to simplify the initial retrofit.