### PR TITLE
pkcs1: support for customizing PEM `LineEnding`

### DIFF
--- a/pkcs1/src/document/private_key.rs
+++ b/pkcs1/src/document/private_key.rs
@@ -11,7 +11,10 @@ use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "pem")]
 use {
-    crate::{pem, private_key::PEM_TYPE_LABEL},
+    crate::{
+        pem::{self, LineEnding},
+        private_key::PEM_TYPE_LABEL,
+    },
     alloc::string::String,
     core::str::FromStr,
 };
@@ -86,8 +89,8 @@ impl ToRsaPrivateKey for RsaPrivateKeyDocument {
 
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem(&self) -> Result<Zeroizing<String>> {
-        let pem_doc = pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.as_der())?;
+    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+        let pem_doc = pem::encode_string(PEM_TYPE_LABEL, line_ending, self.as_der())?;
         Ok(Zeroizing::new(pem_doc))
     }
 

--- a/pkcs1/src/document/public_key.rs
+++ b/pkcs1/src/document/public_key.rs
@@ -13,7 +13,10 @@ use std::{fs, path::Path, str};
 
 #[cfg(feature = "pem")]
 use {
-    crate::{pem, public_key::PEM_TYPE_LABEL},
+    crate::{
+        pem::{self, LineEnding},
+        public_key::PEM_TYPE_LABEL,
+    },
     alloc::string::String,
     core::str::FromStr,
 };
@@ -85,12 +88,8 @@ impl ToRsaPublicKey for RsaPublicKeyDocument {
 
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem(&self) -> Result<String> {
-        Ok(pem::encode_string(
-            PEM_TYPE_LABEL,
-            Default::default(),
-            &self.0,
-        )?)
+    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<String> {
+        Ok(pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)?)
     }
 
     #[cfg(feature = "std")]

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -11,7 +11,11 @@ use der::{
 use crate::RsaPrivateKeyDocument;
 
 #[cfg(feature = "pem")]
-use {crate::pem, alloc::string::String, zeroize::Zeroizing};
+use {
+    crate::pem::{self, LineEnding},
+    alloc::string::String,
+    zeroize::Zeroizing,
+};
 
 /// Type label for PEM-encoded private keys.
 #[cfg(feature = "pem")]
@@ -87,8 +91,15 @@ impl<'a> RsaPrivateKey<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Result<Zeroizing<String>> {
-        let pem_doc =
-            pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.to_der().as_ref())?;
+        self.to_pem_with_le(LineEnding::default())
+    }
+
+    /// Encode this [`RsaPrivateKey`] as PEM-encoded ASN.1 DER using the given
+    /// [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+        let pem_doc = pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der().as_ref())?;
         Ok(Zeroizing::new(pem_doc))
     }
 }

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -11,7 +11,10 @@ use der::{
 use crate::RsaPublicKeyDocument;
 
 #[cfg(feature = "pem")]
-use {crate::pem, alloc::string::String};
+use {
+    crate::pem::{self, LineEnding},
+    alloc::string::String,
+};
 
 /// Type label for PEM-encoded private keys.
 #[cfg(feature = "pem")]
@@ -50,9 +53,17 @@ impl<'a> RsaPublicKey<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(self) -> Result<String> {
+        self.to_pem_with_le(LineEnding::default())
+    }
+
+    /// Encode this [`RsaPublicKey`] as PEM-encoded ASN.1 DER with the given
+    /// [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem_with_le(self, line_ending: LineEnding) -> Result<String> {
         Ok(pem::encode_string(
             PEM_TYPE_LABEL,
-            Default::default(),
+            line_ending,
             self.to_der().as_ref(),
         )?)
     }

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -7,7 +7,7 @@ use core::convert::TryFrom;
 use crate::{RsaPrivateKeyDocument, RsaPublicKeyDocument};
 
 #[cfg(feature = "pem")]
-use alloc::string::String;
+use {crate::pem::LineEnding, alloc::string::String};
 
 #[cfg(feature = "std")]
 use std::path::Path;
@@ -114,17 +114,24 @@ pub trait ToRsaPrivateKey {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs1_pem(&self) -> Result<Zeroizing<String>> {
-        self.to_pkcs1_der()?.to_pkcs1_pem()
+        self.to_pkcs1_pem_with_le(LineEnding::default())
     }
 
-    /// Write ASN.1 DER-encoded PKCS#1 private key to the given path
+    /// Serialize this private key as PEM-encoded PKCS#1 with the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+        self.to_pkcs1_der()?.to_pkcs1_pem_with_le(line_ending)
+    }
+
+    /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_der_file(&self, path: &Path) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_der_file(path)
     }
 
-    /// Write ASN.1 DER-encoded PKCS#1 private key to the given path
+    /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -144,17 +151,24 @@ pub trait ToRsaPublicKey {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs1_pem(&self) -> Result<String> {
-        self.to_pkcs1_der()?.to_pkcs1_pem()
+        self.to_pkcs1_pem_with_le(LineEnding::default())
     }
 
-    /// Write ASN.1 DER-encoded public key to the given path
+    /// Serialize this public key as PEM-encoded PKCS#1 with the given line ending.
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<String> {
+        self.to_pkcs1_der()?.to_pkcs1_pem_with_le(line_ending)
+    }
+
+    /// Write ASN.1 DER-encoded public key to the given path.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_der_file(&self, path: &Path) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_der_file(path)
     }
 
-    /// Write ASN.1 DER-encoded public key to the given path
+    /// Write ASN.1 DER-encoded public key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]


### PR DESCRIPTION
Adds `*pem_with_le` methods that support customizing the `LineEnding` used when encoding PEM.