### PR TITLE
der v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-06-07)
+### Added
+- `TagNumber` type ([#464])
+- Const generic integer de/encoders with support for all of Rust's integer
+  primitives ([#469], [#470])
+- `crypto-bigint` support ([#472])
+- `Tag` number helpers ([#477])
+- `Tag::octet` ([#479])
+- `ErrorKind::Value` helpers ([#481])
+- `SequenceIter` ([#483])
+
+### Changed
+- Bump `const-oid` crate dependency to v0.6 ([#463])
+- Make `Tag` structured ([#464])
+- Namespace ASN.1 types in `asn1` module ([#465])
+- Refactor context-specific field decoding ([#466])
+- MSRV 1.51 ([#469], [#470])
+- Rename `big-uint` crate feature to `bigint` ([#472])
+- Rename `BigUInt` to `UIntBytes` ([#473])
+- Have `Decoder::error()` return an `Error` ([#487])
+  
+### Removed
+- Deprecated methods replaced by associated constants ([#458])
+
+[#458]: https://github.com/RustCrypto/utils/pull/458
+[#463]: https://github.com/RustCrypto/utils/pull/463
+[#464]: https://github.com/RustCrypto/utils/pull/464
+[#465]: https://github.com/RustCrypto/utils/pull/465
+[#466]: https://github.com/RustCrypto/utils/pull/466
+[#469]: https://github.com/RustCrypto/utils/pull/469
+[#470]: https://github.com/RustCrypto/utils/pull/470
+[#472]: https://github.com/RustCrypto/utils/pull/472
+[#473]: https://github.com/RustCrypto/utils/pull/473
+[#477]: https://github.com/RustCrypto/utils/pull/477
+[#479]: https://github.com/RustCrypto/utils/pull/479
+[#481]: https://github.com/RustCrypto/utils/pull/481
+[#483]: https://github.com/RustCrypto/utils/pull/483
+[#487]: https://github.com/RustCrypto/utils/pull/487
+
 ## 0.3.5 (2021-05-24)
 ### Added
 - Helper methods for context-specific fields ([#422], [#423], [#428], [#429])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.2", optional = true, features = ["generic-array"], path = "../crypto-bigint" }
-der_derive = { version = "0.3", optional = true, path = "derive" }
+der_derive = { version = "0.4", optional = true, path = "derive" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-06-07)
+### Changed
+- Generated code updates which ensure compatibility with upstream `der` crate
+  changes ([#464], [#465], [#481])
+
+[#464]: https://github.com/RustCrypto/utils/pull/464
+[#465]: https://github.com/RustCrypto/utils/pull/465
+[#481]: https://github.com/RustCrypto/utils/pull/481
+
 ## 0.3.0 (2021-03-21)
 ### Added
 - `choice::Alternative` and duplicate tracking ([#300])

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Procedural macro for automatically deriving the `der` crate's `Choice` and
 `Message` traits

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -346,7 +346,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.4.0-pre"
+    html_root_url = "https://docs.rs/der/0.4.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "key", "pkcs", "rsa"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "=0.4.0-pre", features = ["bigint", "oid"], path = "../der" }
+der = { version = "0.4", features = ["bigint", "oid"], path = "../der" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "key", "pkcs", "password"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "=0.4.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.4", features = ["oid"], path = "../der" }
 spki = { version = "=0.4.0-pre", path = "../spki" }
 
 aes = { version = "0.7.4", optional = true }

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "=0.4.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.4", features = ["oid"], path = "../der" }
 spki = { version = "=0.4.0-pre", path = "../spki" }
 
 base64ct = { version = "1", optional = true, path = "../base64ct" }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "x509"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "=0.4.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.4", features = ["oid"], path = "../der" }
 
 [features]
 std = ["der/std"]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -14,7 +14,7 @@ keywords   = ["crypto", "x.509"]
 readme     = "README.md"
 
 [dependencies]
-der = { version = "=0.4.0-pre", features = ["derive"], path = "../der" }
+der = { version = "0.4", features = ["derive"], path = "../der" }
 spki = { version = "=0.4.0-pre", path = "../spki" }
 
 [features]


### PR DESCRIPTION
### Added
- `TagNumber` type ([#464])
- Const generic integer de/encoders with support for all of Rust's integer
  primitives ([#469], [#470])
- `crypto-bigint` support ([#472])
- `Tag` number helpers ([#477])
- `Tag::octet` ([#479])
- `ErrorKind::Value` helpers ([#481])
- `SequenceIter` ([#483])

### Changed
- Bump `const-oid` crate dependency to v0.6 ([#463])
- Make `Tag` structured ([#464])
- Namespace ASN.1 types in `asn1` module ([#465])
- Refactor context-specific field decoding ([#466])
- MSRV 1.51 ([#469], [#470])
- Rename `big-uint` crate feature to `bigint` ([#472])
- Rename `BigUInt` to `UIntBytes` ([#473])
- Have `Decoder::error()` return an `Error` ([#487])
  
### Removed
- Deprecated methods replaced by associated constants ([#458])

[#458]: https://github.com/RustCrypto/utils/pull/458
[#463]: https://github.com/RustCrypto/utils/pull/463
[#464]: https://github.com/RustCrypto/utils/pull/464
[#465]: https://github.com/RustCrypto/utils/pull/465
[#466]: https://github.com/RustCrypto/utils/pull/466
[#469]: https://github.com/RustCrypto/utils/pull/469
[#470]: https://github.com/RustCrypto/utils/pull/470
[#472]: https://github.com/RustCrypto/utils/pull/472
[#473]: https://github.com/RustCrypto/utils/pull/473
[#477]: https://github.com/RustCrypto/utils/pull/477
[#479]: https://github.com/RustCrypto/utils/pull/479
[#481]: https://github.com/RustCrypto/utils/pull/481
[#483]: https://github.com/RustCrypto/utils/pull/483
[#487]: https://github.com/RustCrypto/utils/pull/487