### PR TITLE
pkcs8: support for customizing PEM `LineEnding`

### DIFF
--- a/pem-rfc7468/src/encoder.rs
+++ b/pem-rfc7468/src/encoder.rs
@@ -69,13 +69,13 @@ pub fn encode_string(label: &str, line_ending: LineEnding, input: &[u8]) -> Resu
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum LineEnding {
-    /// Carriage return (Pre-OS X Macintosh)
+    /// Carriage return: `\r` (Pre-OS X Macintosh)
     CR,
 
-    /// Line feed (Unix OSes)
+    /// Line feed: `\n` (Unix OSes)
     LF,
 
-    /// Carriage return + line feed (Windows)
+    /// Carriage return + line feed: `\r\n` (Windows)
     CRLF,
 }
 

--- a/pem-rfc7468/src/error.rs
+++ b/pem-rfc7468/src/error.rs
@@ -2,10 +2,10 @@
 
 use core::fmt;
 
-/// Result type
+/// Result type.
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// Error type
+/// Error type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {

--- a/pkcs1/src/document/private_key.rs
+++ b/pkcs1/src/document/private_key.rs
@@ -11,10 +11,7 @@ use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "pem")]
 use {
-    crate::{
-        pem::{self, LineEnding},
-        private_key::PEM_TYPE_LABEL,
-    },
+    crate::{pem, private_key::PEM_TYPE_LABEL, LineEnding},
     alloc::string::String,
     core::str::FromStr,
 };

--- a/pkcs1/src/document/public_key.rs
+++ b/pkcs1/src/document/public_key.rs
@@ -13,10 +13,7 @@ use std::{fs, path::Path, str};
 
 #[cfg(feature = "pem")]
 use {
-    crate::{
-        pem::{self, LineEnding},
-        public_key::PEM_TYPE_LABEL,
-    },
+    crate::{pem, public_key::PEM_TYPE_LABEL, LineEnding},
     alloc::string::String,
     core::str::FromStr,
 };

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -50,9 +50,6 @@ mod document;
 
 pub use der::{self, asn1::UIntBytes};
 
-#[cfg(feature = "pem")]
-use pem_rfc7468 as pem;
-
 pub use self::{
     error::{Error, Result},
     private_key::RsaPrivateKey,
@@ -61,8 +58,15 @@ pub use self::{
     version::Version,
 };
 
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+pub use pem_rfc7468::LineEnding;
+
 #[cfg(feature = "alloc")]
 pub use crate::{
     document::{private_key::RsaPrivateKeyDocument, public_key::RsaPublicKeyDocument},
     traits::{ToRsaPrivateKey, ToRsaPublicKey},
 };
+
+#[cfg(feature = "pem")]
+use pem_rfc7468 as pem;

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -12,7 +12,7 @@ use crate::RsaPrivateKeyDocument;
 
 #[cfg(feature = "pem")]
 use {
-    crate::pem::{self, LineEnding},
+    crate::{pem, LineEnding},
     alloc::string::String,
     zeroize::Zeroizing,
 };

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -12,7 +12,7 @@ use crate::RsaPublicKeyDocument;
 
 #[cfg(feature = "pem")]
 use {
-    crate::pem::{self, LineEnding},
+    crate::{pem, LineEnding},
     alloc::string::String,
 };
 

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -7,7 +7,7 @@ use core::convert::TryFrom;
 use crate::{RsaPrivateKeyDocument, RsaPublicKeyDocument};
 
 #[cfg(feature = "pem")]
-use {crate::pem::LineEnding, alloc::string::String};
+use {crate::LineEnding, alloc::string::String};
 
 #[cfg(feature = "std")]
 use std::path::Path;

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -14,7 +14,7 @@ use crate::PrivateKeyDocument;
 
 #[cfg(feature = "pem")]
 use {
-    crate::{encrypted_private_key_info::PEM_TYPE_LABEL, pem},
+    crate::{encrypted_private_key_info::PEM_TYPE_LABEL, pem, LineEnding},
     alloc::string::String,
     core::str::FromStr,
 };
@@ -81,8 +81,16 @@ impl EncryptedPrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
+        self.to_pem_with_le(LineEnding::default())
+    }
+
+    /// Serialize [`EncryptedPrivateKeyDocument`] as self-zeroizing PEM-encoded
+    /// PKCS#8 string with the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Zeroizing<String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, Default::default(), &self.0)
+            pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)
                 .expect(error::PEM_ENCODING_MSG),
         )
     }

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -18,7 +18,7 @@ use {
 
 #[cfg(feature = "pem")]
 use {
-    crate::{pem, private_key_info::PEM_TYPE_LABEL},
+    crate::{pem, private_key_info::PEM_TYPE_LABEL, LineEnding},
     alloc::string::String,
     core::str::FromStr,
 };
@@ -69,8 +69,16 @@ impl PrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
+        self.to_pem_with_le(LineEnding::default())
+    }
+
+    /// Serialize [`PrivateKeyDocument`] as self-zeroizing PEM-encoded PKCS#8 string
+    /// with the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Zeroizing<String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, Default::default(), &self.0)
+            pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)
                 .expect(error::PEM_ENCODING_MSG),
         )
     }

--- a/pkcs8/src/document/public_key.rs
+++ b/pkcs8/src/document/public_key.rs
@@ -12,7 +12,11 @@ use der::Encodable;
 use std::{fs, path::Path, str};
 
 #[cfg(feature = "pem")]
