### PR TITLE
crypto-bigint: make `Limb`'s `Inner` value public

### DIFF
--- a/crypto-bigint/src/limb.rs
+++ b/crypto-bigint/src/limb.rs
@@ -42,7 +42,7 @@ pub(crate) type Wide = u128;
 /// called "limbs".
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(transparent)]
-pub struct Limb(pub(crate) Inner);
+pub struct Limb(pub Inner);
 
 impl Limb {
     /// The value `0`.


### PR DESCRIPTION
This is mostly needed for `const fn` use as we can't use traits