### PR TITLE
crypto-bigint: deprecate `LIMB_BYTES` constant

### DIFF
--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -66,8 +66,10 @@ pub use {
 
 /// Number of bytes in a [`Limb`].
 #[cfg(target_pointer_width = "32")]
+#[deprecated(since = "0.2.2", note = "use `Limb::BYTE_SIZE` instead")]
 pub const LIMB_BYTES: usize = 4;
 
 /// Number of bytes in a [`Limb`].
 #[cfg(target_pointer_width = "64")]
+#[deprecated(since = "0.2.2", note = "use `Limb::BYTE_SIZE` instead")]
 pub const LIMB_BYTES: usize = 8;

--- a/crypto-bigint/src/limb.rs
+++ b/crypto-bigint/src/limb.rs
@@ -13,6 +13,18 @@ use subtle::{Choice, ConditionallySelectable};
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 
+/// Size of the inner integer in bits
+#[cfg(target_pointer_width = "32")]
+pub(crate) const BIT_SIZE: usize = 32;
+#[cfg(target_pointer_width = "64")]
+pub(crate) const BIT_SIZE: usize = 64;
+
+/// Size of the inner integer in bytes
+#[cfg(target_pointer_width = "32")]
+pub(crate) const BYTE_SIZE: usize = 4;
+#[cfg(target_pointer_width = "64")]
+pub(crate) const BYTE_SIZE: usize = 8;
+
 /// Inner integer type.
 // TODO(tarcieri): expose this?
 #[cfg(target_pointer_width = "32")]

--- a/crypto-bigint/src/limb/encoding.rs
+++ b/crypto-bigint/src/limb/encoding.rs
@@ -4,19 +4,11 @@ use super::{Inner, Limb};
 use crate::Encoding;
 
 impl Encoding for Limb {
-    // 32-bit
-    #[cfg(target_pointer_width = "32")]
-    const BIT_SIZE: usize = 32;
-    #[cfg(target_pointer_width = "32")]
-    const BYTE_SIZE: usize = 4;
+    const BIT_SIZE: usize = super::BIT_SIZE;
+    const BYTE_SIZE: usize = super::BYTE_SIZE;
+
     #[cfg(target_pointer_width = "32")]
     type Repr = [u8; 4];
-
-    // 64-bit
-    #[cfg(target_pointer_width = "64")]
-    const BIT_SIZE: usize = 64;
-    #[cfg(target_pointer_width = "64")]
-    const BYTE_SIZE: usize = 8;
     #[cfg(target_pointer_width = "64")]
     type Repr = [u8; 8];
 

--- a/crypto-bigint/src/macros.rs
+++ b/crypto-bigint/src/macros.rs
@@ -14,7 +14,7 @@ macro_rules! const_assert {
 #[macro_export]
 macro_rules! nlimbs {
     ($bits:expr) => {
-        $bits / 8 / $crate::LIMB_BYTES
+        $bits / $crate::limb::BIT_SIZE
     };
 }
 

--- a/crypto-bigint/src/uint/from.rs
+++ b/crypto-bigint/src/uint/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`UInt`].
 
-use crate::{limb, Limb, Split, UInt, LIMB_BYTES, U128, U64};
+use crate::{limb, Limb, Split, UInt, U128, U64};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a [`UInt`] from a `u8` (const-friendly)
@@ -55,7 +55,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
     pub const fn from_u128(n: u128) -> Self {
         const_assert!(
-            LIMBS >= (16 / LIMB_BYTES),
+            LIMBS >= (128 / limb::BIT_SIZE),
             "number of limbs must be greater than zero"
         );
 
@@ -107,7 +107,7 @@ impl<const LIMBS: usize> From<u32> for UInt<LIMBS> {
 impl<const LIMBS: usize> From<u64> for UInt<LIMBS> {
     fn from(n: u64) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (8 / LIMB_BYTES), "not enough limbs");
+        debug_assert!(LIMBS >= (64 / limb::BIT_SIZE), "not enough limbs");
         Self::from_u64(n)
     }
 }
@@ -115,7 +115,7 @@ impl<const LIMBS: usize> From<u64> for UInt<LIMBS> {
 impl<const LIMBS: usize> From<u128> for UInt<LIMBS> {
     fn from(n: u128) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (16 / LIMB_BYTES), "not enough limbs");
+        debug_assert!(LIMBS >= (128 / limb::BIT_SIZE), "not enough limbs");
         Self::from_u128(n)
     }
 }


### PR DESCRIPTION
Now that we have a `Limb` newtype, we can use the associated constants `Limb::BYTE_SIZE` and `Limb::BIT_SIZE` instead.