### PR TITLE
pkcs1 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "der",
  "hex-literal 0.3.1",

--- a/pkcs1/CHANGELOG.md
+++ b/pkcs1/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-07-25)
+### Added
+- `From*`/`To*` traits for `RsaPrivateKey`/`RsaPublicKey` ([#540])
+
+### Changed
+- Use `FromRsa*`/`ToRsa*` traits with `*Document` types ([#541])
+
+[#540]: https://github.com/RustCrypto/utils/pull/540
+[#541]: https://github.com/RustCrypto/utils/pull/541
+
 ## 0.1.1 (2021-07-24)
 ### Added
 - Re-export `der` crate and `der::UIntBytes` ([#537])

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -29,7 +29,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs1/0.1.1"
+    html_root_url = "https://docs.rs/pkcs1/0.2.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `From*`/`To*` traits for `RsaPrivateKey`/`RsaPublicKey` ([#540])

### Changed
- Use `FromRsa*`/`ToRsa*` traits with `*Document` types ([#541])

[#540]: https://github.com/RustCrypto/utils/pull/540
[#541]: https://github.com/RustCrypto/utils/pull/541