### PR TITLE
spki v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "der",
 ]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 
 [dependencies]
 der = { version = "0.4", features = ["oid"], path = "../der" }
-spki = { version = "=0.4.0-pre", path = "../spki" }
+spki = { version = "0.4", path = "../spki" }
 
 aes = { version = "0.7.4", optional = true }
 block-modes = { version = "0.8", optional = true, default-features = false }

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 der = { version = "0.4", features = ["oid"], path = "../der" }
-spki = { version = "=0.4.0-pre", path = "../spki" }
+spki = { version = "0.4", path = "../spki" }
 
 base64ct = { version = "1", optional = true, path = "../base64ct" }
 rand_core = { version = "0.6", optional = true, default-features = false }

--- a/spki/CHANGELOG.md
+++ b/spki/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-06-07)
+### Added
+- `AlgorithmIdentifier::assert_oids` ([#485], [#486])
+
+### Changed
+- Bump `der` to v0.4 ([#490])
+
+[#485]: https://github.com/RustCrypto/utils/pull/485
+[#486]: https://github.com/RustCrypto/utils/pull/486
+[#490]: https://github.com/RustCrypto/utils/pull/490
+
 ## 0.3.0 (2021-03-22)
 ### Changed
 - Bump `der` to v0.3 ([#354])

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -33,7 +33,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/spki/0.4.0-pre"
+    html_root_url = "https://docs.rs/spki/0.4.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -15,7 +15,7 @@ readme     = "README.md"
 
 [dependencies]
 der = { version = "0.4", features = ["derive"], path = "../der" }
-spki = { version = "=0.4.0-pre", path = "../spki" }
+spki = { version = "0.4", path = "../spki" }
 
 [features]
 std = []


### PR DESCRIPTION
### Added
- `AlgorithmIdentifier::assert_oids` ([#485], [#486])

### Changed
- Bump `der` to v0.4 ([#490])

[#485]: https://github.com/RustCrypto/utils/pull/485
[#486]: https://github.com/RustCrypto/utils/pull/486
[#490]: https://github.com/RustCrypto/utils/pull/490