### PR TITLE
cpufeatures v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpufeatures 0.1.4",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -94,15 +94,15 @@ dependencies = [
 [[package]]
 name = "cpufeatures"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+version = "0.1.5"
 dependencies = [
  "libc",
 ]
@@ -313,7 +313,7 @@ checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpufeatures 0.1.4",
  "digest",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.5 (2021-06-21)
+### Added
+- iOS support ([#435], [#501])
+
+### Changed
+- Map `aarch64` HWCAPs to target features; add `crypto` ([#456])
+
+[#435]: https://github.com/RustCrypto/utils/pull/435
+[#456]: https://github.com/RustCrypto/utils/pull/456
+[#501]: https://github.com/RustCrypto/utils/pull/501
+
 ## 0.1.4 (2021-05-14)
 ### Added
 - Support compiling on non-Linux/macOS aarch64 targets ([#408])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.1.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.5" # Also update html_root_url in lib.rs when bumping this
 description = """
 Lightweight and efficient no-std compatible alternative to the
 is_x86_feature_detected! macro

--- a/cpufeatures/README.md
+++ b/cpufeatures/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: CPU Feature Detection
+# [RustCrypto]: CPU Feature Detection
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -82,4 +82,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
+[RustCrypto]: https://github.com/rustcrypto
 [RustCrypto/utils#378]: https://github.com/RustCrypto/utils/issues/378

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/cpufeatures/0.1.4"
+    html_root_url = "https://docs.rs/cpufeatures/0.1.5"
 )]
 
 #[cfg(all(target_arch = "aarch64"))]


### PR DESCRIPTION
### Added
- iOS support ([#435], [#501])

### Changed
- Map `aarch64` HWCAPs to target features; add `crypto` ([#456])

[#435]: https://github.com/RustCrypto/utils/pull/435
[#456]: https://github.com/RustCrypto/utils/pull/456
[#501]: https://github.com/RustCrypto/utils/pull/501