### PR TITLE
crypto-bigint v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "generic-array",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto-bigint/CHANGELOG.md
+++ b/crypto-bigint/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2021-06-07)
+## 0.2.1 (2021-06-21)
+### Added
+- `Limb` newtype ([#499])
+- Target-specific rustdocs ([#500])
+
+[#499]: https://github.com/RustCrypto/utils/pull/499
+[#500]: https://github.com/RustCrypto/utils/pull/500
+
+## 0.2.0 (2021-06-07) [YANKED]
 ### Added
 - `ConstantTimeGreater`/`ConstantTimeLess` impls for UInt ([#459])
 - `From` conversions between `UInt` and limb arrays ([#460])

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -35,7 +35,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.0"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Limb` newtype ([#499])
- Target-specific rustdocs ([#500])

[#499]: https://github.com/RustCrypto/utils/pull/499
[#500]: https://github.com/RustCrypto/utils/pull/500