-use {crate::pem, alloc::string::String, core::str::FromStr};
+use {
+    crate::{pem, LineEnding},
+    alloc::string::String,
+    core::str::FromStr,
+};
 
 /// Type label for PEM-encoded private keys.
 #[cfg(feature = "pem")]
@@ -33,12 +37,12 @@ impl PublicKeyDocument {
         SubjectPublicKeyInfo::try_from(self.0.as_slice()).expect("malformed PublicKeyDocument")
     }
 
-    /// Parse [`PublicKeyDocument`] from ASN.1 DER
+    /// Parse [`PublicKeyDocument`] from ASN.1 DER.
     pub fn from_der(bytes: &[u8]) -> Result<Self> {
         bytes.try_into()
     }
 
-    /// Parse [`PublicKeyDocument`] from PEM
+    /// Parse [`PublicKeyDocument`] from PEM.
     ///
     /// PEM-encoded public keys can be identified by the leading delimiter:
     ///
@@ -57,12 +61,19 @@ impl PublicKeyDocument {
         Self::from_der(&*der_bytes)
     }
 
-    /// Serialize [`PublicKeyDocument`] as PEM-encoded PKCS#8 string.
+    /// Serialize [`PublicKeyDocument`] as PEM-encoded PKCS#8 (SPKI) string.
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> String {
-        pem::encode_string(PEM_TYPE_LABEL, Default::default(), &self.0)
-            .expect(error::PEM_ENCODING_MSG)
+        self.to_pem_with_le(LineEnding::default())
+    }
+
+    /// Serialize [`PublicKeyDocument`] as PEM-encoded PKCS#8 (SPKI) string
+    /// with the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> String {
+        pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0).expect(error::PEM_ENCODING_MSG)
     }
 
     /// Load [`PublicKeyDocument`] from an ASN.1 DER-encoded file on the local

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -16,7 +16,7 @@ use core::convert::TryInto;
 
 #[cfg(feature = "pem")]
 use {
-    crate::{error, pem},
+    crate::{error, pem, LineEnding},
     zeroize::Zeroizing,
 };
 
@@ -77,8 +77,16 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<alloc::string::String> {
+        self.to_pem_with_le(LineEnding::default())
+    }
+
+    /// Encode this [`EncryptedPrivateKeyInfo`] as PEM-encoded ASN.1 DER with
+    /// the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Zeroizing<alloc::string::String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.to_der().as_ref())
+            pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der().as_ref())
                 .expect(error::PEM_ENCODING_MSG),
         )
     }

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -112,6 +112,10 @@ pub use crate::{
     traits::{ToPrivateKey, ToPublicKey},
 };
 
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+pub use pem_rfc7468::LineEnding;
+
 #[cfg(feature = "pkcs5")]
 pub use encrypted_private_key_info::EncryptedPrivateKeyInfo;
 

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -21,7 +21,7 @@ use {
 
 #[cfg(feature = "pem")]
 use {
-    crate::{error, pem},
+    crate::{error, pem, LineEnding},
     alloc::string::String,
     zeroize::Zeroizing,
 };
@@ -161,8 +161,16 @@ impl<'a> PrivateKeyInfo<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self) -> Zeroizing<String> {
+        self.to_pem_with_le(LineEnding::default())
+    }
+
+    /// Encode this [`PrivateKeyInfo`] as PEM-encoded ASN.1 DER with the given
+    /// [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Zeroizing<String> {
         Zeroizing::new(
-            pem::encode_string(PEM_TYPE_LABEL, Default::default(), self.to_der().as_ref())
+            pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der().as_ref())
                 .expect(error::PEM_ENCODING_MSG),
         )
     }

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -13,7 +13,7 @@ use {
 };
 
 #[cfg(feature = "pem")]
-use alloc::string::String;
+use {crate::LineEnding, alloc::string::String};
 
 #[cfg(feature = "pkcs1")]
 use crate::{Error, ObjectIdentifier};
@@ -179,7 +179,14 @@ pub trait ToPrivateKey {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs8_pem(&self) -> Result<Zeroizing<String>> {
-        Ok(self.to_pkcs8_der()?.to_pem())
+        self.to_pkcs8_pem_with_le(LineEnding::default())
+    }
+
+    /// Serialize this private key as PEM-encoded PKCS#8 with the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn to_pkcs8_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+        Ok(self.to_pkcs8_der()?.to_pem_with_le(line_ending))
     }
 
     /// Serialize this private key as an encrypted PEM-encoded PKCS#8 private
@@ -223,7 +230,14 @@ pub trait ToPublicKey {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_public_key_pem(&self) -> Result<String> {
-        Ok(self.to_public_key_der()?.to_pem())
+        self.to_public_key_pem_with_le(LineEnding::default())
+    }
+
+    /// Serialize this public key as PEM-encoded SPKI with the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn to_public_key_pem_with_le(&self, line_ending: LineEnding) -> Result<String> {
+        Ok(self.to_public_key_der()?.to_pem_with_le(line_ending))
     }
 
     /// Write ASN.1 DER-encoded public key to the given path


### PR DESCRIPTION
Adds `*pem_with_le` methods that support customizing the `LineEnding` used when encoding PEM.

See also #553.