### PR TITLE
pkcs1+pkcs8: simplify/fix version encoder

### DIFF
--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -59,8 +59,7 @@ impl Encodable for Version {
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        der::Header::new(Self::TAG, 1u8)?.encode(encoder)?;
-        encoder.encode(self)
+        u8::from(*self).encode(encoder)
     }
 }
 

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -59,8 +59,7 @@ impl Encodable for Version {
     }
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        der::Header::new(Self::TAG, 1u8)?.encode(encoder)?;
-        encoder.encode(self)
+        u8::from(*self).encode(encoder)
     }
 }
 


### PR DESCRIPTION
Uses the `u8` encoder to encode version numbers