### PR TITLE
pkcs8 v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "der",
  "hex-literal 0.3.1",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2021-07-24)
+### Changed
+- Use `pem-rfc7468` crate ([#530])
+
+[#530]: https://github.com/RustCrypto/utils/pull/530
+
 ## 0.7.2 (2021-07-20)
 ### Added
 - `Error::ParametersMalformed` variant ([#523])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.7.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -69,7 +69,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.7.2"
+    html_root_url = "https://docs.rs/pkcs8/0.7.3"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Use `pem-rfc7468` crate ([#530])

[#530]: https://github.com/RustCrypto/utils/pull/530