### PR TITLE
crypto-bigint v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "generic-array",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto-bigint/CHANGELOG.md
+++ b/crypto-bigint/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2021-06-26)
+### Added
+- `Limb::is_odd` and `UInt::is_odd` ([#505])
+- `UInt::new` ([#506])
+- `rand` feature ([#508])
+
+### Changed
+- Deprecate `LIMB_BYTES` constant ([#504])
+- Make `Limb`'s `Inner` value public ([#507])
+
+[#504]: https://github.com/RustCrypto/utils/pull/504
+[#505]: https://github.com/RustCrypto/utils/pull/505
+[#506]: https://github.com/RustCrypto/utils/pull/506
+[#507]: https://github.com/RustCrypto/utils/pull/507
+[#508]: https://github.com/RustCrypto/utils/pull/508
+
 ## 0.2.1 (2021-06-21)
 ### Added
 - `Limb` newtype ([#499])

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -35,7 +35,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.1"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.2"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Limb::is_odd` and `UInt::is_odd` ([#505])
- `UInt::new` ([#506])
- `rand` feature ([#508])

### Changed
- Deprecate `LIMB_BYTES` constant ([#504])
- Make `Limb`'s `Inner` value public ([#507])

[#504]: https://github.com/RustCrypto/utils/pull/504
[#505]: https://github.com/RustCrypto/utils/pull/505
[#506]: https://github.com/RustCrypto/utils/pull/506
[#507]: https://github.com/RustCrypto/utils/pull/507
[#508]: https://github.com/RustCrypto/utils/pull/508