### PR TITLE
pem-rfc7468: support for customizing PEM line endings

### DIFF
--- a/pem-rfc7468/src/encoder.rs
+++ b/pem-rfc7468/src/encoder.rs
@@ -1,7 +1,8 @@
 //! PEM encoder.
 
 use crate::{
-    grammar, Error, Result, BASE64_WRAP_WIDTH, ENCAPSULATION_BOUNDARY_DELIMITER,
+    grammar::{self, CHAR_CR, CHAR_LF},
+    Error, Result, BASE64_WRAP_WIDTH, ENCAPSULATION_BOUNDARY_DELIMITER,
     POST_ENCAPSULATION_BOUNDARY, PRE_ENCAPSULATION_BOUNDARY,
 };
 use base64ct::{Base64, Encoding};
@@ -9,15 +10,16 @@ use base64ct::{Base64, Encoding};
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 
-/// Newline character to use
-// TODO(tarcieri): make newline character customizable
-const NEWLINE: &[u8] = b"\n";
-
 /// Encode a PEM document according to RFC 7468's "Strict" grammar.
-pub fn encode<'a>(label: &str, input: &[u8], buf: &'a mut [u8]) -> Result<&'a [u8]> {
+pub fn encode<'a>(
+    label: &str,
+    line_ending: LineEnding,
+    input: &[u8],
+    buf: &'a mut [u8],
+) -> Result<&'a [u8]> {
     grammar::validate_label(label.as_bytes())?;
 
-    let mut buf = Buffer::new(buf);
+    let mut buf = Buffer::new(buf, line_ending);
     buf.write(PRE_ENCAPSULATION_BOUNDARY)?;
     buf.write(label.as_bytes())?;
     buf.writeln(ENCAPSULATION_BOUNDARY_DELIMITER)?;
@@ -33,31 +35,77 @@ pub fn encode<'a>(label: &str, input: &[u8], buf: &'a mut [u8]) -> Result<&'a [u
 }
 
 /// Get the length of a PEM encoded document with the given bytes and label.
