### PR TITLE
pkcs5+pkcs8: documentation improvements

### DIFF
--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -295,7 +295,7 @@ impl Encodable for Pbkdf2Prf {
     }
 }
 
-/// scrypt parameters as defined in [RFC 8914 Section 7.1].
+/// scrypt parameters as defined in [RFC 7914 Section 7.1].
 ///
 /// ```text
 /// scrypt-params ::= SEQUENCE {
@@ -307,7 +307,7 @@ impl Encodable for Pbkdf2Prf {
 /// }
 /// ```
 ///
-/// [RFC 8914 Section 7.1]: https://datatracker.ietf.org/doc/html/rfc7914#section-7.1
+/// [RFC 7914 Section 7.1]: https://datatracker.ietf.org/doc/html/rfc7914#section-7.1
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct ScryptParams<'a> {
     /// scrypt salt

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -51,8 +51,8 @@
 //! algorithms:
 //!
 //! - [PKCS#5v2 Password Based Encryption Scheme 2 (RFC 8018)]
-//!   - Key derivation function: PBKDF2 with HMAC-SHA256 as the PRF
-//!   - Symmetric encryption: AES-128-CBC or AES-256-CBC
+//!   - Key derivation function: [scrypt] ([RFC 7914], also supports PBKDF2-HMAC-SHA256)
+//!   - Symmetric encryption: AES-128-CBC or AES-256-CBC (best available options for PKCS#5v2)
 //!
 //! # Minimum Supported Rust Version
 //!
@@ -60,7 +60,9 @@
 //!
 //! [RFC 5208]: https://tools.ietf.org/html/rfc5208
 //! [RFC 5958]: https://tools.ietf.org/html/rfc5958
+//! [RFC 7914]: https://datatracker.ietf.org/doc/html/rfc7914
 //! [PKCS#5v2 Password Based Encryption Scheme 2 (RFC 8018)]: https://tools.ietf.org/html/rfc8018#section-6.2
+//! [scrypt]: https://en.wikipedia.org/wiki/Scrypt
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
- Fixes scrypt RFC number in `pkcs5` (was 8914, should be 7914)
- Notes `pkcs8` uses scrypt as the default PBKDF