### PR TITLE
der: have `Decoder::error()` return an `Error`

### DIFF
--- a/der/src/decodable.rs
+++ b/der/src/decodable.rs
@@ -32,6 +32,6 @@ where
     fn decode(decoder: &mut Decoder<'a>) -> Result<T> {
         Any::decode(decoder)
             .and_then(Self::try_from)
-            .or_else(|e| decoder.error(e.kind()))
+            .map_err(|e| decoder.error(e.kind()))
     }
 }


### PR DESCRIPTION
...instead of a `Result`.

The original goal was to avoid having to write `Err(...)` but the result is a bit awkward and clumsy instead.