### PR TITLE
pem-rfc7468: increase LF precedence in EOL stripping functions

### DIFF
--- a/.github/workflows/pem-rfc7468.yml
+++ b/.github/workflows/pem-rfc7468.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "base64ct/**"
+      - "pem-rfc7468/**"
       - "Cargo.*"
   push:
     branches: master

--- a/pem-rfc7468/src/grammar.rs
+++ b/pem-rfc7468/src/grammar.rs
@@ -97,9 +97,9 @@ pub(crate) fn split_label(bytes: &[u8]) -> Option<(&str, &[u8])> {
 /// > lines are divided with CRLF, CR, or LF.
 pub(crate) fn strip_leading_eol(bytes: &[u8]) -> Option<&[u8]> {
     match bytes {
+        [CHAR_LF, rest @ ..] => Some(rest),
         [CHAR_CR, CHAR_LF, rest @ ..] => Some(rest),
         [CHAR_CR, rest @ ..] => Some(rest),
-        [CHAR_LF, rest @ ..] => Some(rest),
         _ => None,
     }
 }
@@ -114,8 +114,8 @@ pub(crate) fn strip_leading_eol(bytes: &[u8]) -> Option<&[u8]> {
 pub(crate) fn strip_trailing_eol(bytes: &[u8]) -> Option<&[u8]> {
     match bytes {
         [head @ .., CHAR_CR, CHAR_LF] => Some(head),
-        [head @ .., CHAR_CR] => Some(head),
         [head @ .., CHAR_LF] => Some(head),
+        [head @ .., CHAR_CR] => Some(head),
         _ => None,
     }
 }


### PR DESCRIPTION
CRLF handling can potentially touch secret data.

Unfortunately in the trailing CRLF case this is somewhat unavoidable, as looking at the previous byte before a LF is needed to disambiguate CRLF from LF.

However, for a leading EOL, if LF is examined first we can skip the CRLF check, and avoid branching on potentially secret data.

This should reduce the total number of secret bytes potentially branched on in the happy path to just 1-byte: handling the EOL that separates the encapsulated text from the post-encapsulation boundary.