-pub fn encoded_len(label: &str, input: &[u8]) -> usize {
+pub fn encoded_len(label: &str, line_ending: LineEnding, input: &[u8]) -> usize {
     // TODO(tarcieri): use checked arithmetic
     PRE_ENCAPSULATION_BOUNDARY.len()
         + label.as_bytes().len()
         + ENCAPSULATION_BOUNDARY_DELIMITER.len()
-        + NEWLINE.len()
+        + line_ending.len()
         + input
             .chunks((BASE64_WRAP_WIDTH * 3) / 4)
             .fold(0, |acc, chunk| {
-                acc + Base64::encoded_len(chunk) + NEWLINE.len()
+                acc + Base64::encoded_len(chunk) + line_ending.len()
             })
         + POST_ENCAPSULATION_BOUNDARY.len()
         + label.as_bytes().len()
         + ENCAPSULATION_BOUNDARY_DELIMITER.len()
-        + NEWLINE.len()
+        + line_ending.len()
 }
 
 /// Encode a PEM document according to RFC 7468's "Strict" grammar, returning
 /// the result as a [`String`].
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub fn encode_string(label: &str, input: &[u8]) -> Result<String> {
-    let mut buf = vec![0u8; encoded_len(label, input)];
-    encode(label, input, &mut buf)?;
+pub fn encode_string(label: &str, line_ending: LineEnding, input: &[u8]) -> Result<String> {
+    let mut buf = vec![0u8; encoded_len(label, line_ending, input)];
+    encode(label, line_ending, input, &mut buf)?;
     String::from_utf8(buf).map_err(|_| Error::CharacterEncoding)
+}
+
+/// Line endings.
+///
+/// Use [`LineEnding::default`] to get an appropriate line ending for the
+/// current operating system.
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum LineEnding {
+    /// Carriage return (Pre-OS X Macintosh)
+    CR,
+
+    /// Line feed (Unix OSes)
+    LF,
+
+    /// Carriage return + line feed (Windows)
+    CRLF,
+}
+
+impl Default for LineEnding {
+    /// Use the line ending for the current OS
+    #[cfg(windows)]
+    fn default() -> LineEnding {
+        LineEnding::CRLF
+    }
+    #[cfg(not(windows))]
+    fn default() -> LineEnding {
+        LineEnding::LF
+    }
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl LineEnding {
+    /// Get the byte serialization of this [`LineEnding`].
+    pub fn as_bytes(self) -> &'static [u8] {
+        match self {
+            LineEnding::CR => &[CHAR_CR],
+            LineEnding::LF => &[CHAR_LF],
+            LineEnding::CRLF => &[CHAR_CR, CHAR_LF],
+        }
+    }
+
+    /// Get the encoded length of this [`LineEnding`].
+    pub fn len(self) -> usize {
+        self.as_bytes().len()
+    }
 }
 
 /// Output buffer for writing encoded PEM output.
@@ -67,12 +115,19 @@ struct Buffer<'a> {
 
     /// Total number of bytes written into the buffer so far.
     position: usize,
+
+    /// Line ending to use
+    line_ending: LineEnding,
 }
 
 impl<'a> Buffer<'a> {
     /// Initialize buffer.
-    pub fn new(bytes: &'a mut [u8]) -> Self {
-        Self { bytes, position: 0 }
+    pub fn new(bytes: &'a mut [u8], line_ending: LineEnding) -> Self {
+        Self {
+            bytes,
+            position: 0,
+            line_ending,
+        }
     }
 
     /// Write a byte slice to the buffer.
@@ -85,7 +140,7 @@ impl<'a> Buffer<'a> {
     /// Write a byte slice to the buffer with a newline at the end.
     pub fn writeln(&mut self, slice: &[u8]) -> Result<()> {
         self.write(slice)?;
-        self.write(NEWLINE)
+        self.write(self.line_ending.as_bytes())
     }
 
     /// Write Base64-encoded data to the buffer.
@@ -94,7 +149,7 @@ impl<'a> Buffer<'a> {
     pub fn write_base64ln(&mut self, bytes: &[u8]) -> Result<()> {
         let reserved = self.reserve(Base64::encoded_len(bytes))?;
         Base64::encode(bytes, reserved)?;
-        self.write(NEWLINE)
+        self.write(self.line_ending.as_bytes())
     }
 
     /// Finish writing to the buffer, returning the portion that has been

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -77,7 +77,8 @@
 //! );
 //!
 //! // Encode PEM
-//! let encoded_pem = pem_rfc7468::encode_string(type_label, &data)?;
+//! use pem_rfc7468::LineEnding;
+//! let encoded_pem = pem_rfc7468::encode_string(type_label, LineEnding::default(), &data)?;
 //! assert_eq!(&encoded_pem, example_pem);
 //! # }
 //! # Ok(())
@@ -112,7 +113,7 @@ mod grammar;
 
 pub use crate::{
     decoder::decode,
-    encoder::{encode, encoded_len},
+    encoder::{encode, encoded_len, LineEnding},
     error::{Error, Result},
 };
 

--- a/pem-rfc7468/tests/encode.rs
+++ b/pem-rfc7468/tests/encode.rs
@@ -2,11 +2,13 @@
 
 #![cfg(feature = "alloc")]
 
+use pem_rfc7468::LineEnding;
+
 #[test]
 fn pkcs1_example() {
     let label = "RSA PRIVATE KEY";
     let bytes = include_bytes!("examples/pkcs1.der");
-    let encoded = pem_rfc7468::encode_string(label, bytes).unwrap();
+    let encoded = pem_rfc7468::encode_string(label, LineEnding::LF, bytes).unwrap();
     assert_eq!(&encoded, include_str!("examples/pkcs1.pem"));
 }
 
@@ -14,6 +16,6 @@ fn pkcs1_example() {
 fn pkcs8_example() {
     let label = "PRIVATE KEY";
     let bytes = include_bytes!("examples/pkcs8.der");
-    let encoded = pem_rfc7468::encode_string(label, bytes).unwrap();
+    let encoded = pem_rfc7468::encode_string(label, LineEnding::LF, bytes).unwrap();
     assert_eq!(&encoded, include_str!("examples/pkcs8.pem"));
 }

--- a/pkcs1/src/document/private_key.rs
+++ b/pkcs1/src/document/private_key.rs
@@ -87,7 +87,7 @@ impl ToRsaPrivateKey for RsaPrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs1_pem(&self) -> Result<Zeroizing<String>> {
-        let pem_doc = pem::encode_string(PEM_TYPE_LABEL, self.as_der())?;
+        let pem_doc = pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.as_der())?;
         Ok(Zeroizing::new(pem_doc))
     }
 

--- a/pkcs1/src/document/public_key.rs
+++ b/pkcs1/src/document/public_key.rs
@@ -86,7 +86,11 @@ impl ToRsaPublicKey for RsaPublicKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs1_pem(&self) -> Result<String> {
-        Ok(pem::encode_string(PEM_TYPE_LABEL, &self.0)?)
+        Ok(pem::encode_string(
+            PEM_TYPE_LABEL,
+            Default::default(),
+            &self.0,
+        )?)
     }
 
     #[cfg(feature = "std")]

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -87,7 +87,8 @@ impl<'a> RsaPrivateKey<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Result<Zeroizing<String>> {
-        let pem_doc = pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref())?;
+        let pem_doc =
+            pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.to_der().as_ref())?;
         Ok(Zeroizing::new(pem_doc))
     }
 }

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -50,7 +50,11 @@ impl<'a> RsaPublicKey<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(self) -> Result<String> {
-        Ok(pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref())?)
+        Ok(pem::encode_string(
+            PEM_TYPE_LABEL,
+            Default::default(),
+            self.to_der().as_ref(),
+        )?)
     }
 }
 

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -81,7 +81,10 @@ impl EncryptedPrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
-        Zeroizing::new(pem::encode_string(PEM_TYPE_LABEL, &self.0).expect(error::PEM_ENCODING_MSG))
+        Zeroizing::new(
+            pem::encode_string(PEM_TYPE_LABEL, Default::default(), &self.0)
+                .expect(error::PEM_ENCODING_MSG),
+        )
     }
 
     /// Load [`EncryptedPrivateKeyDocument`] from an ASN.1 DER-encoded file on

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -69,7 +69,10 @@ impl PrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
-        Zeroizing::new(pem::encode_string(PEM_TYPE_LABEL, &self.0).expect(error::PEM_ENCODING_MSG))
+        Zeroizing::new(
+            pem::encode_string(PEM_TYPE_LABEL, Default::default(), &self.0)
+                .expect(error::PEM_ENCODING_MSG),
+        )
     }
 
     /// Load [`PrivateKeyDocument`] from an ASN.1 DER-encoded file on the local

--- a/pkcs8/src/document/public_key.rs
+++ b/pkcs8/src/document/public_key.rs
@@ -61,7 +61,8 @@ impl PublicKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> String {
-        pem::encode_string(PEM_TYPE_LABEL, &self.0).expect(error::PEM_ENCODING_MSG)
+        pem::encode_string(PEM_TYPE_LABEL, Default::default(), &self.0)
+            .expect(error::PEM_ENCODING_MSG)
     }
 
     /// Load [`PublicKeyDocument`] from an ASN.1 DER-encoded file on the local

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -78,7 +78,7 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<alloc::string::String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref())
+            pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.to_der().as_ref())
                 .expect(error::PEM_ENCODING_MSG),
         )
     }

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -162,7 +162,7 @@ impl<'a> PrivateKeyInfo<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, self.to_der().as_ref())
+            pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.to_der().as_ref())
                 .expect(error::PEM_ENCODING_MSG),
         )
     }


### PR DESCRIPTION
Makes line endings used for PEM encoding explicit, with the option of using `Default::default` to use the current operating system's line endings, or otherwise picking from CR, LF, or CRLF.