### PR TITLE
crypto-bigint: add/extract `Encoding` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "generic-array",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -228,7 +228,6 @@ dependencies = [
 name = "pkcs1"
 version = "0.0.0"
 dependencies = [
- "crypto-bigint",
  "der",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/crypto-bigint/src/array.rs
+++ b/crypto-bigint/src/array.rs
@@ -1,5 +1,6 @@
 //! Interop support for `generic-array`
 
+use crate::Encoding;
 use core::ops::Add;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
@@ -9,15 +10,15 @@ pub type ByteArray<T> = GenericArray<u8, <T as ArrayEncoding>::ByteSize>;
 
 /// Support for encoding a big integer as a `GenericArray`.
 #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
-pub trait ArrayEncoding: Sized {
+pub trait ArrayEncoding: Encoding {
     /// Size of a byte array which encodes a big integer.
     type ByteSize: ArrayLength<u8> + Add + Eq + Ord + Unsigned;
 
     /// Deserialize from a big-endian byte array.
-    fn from_be_byte_array(bytes: &ByteArray<Self>) -> Self;
+    fn from_be_byte_array(bytes: ByteArray<Self>) -> Self;
 
     /// Deserialize from a little-endian byte array.
-    fn from_le_byte_array(bytes: &ByteArray<Self>) -> Self;
+    fn from_le_byte_array(bytes: ByteArray<Self>) -> Self;
 
     /// Serialize to a big-endian byte array.
     fn to_be_byte_array(&self) -> ByteArray<Self>;

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -56,13 +56,7 @@ mod array;
 mod checked;
 mod wrapping;
 
-pub use crate::{
-    checked::Checked,
-    limb::Limb,
-    traits::{Concat, NumBits, NumBytes, Split},
-    uint::*,
-    wrapping::Wrapping,
-};
+pub use crate::{checked::Checked, limb::Limb, traits::*, uint::*, wrapping::Wrapping};
 pub use subtle;
 
 #[cfg(feature = "generic-array")]

--- a/crypto-bigint/src/traits.rs
+++ b/crypto-bigint/src/traits.rs
@@ -11,16 +11,28 @@ pub trait Concat<Rhs = Self> {
     fn concat(&self, rhs: &Self) -> Self::Output;
 }
 
-/// Number of bits required to express a given big integer.
-pub trait NumBits {
-    /// Number of bits required to express this integer.
-    const NUM_BITS: usize;
-}
+/// Encoding support.
+pub trait Encoding: Sized {
+    /// Size of this integer in bits.
+    const BIT_SIZE: usize;
 
-/// Number of bytes required to express a given big integer.
-pub trait NumBytes {
-    /// Number of bytes required to express this integer.
-    const NUM_BYTES: usize;
+    /// Size of this integer in bytes.
+    const BYTE_SIZE: usize;
+
+    /// Byte array representation.
+    type Repr: Copy + Clone + AsRef<[u8]> + AsMut<[u8]> + Sized;
+
+    /// Decode from big endian bytes.
+    fn from_be_bytes(bytes: Self::Repr) -> Self;
+
+    /// Decode from little endian bytes.
+    fn from_le_bytes(bytes: Self::Repr) -> Self;
+
+    /// Encode to big endian bytes.
+    fn to_be_bytes(&self) -> Self::Repr;
+
+    /// Encode to little endian bytes.
+    fn to_le_bytes(&self) -> Self::Repr;
 }
 
 /// Split a number in half, returning the most significant half followed by

--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -7,7 +7,7 @@ mod macros;
 
 mod add;
 mod ct;
-mod decode;
+mod encoding;
 mod from;
 mod mul;
 mod sub;
@@ -15,7 +15,7 @@ mod sub;
 #[cfg(feature = "generic-array")]
 mod array;
 
-use crate::{Concat, Limb, NumBits, NumBytes, Split};
+use crate::{Concat, Encoding, Limb, Split};
 use core::{cmp::Ordering, fmt};
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 

--- a/crypto-bigint/src/uint/encoding.rs
+++ b/crypto-bigint/src/uint/encoding.rs
@@ -5,7 +5,7 @@ use crate::{Limb, LIMB_BYTES};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a new [`UInt`] from the provided big endian bytes.
-    pub const fn from_be_bytes(bytes: &[u8]) -> Self {
+    pub const fn from_be_slice(bytes: &[u8]) -> Self {
         const_assert!(
             bytes.len() == LIMB_BYTES * LIMBS,
             "bytes are not the expected size"
@@ -45,7 +45,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 
     /// Create a new [`UInt`] from the provided little endian bytes.
-    pub const fn from_le_bytes(bytes: &[u8]) -> Self {
+    pub const fn from_le_slice(bytes: &[u8]) -> Self {
         const_assert!(
             bytes.len() == LIMB_BYTES * LIMBS,
             "bytes are not the expected size"
@@ -81,6 +81,35 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
 
         decoder.finish()
+    }
+
+    /// Serialize this [`UInt`] as big-endian, writing it into the provided
+    /// byte slice.
+    #[inline]
+    #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
+    pub(crate) fn write_be_bytes(&self, out: &mut [u8]) {
+        debug_assert_eq!(out.len(), LIMB_BYTES * LIMBS);
+
+        for (src, dst) in self
+            .limbs
+            .iter()
+            .rev()
+            .zip(out.chunks_exact_mut(LIMB_BYTES))
+        {
+            dst.copy_from_slice(&src.to_be_bytes());
+        }
+    }
+
+    /// Serialize this [`UInt`] as little-endian, writing it into the provided
+    /// byte slice.
+    #[inline]
+    #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
+    pub(crate) fn write_le_bytes(&self, out: &mut [u8]) {
+        debug_assert_eq!(out.len(), LIMB_BYTES * LIMBS);
+
+        for (src, dst) in self.limbs.iter().zip(out.chunks_exact_mut(LIMB_BYTES)) {
+            dst.copy_from_slice(&src.to_le_bytes());
+        }
     }
 }
 
@@ -179,7 +208,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn from_be_bytes() {
         let bytes = hex!("0011223344556677");
-        let n = UIntEx::from_be_bytes(&bytes);
+        let n = UIntEx::from_be_slice(&bytes);
         assert_eq!(n.limbs(), &[0x44556677, 0x00112233]);
     }
 
@@ -187,7 +216,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn from_be_bytes() {
         let bytes = hex!("00112233445566778899aabbccddeeff");
-        let n = UIntEx::from_be_bytes(&bytes);
+        let n = UIntEx::from_be_slice(&bytes);
         assert_eq!(n.limbs(), &[0x8899aabbccddeeff, 0x0011223344556677]);
     }
 
@@ -195,7 +224,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn from_le_bytes() {
         let bytes = hex!("7766554433221100");
-        let n = UIntEx::from_le_bytes(&bytes);
+        let n = UIntEx::from_le_slice(&bytes);
         assert_eq!(n.limbs(), &[0x44556677, 0x00112233]);
     }
 
@@ -203,7 +232,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn from_le_bytes() {
         let bytes = hex!("ffeeddccbbaa99887766554433221100");
-        let n = UIntEx::from_le_bytes(&bytes);
+        let n = UIntEx::from_le_slice(&bytes);
         assert_eq!(n.limbs(), &[0x8899aabbccddeeff, 0x0011223344556677]);
     }
 

--- a/crypto-bigint/src/uint/macros.rs
+++ b/crypto-bigint/src/uint/macros.rs
@@ -9,12 +9,33 @@ macro_rules! impl_uint_aliases {
             #[doc="unsigned big integer"]
             pub type $name = UInt<{nlimbs!($bits)}>;
 
-            impl NumBits for $name {
-                const NUM_BITS: usize = $bits;
-            }
+            impl Encoding for $name {
+                const BIT_SIZE: usize = $bits;
+                const BYTE_SIZE: usize = $bits / 8;
 
-            impl NumBytes for $name {
-                const NUM_BYTES: usize = $bits / 8;
+                type Repr = [u8; $bits / 8];
+
+                fn from_be_bytes(bytes: Self::Repr) -> Self {
+                    Self::from_be_slice(&bytes)
+                }
+
+                fn from_le_bytes(bytes: Self::Repr) -> Self {
+                    Self::from_be_slice(&bytes)
+                }
+
+                #[inline]
+                fn to_be_bytes(&self) -> Self::Repr {
+                    let mut result = [0u8; $bits / 8];
+                    self.write_be_bytes(&mut result);
+                    result
+                }
+
+                #[inline]
+                fn to_le_bytes(&self) -> Self::Repr {
+                    let mut result = [0u8; $bits / 8];
+                    self.write_le_bytes(&mut result);
+                    result
+                }
             }
         )+
      };

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
-crypto-bigint = { version = "0.1", optional = true, features = ["generic-array"], path = "../crypto-bigint" }
+crypto-bigint = { version = "=0.2.0-pre", optional = true, features = ["generic-array"], path = "../crypto-bigint" }
 der_derive = { version = "0.3", optional = true, path = "derive" }
 
 [dev-dependencies]

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -116,7 +116,7 @@ where
         let mut array = GenericArray::default();
         let offset = array.len().saturating_sub(bytes.len().try_into()?);
         array[offset..].copy_from_slice(bytes.as_bytes());
-        Ok(UInt::from_be_byte_array(&array))
+        Ok(UInt::from_be_byte_array(array))
     }
 }
 

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["crypto", "key", "pkcs", "rsa"]
 readme = "README.md"
 
 [dependencies]
-crypto-bigint = { version = "0.1", path = "../crypto-bigint" }
 der = { version = "=0.4.0-pre", features = ["bigint", "oid"], path = "../der" }
 
 [dev-dependencies]


### PR DESCRIPTION
Extracts byte encoding functionality into an `Encoding` trait that acts on an associated `Encoding::Repr` type.

Breaking change, so it also bumps the version to v0.2.0-pre.