### PR TITLE
pkcs8: add `error::PEM_ENCODING_MSG` constant

### DIFF
--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -11,7 +11,7 @@ cryptographic private keys.
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
-repository = "https://github.com/RustCrypto/utils/tree/master/pem"
+repository = "https://github.com/RustCrypto/utils/tree/master/pem-rfc7468"
 categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto", "key", "pkcs", "rsa"]
 readme = "README.md"

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -81,7 +81,7 @@ impl EncryptedPrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
-        Zeroizing::new(pem::encode_string(PEM_TYPE_LABEL, &self.0).expect("PEM encoding error"))
+        Zeroizing::new(pem::encode_string(PEM_TYPE_LABEL, &self.0).expect(error::PEM_ENCODING_MSG))
     }
 
     /// Load [`EncryptedPrivateKeyDocument`] from an ASN.1 DER-encoded file on

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -69,7 +69,7 @@ impl PrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
-        Zeroizing::new(pem::encode_string(PEM_TYPE_LABEL, &self.0).expect("PEM encoding error"))
+        Zeroizing::new(pem::encode_string(PEM_TYPE_LABEL, &self.0).expect(error::PEM_ENCODING_MSG))
     }
 
     /// Load [`PrivateKeyDocument`] from an ASN.1 DER-encoded file on the local

--- a/pkcs8/src/document/public_key.rs
+++ b/pkcs8/src/document/public_key.rs
@@ -61,7 +61,7 @@ impl PublicKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> String {
-        pem::encode_string(PEM_TYPE_LABEL, &self.0).expect("PEM encoding error")
+        pem::encode_string(PEM_TYPE_LABEL, &self.0).expect(error::PEM_ENCODING_MSG)
     }
 
     /// Load [`PublicKeyDocument`] from an ASN.1 DER-encoded file on the local

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -15,7 +15,10 @@ use crate::{EncryptedPrivateKeyDocument, PrivateKeyDocument};
 use core::convert::TryInto;
 
 #[cfg(feature = "pem")]
-use {crate::pem, zeroize::Zeroizing};
+use {
+    crate::{error, pem},
+    zeroize::Zeroizing,
+};
 
 /// Type label for PEM-encoded private keys.
 #[cfg(feature = "pem")]
@@ -75,7 +78,8 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<alloc::string::String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref()).expect("PEM encoding error"),
+            pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref())
+                .expect(error::PEM_ENCODING_MSG),
         )
     }
 }

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -6,6 +6,10 @@ use core::fmt;
 #[cfg(feature = "alloc")]
 pub(crate) const DER_ENCODING_MSG: &str = "DER encoding error";
 
+/// Message to display when an `expect`-ed PEM encoding error occurs
+#[cfg(feature = "pem")]
+pub(crate) const PEM_ENCODING_MSG: &str = "PEM encoding error";
+
 /// Result type
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -20,7 +20,11 @@ use {
 };
 
 #[cfg(feature = "pem")]
-use {crate::pem, alloc::string::String, zeroize::Zeroizing};
+use {
+    crate::{error, pem},
+    alloc::string::String,
+    zeroize::Zeroizing,
+};
 
 /// Context-specific tag number for [`Attributes`].
 const ATTRIBUTES_TAG: TagNumber = TagNumber::new(0);
@@ -158,7 +162,8 @@ impl<'a> PrivateKeyInfo<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref()).expect("PEM encoding error"),
+            pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref())
+                .expect(error::PEM_ENCODING_MSG),
         )
     }
 }


### PR DESCRIPTION
Ensures that the `expect` message for PEM encoding failures is consistent.

Separately, it might make sense to move to a fallible encoding API eventually to ensure code is panic-free, but for now this at least ensures consistency.