### PR TITLE
pkcs8 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-06-07)
+### Added
+- ASN.1 error improvements ([#478])
+
+### Changed
+- Merge `OneAsymmetricKey` into `PrivateKeyInfo` ([#467])
+- Use scrypt as the default PBES2 KDF ([#468])
+- Return `Result`(s) when encoding ([#478]) 
+- Bump `der` to v0.4 ([#490])
+- Bump `spki` to v0.4 ([#491])
+- Bump `pkcs5` to v0.3 ([#492])
+
+[#467]: https://github.com/RustCrypto/utils/pull/467
+[#468]: https://github.com/RustCrypto/utils/pull/468
+[#478]: https://github.com/RustCrypto/utils/pull/478
+[#490]: https://github.com/RustCrypto/utils/pull/490
+[#491]: https://github.com/RustCrypto/utils/pull/491
+[#492]: https://github.com/RustCrypto/utils/pull/492
+
 ## 0.6.1 (2021-05-24)
 ### Added
 - Support for RFC5958's `OneAsymmetricKey` ([#424], [#425])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.7.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -67,7 +67,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.7.0-pre"
+    html_root_url = "https://docs.rs/pkcs8/0.7.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- ASN.1 error improvements ([#478])

### Changed
- Merge `OneAsymmetricKey` into `PrivateKeyInfo` ([#467])
- Use scrypt as the default PBES2 KDF ([#468])
- Return `Result`(s) when encoding ([#478]) 
- Bump `der` to v0.4 ([#490])
- Bump `spki` to v0.4 ([#491])
- Bump `pkcs5` to v0.3 ([#492])

[#467]: https://github.com/RustCrypto/utils/pull/467
[#468]: https://github.com/RustCrypto/utils/pull/468
[#478]: https://github.com/RustCrypto/utils/pull/478
[#490]: https://github.com/RustCrypto/utils/pull/490
[#491]: https://github.com/RustCrypto/utils/pull/491
[#492]: https://github.com/RustCrypto/utils/pull/492