### PR TITLE
pkcs5 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "aes",
  "block-modes",

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-06-07)
+### Changed
+- Bump `der` crate dependency to v0.4 ([#490])
+- Bump `spki` crate dependency to v0.4 ([#491])
+
+[#490]: https://github.com/RustCrypto/utils/pull/490
+[#491]: https://github.com/RustCrypto/utils/pull/491
+
 ## 0.2.2 (2021-05-26)
 ### Added
 - `scrypt` support as specified in RFC 7914 ([#434], [#436], [#437])

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.3.0-pre"
+    html_root_url = "https://docs.rs/pkcs5/0.3.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -20,7 +20,7 @@ spki = { version = "0.4", path = "../spki" }
 
 base64ct = { version = "1", optional = true, path = "../base64ct" }
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.3.0-pre", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "0.3", optional = true, path = "../pkcs5" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
### Changed
- Bump `der` crate dependency to v0.4 ([#490])
- Bump `spki` crate dependency to v0.4 ([#491])

[#490]: https://github.com/RustCrypto/utils/pull/490
[#491]: https://github.com/RustCrypto/utils/pull/491