### PR TITLE
cpufeatures: whitelist ARMv8 `crypto` feature on iOS

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -163,6 +163,9 @@ macro_rules! check {
     ("aes") => {
         true
     };
+    ("crypto") => {
+        true
+    };
     ("sha2") => {
         true
     };


### PR DESCRIPTION
This commit encodes the assumption that every ARMv8 CPU ever produced by Apple which is capable of running iOS supports the Cryptography Extensions for AES, PMULL, and SHA2.