### PR TITLE
pem-rfc7468 v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64ct",
 ]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,5 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2021-07-24)
+### Changed
+- Increase LF precedence in EOL stripping functions ([#532])
+
+### Fixed
+- Bug in the size calculation for `decode_vec` ([#530])
+
+[#530]: https://github.com/RustCrypto/utils/pull/530
+[#532]: https://github.com/RustCrypto/utils/pull/532
+
 ## 0.1.0 (2021-07-23)
 - Initial release

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/README.md
+++ b/pem-rfc7468/README.md
@@ -44,6 +44,19 @@ rules, implementing all of the MUSTs and SHOULDs while avoiding the MAYs,
 and targeting the "ABNF (Strict)" subset of the grammar as described in
 Section 3 Figure 3.
 
+## Implementation notes
+
+- Core PEM implementation is `no_std`-friendly and requires no heap allocations.
+- Avoids use of copies and temporary buffers.
+- Uses the [`base64ct`] crate to decode/encode Base64 in constant-time.
+- PEM parser avoids branching on potentially secret data as much as possible.
+  In the happy path, only 1-byte of secret data is potentially
+  branched upon.
+
+Note: a forthcoming paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
+demonstrates how the leakage from non-constant-time PEM parsers can be used
+to practically extract RSA private keys from SGX enclaves.
+
 ## License
 
 Licensed under either of:
@@ -72,7 +85,9 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/utils/workflows/pem-rfc7468/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/utils/actions
 
-[//]: # (general links)
+[//]: # (links)
 
 [RFC 1421]: https://datatracker.ietf.org/doc/html/rfc1421
 [RFC 7468]: https://datatracker.ietf.org/doc/html/rfc7468
+[`base64ct`]: https://github.com/RustCrypto/utils/tree/master/base64ct
+[Util::Lookup]: https://twitter.com/JanWichelmann/status/1418532480081145857

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -33,17 +33,18 @@
 //! and targeting the "ABNF (Strict)" subset of the grammar as described in
 //! [RFC 7468 Section 3 Figure 3 (p6)][RFC 7468 p6].
 //!
-//! # Implementation
+//! # Implementation notes
 //!
-//! The implementation of this crate takes great care to operate in
-//! constant-time whenever possible by avoiding branching on any values which
-//! may contain secret data.
+//! - Core PEM implementation is `no_std`-friendly and requires no heap allocations.
+//! - Avoids use of copies and temporary buffers.
+//! - Uses the [`base64ct`] crate to decode/encode Base64 in constant-time.
+//! - PEM parser avoids branching on potentially secret data as much as
+//!   possible. In the happy path, only 1-byte of secret data is potentially
+//!   branched upon.
 //!
-//! It uses the [`base64ct`] crate for Base64 decoding/encoding, which provides
-//! a portable constant-time implementation of the Base64 format.
-//!
-//! The implementation also avoids heap allocations by default, allowing it to
-//! work in "heapless" `no_std` environments.
+//! Note: a forthcoming paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
+//! demonstrates how the leakage from non-constant-time PEM parsers can be used
+//! to practically extract RSA private keys from SGX enclaves.
 //!
 //! # Minimum Supported Rust Version
 //!
@@ -86,13 +87,14 @@
 //! [RFC 1421]: https://datatracker.ietf.org/doc/html/rfc1421
 //! [RFC 7468]: https://datatracker.ietf.org/doc/html/rfc7468
 //! [RFC 7468 p6]: https://datatracker.ietf.org/doc/html/rfc7468#page-6
+//! [Util::Lookup]: https://twitter.com/JanWichelmann/status/1418532480081145857
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.1.0"
+    html_root_url = "https://docs.rs/pem-rfc7468/0.1.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Increase LF precedence in EOL stripping functions ([#532])

### Fixed
- Bug in the size calculation for `decode_vec` ([#530])

[#530]: https://github.com/RustCrypto/utils/pull/530
[#532]: https://github.com/RustCrypto/utils/pull/532