### PR TITLE
pkcs1: replace Error::{Decode, Encode} with Error::Asn1

### DIFF
--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -20,11 +20,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
-    /// Decoding errors
-    Decode,
-
-    /// Encoding errors
-    Encode,
+    /// ASN.1 DER-related errors.
+    Asn1(der::Error),
 
     /// File not found error.
     #[cfg(feature = "std")]
@@ -52,8 +49,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Decode => f.write_str("PKCS#1 decoding error"),
-            Error::Encode => f.write_str("PKCS#1 encoding error"),
+            Error::Asn1(err) => write!(f, "PKCS#1 ASN.1 error: {}", err),
             #[cfg(feature = "std")]
             Error::FileNotFound => f.write_str("file not found"),
             #[cfg(feature = "std")]
@@ -78,8 +74,8 @@ impl From<pem_rfc7468::Error> for Error {
 impl std::error::Error for Error {}
 
 impl From<der::Error> for Error {
-    fn from(_: der::Error) -> Error {
-        Error::Decode
+    fn from(err: der::Error) -> Error {
+        Error::Asn1(err)
     }
 }
 

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -61,8 +61,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Crypto => f.write_str("PKCS#8 cryptographic error"),
             Error::Asn1(err) => write!(f, "PKCS#8 ASN.1 error: {}", err),
+            Error::Crypto => f.write_str("PKCS#8 cryptographic error"),
             #[cfg(feature = "std")]
             Error::FileNotFound => f.write_str("file not found"),
             Error::KeyMalformed => f.write_str("PKCS#8 cryptographic key data malformed"),


### PR DESCRIPTION
Replaces opaque variants for decoding/encoding errors with one which propagates the underlying `der::Error`.

Technically a breaking change, but the initial release was today, so it's possible to just nuke it and publish a replacement.