### PR TITLE
crypto-bigint v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "generic-array",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto-bigint/CHANGELOG.md
+++ b/crypto-bigint/CHANGELOG.md
@@ -4,5 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-06-07)
+### Added
+- `ConstantTimeGreater`/`ConstantTimeLess` impls for UInt ([#459])
+- `From` conversions between `UInt` and limb arrays ([#460])
+- `zeroize` feature ([#461])
+- Additional `ArrayEncoding::ByteSize` bounds ([#462])
+- `UInt::into_limbs` ([#484])
+- `Encoding` trait ([#488])
+
+### Removed
+- `NumBits`/`NumBytes` traits; use `Encoding` instead ([#488])
+
+[#459]: https://github.com/RustCrypto/utils/pull/459
+[#460]: https://github.com/RustCrypto/utils/pull/460
+[#461]: https://github.com/RustCrypto/utils/pull/461
+[#462]: https://github.com/RustCrypto/utils/pull/462
+[#484]: https://github.com/RustCrypto/utils/pull/484
+[#488]: https://github.com/RustCrypto/utils/pull/488
+
 ## 0.1.0 (2021-05-30)
 - Initial release

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -9,9 +9,8 @@
 //! **Rust 1.51** at a minimum.
 //!
 //! # Goals
-//! - No heap allocations (`no_std`-friendly)
-//! - Constant-time by default: if we add variable-time operations in the future
-//!   they will be secondary and explicitly labeled.
+//! - No heap allocations i.e. `no_std`-friendly.
+//! - Constant-time by default using traits from the [`subtle`] crate.
 //! - Leverage what is possible today with const generics on `stable` rust.
 //! - Support `const fn` as much as possible, including decoding big integers from
 //!   bytes/hex and performing arithmetic operations on them, with the goal of
@@ -36,7 +35,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.1.0"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/crypto-bigint/src/uint/array.rs
+++ b/crypto-bigint/src/uint/array.rs
@@ -1,4 +1,4 @@
-//! `generic-array` integration with [`UInt`]
+//! `generic-array` integration with `UInt`.
 // TODO(tarcieri): completely phase out `generic-array` when const generics are powerful enough
 
 use crate::{ArrayEncoding, ByteArray};

--- a/crypto-bigint/src/uint/macros.rs
+++ b/crypto-bigint/src/uint/macros.rs
@@ -1,4 +1,4 @@
-//! Macros for defining aliases and relationships between [`UInt`] types.
+//! Macros for defining aliases and relationships between `UInt` types.
 // TODO(tarcieri): replace these with `const_evaluatable_checked` exprs when stable
 
 // TODO(tarcieri): use `const_evaluatable_checked` when stable to make generic around bits.

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
-crypto-bigint = { version = "=0.2.0-pre", optional = true, features = ["generic-array"], path = "../crypto-bigint" }
+crypto-bigint = { version = "0.2", optional = true, features = ["generic-array"], path = "../crypto-bigint" }
 der_derive = { version = "0.3", optional = true, path = "derive" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added
- `ConstantTimeGreater`/`ConstantTimeLess` impls for UInt ([#459])
- `From` conversions between `UInt` and limb arrays ([#460])
- `zeroize` feature ([#461])
- Additional `ArrayEncoding::ByteSize` bounds ([#462])
- `UInt::into_limbs` ([#484])
- `Encoding` trait ([#488])

### Removed
- `NumBits`/`NumBytes` traits; use `Encoding` instead ([#488])

[#459]: https://github.com/RustCrypto/utils/pull/459
[#460]: https://github.com/RustCrypto/utils/pull/460
[#461]: https://github.com/RustCrypto/utils/pull/461
[#462]: https://github.com/RustCrypto/utils/pull/462
[#484]: https://github.com/RustCrypto/utils/pull/484
[#488]: https://github.com/RustCrypto/utils/pull/488