### PR TITLE
pem-rfc7468 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64ct",
 ]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-07-26)
+### Added
+- Support for customizing PEM line endings ([#551])
+
+[#551]: https://github.com/RustCrypto/utils/pull/551
+
 ## 0.1.1 (2021-07-24)
 ### Changed
 - Increase LF precedence in EOL stripping functions ([#532])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 der = { version = "0.4", features = ["bigint", "oid"], path = "../der" }
 
 # optional dependencies
-pem-rfc7468 = { version = "0.1", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -22,7 +22,7 @@ spki = { version = "0.4", path = "../spki" }
 rand_core = { version = "0.6", optional = true, default-features = false }
 pkcs1 = { version = "0.2", optional = true, features = ["alloc"], path = "../pkcs1" }
 pkcs5 = { version = "0.3", optional = true, path = "../pkcs5" }
-pem-rfc7468 = { version = "0.1", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added
- Support for customizing PEM line endings ([#551])

[#551]: https://github.com/RustCrypto/utils/pull/551