### PR TITLE
pkcs1 v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "der",
  "hex-literal 0.3.1",

--- a/pkcs1/CHANGELOG.md
+++ b/pkcs1/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2021-07-26)
+### Added
+- Support for customizing PEM `LineEnding` ([#553])
+
+### Changed
+- Bump `pem-rfc7468` dependency to v0.2 ([#552])
+
+[#552]: https://github.com/RustCrypto/utils/pull/552
+[#553]: https://github.com/RustCrypto/utils/pull/553
+
 ## 0.2.2 (2021-07-25)
 ### Fixed
 - `Version` encoder ([#547])

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -29,7 +29,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs1/0.2.2"
+    html_root_url = "https://docs.rs/pkcs1/0.2.3"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Support for customizing PEM `LineEnding` ([#553])

### Changed
- Bump `pem-rfc7468` dependency to v0.2 ([#552])

[#552]: https://github.com/RustCrypto/utils/pull/552
[#553]: https://github.com/RustCrypto/utils/pull/553