### PR TITLE
spki: add `assert_*_oid` methods to AlgorithmIdentifier

### DIFF
--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -85,6 +85,31 @@ pub enum Tag {
 }
 
 impl Tag {
+    /// Assert that this [`Tag`] matches the provided expected tag.
+    ///
+    /// On mismatch, returns an [`Error`] with [`ErrorKind::UnexpectedTag`].
+    pub fn assert_eq(self, expected: Tag) -> Result<Tag> {
+        if self == expected {
+            Ok(self)
+        } else {
+            Err(ErrorKind::UnexpectedTag {
+                expected: Some(expected),
+                actual: self,
+            }
+            .into())
+        }
+    }
+
+    /// Get the [`Class`] that corresponds to this [`Tag`].
+    pub fn class(self) -> Class {
+        match self {
+            Tag::Application(_) => Class::Application,
+            Tag::ContextSpecific(_) => Class::ContextSpecific,
+            Tag::Private(_) => Class::Private,
+            _ => Class::Universal,
+        }
+    }
+
     /// Get the octet encoding for this [`Tag`].
     pub fn octet(self) -> u8 {
         match self {
@@ -155,33 +180,6 @@ impl From<Tag> for u8 {
 impl From<&Tag> for u8 {
     fn from(tag: &Tag) -> u8 {
         u8::from(*tag)
-    }
-}
-
-impl Tag {
-    /// Assert that this [`Tag`] matches the provided expected tag.
-    ///
-    /// On mismatch, returns an [`Error`] with [`ErrorKind::UnexpectedTag`].
-    pub fn assert_eq(self, expected: Tag) -> Result<Tag> {
-        if self == expected {
-            Ok(self)
-        } else {
-            Err(ErrorKind::UnexpectedTag {
-                expected: Some(expected),
-                actual: self,
-            }
-            .into())
-        }
-    }
-
-    /// Get the [`Class`] that corresponds to this [`Tag`].
-    pub fn class(self) -> Class {
-        match self {
-            Tag::Application(_) => Class::Application,
-            Tag::ContextSpecific(_) => Class::ContextSpecific,
-            Tag::Private(_) => Class::Private,
-            _ => Class::Universal,
-        }
     }
 }
 

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -26,6 +26,29 @@ pub struct AlgorithmIdentifier<'a> {
 }
 
 impl<'a> AlgorithmIdentifier<'a> {
+    /// Assert the `algorithm` OID is an expected value.
+    pub fn assert_algorithm_oid(&self, expected_oid: ObjectIdentifier) -> Result<ObjectIdentifier> {
+        if self.oid == expected_oid {
+            Ok(expected_oid)
+        } else {
+            Err(ErrorKind::UnknownOid { oid: expected_oid }.into())
+        }
+    }
+
+    /// Assert `parameters` is an OID and has the expected value.
+    pub fn assert_parameters_oid(
+        &self,
+        expected_oid: ObjectIdentifier,
+    ) -> Result<ObjectIdentifier> {
+        let actual_oid = self.parameters_oid()?;
+
+        if actual_oid == expected_oid {
+            Ok(actual_oid)
+        } else {
+            Err(ErrorKind::UnknownOid { oid: expected_oid }.into())
+        }
+    }
+
     /// Get the `parameters` field as an [`Any`].
     ///
     /// Returns an error if `parameters` are `None`.


### PR DESCRIPTION
Adds methods for asserting that the OIDs in `AlgorithmIdentifier` are an expected value.