### PR TITLE
pkcs8: PKCS#1 support

### DIFF
--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -43,6 +43,7 @@ jobs:
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features alloc
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features encryption
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pem
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pkcs1
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pkcs5
 
   test:
@@ -64,5 +65,7 @@ jobs:
       - run: cargo test --release --features alloc
       - run: cargo test --release --features encryption
       - run: cargo test --release --features pem
+      - run: cargo test --release --features pkcs1
+      - run: cargo test --release --features pkcs1,alloc
       - run: cargo test --release --features pkcs5
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "der",
  "hex-literal 0.3.1",
  "pem-rfc7468",
+ "pkcs1",
  "pkcs5",
  "rand_core",
  "spki",

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -20,6 +20,7 @@ spki = { version = "0.4", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
+pkcs1 = { version = "0.2", optional = true, features = ["alloc"], path = "../pkcs1" }
 pkcs5 = { version = "0.3", optional = true, path = "../pkcs5" }
 pem-rfc7468 = { version = "0.1", optional = true, path = "../pem-rfc7468" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -47,15 +47,20 @@ pub enum Error {
     /// is malformed or otherwise encoded in an unexpected manner.
     ParametersMalformed,
 
+    /// PEM encoding errors.
+    // TODO(tarcieri): propagate `pem_rfc7468::Error`
+    #[cfg(feature = "pem")]
+    Pem,
+
     /// Permission denied reading file.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     PermissionDenied,
 
-    /// PEM encoding errors.
-    // TODO(tarcieri): propagate `pem_rfc7468::Error`
-    #[cfg(feature = "pem")]
-    Pem,
+    /// PKCS#1 errors.
+    #[cfg(feature = "pkcs1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pkcs1")))]
+    Pkcs1(pkcs1::Error),
 }
 
 impl fmt::Display for Error {
@@ -68,11 +73,13 @@ impl fmt::Display for Error {
             Error::KeyMalformed => f.write_str("PKCS#8 cryptographic key data malformed"),
             #[cfg(feature = "std")]
             Error::Io => f.write_str("I/O error"),
+            Error::ParametersMalformed => f.write_str("PKCS#8 algorithm parameters malformed"),
             #[cfg(feature = "pem")]
             Error::Pem => f.write_str("PKCS#8 PEM error"),
-            Error::ParametersMalformed => f.write_str("PKCS#8 algorithm parameters malformed"),
             #[cfg(feature = "std")]
             Error::PermissionDenied => f.write_str("permission denied"),
+            #[cfg(feature = "pkcs1")]
+            Error::Pkcs1(err) => write!(f, "{}", err),
         }
     }
 }
@@ -97,6 +104,13 @@ impl From<pem_rfc7468::Error> for Error {
     fn from(_: pem_rfc7468::Error) -> Error {
         // TODO(tarcieri): propagate `pem_rfc7468::Error`
         Error::Pem
+    }
+}
+
+#[cfg(feature = "pkcs1")]
+impl From<pkcs1::Error> for Error {
+    fn from(err: pkcs1::Error) -> Error {
+        Error::Pkcs1(err)
     }
 }
 

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -54,6 +54,11 @@
 //!   - Key derivation function: [scrypt] ([RFC 7914], also supports PBKDF2-HMAC-SHA256)
 //!   - Symmetric encryption: AES-128-CBC or AES-256-CBC (best available options for PKCS#5v2)
 //!
+//! # PKCS#1 support (optional)
+//! When the `pkcs1` feature of this crate is enabled, this crate provides
+//! a blanket impl of PKCS#8 support for types which impl the traits from the
+//! [`pkcs1`] crate (e.g. `FromRsaPrivateKey`, `ToRsaPrivateKey`).
+//!
 //! # Minimum Supported Rust Version
 //!
 //! This crate requires **Rust 1.51** at a minimum.
@@ -107,14 +112,17 @@ pub use crate::{
     traits::{ToPrivateKey, ToPublicKey},
 };
 
-#[cfg(feature = "pem")]
-use pem_rfc7468 as pem;
-
 #[cfg(feature = "pkcs5")]
 pub use encrypted_private_key_info::EncryptedPrivateKeyInfo;
+
+#[cfg(feature = "pkcs1")]
+pub use pkcs1;
 
 #[cfg(feature = "pkcs5")]
 pub use pkcs5;
 
 #[cfg(all(feature = "alloc", feature = "pkcs5"))]
 pub use crate::document::encrypted_private_key::EncryptedPrivateKeyDocument;
+
+#[cfg(feature = "pem")]
+use pem_rfc7468 as pem;


### PR DESCRIPTION
Adds an optional `pkcs1` feature to the `pkcs8` crate, which provides blanket impls of the `pkcs8` key decoding/encoding traits for any type which impls the corresponding traits from the `pkcs1` crate.