### PR TITLE
pkcs8 v0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "der",
  "hex-literal 0.3.1",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.5 (2021-07-26)
+### Added
+- Support for customizing PEM `LineEnding` ([#554])
+
+### Changed
+- Bump `pem-rfc7468` dependency to v0.2 ([#552])
+
+[#552]: https://github.com/RustCrypto/utils/pull/552
+[#554]: https://github.com/RustCrypto/utils/pull/554
+
 ## 0.7.4 (2021-07-25)
 ### Added
 - PKCS#1 support ([#543])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.7.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.5" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -74,7 +74,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.7.4"
+    html_root_url = "https://docs.rs/pkcs8/0.7.5"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Support for customizing PEM `LineEnding` ([#554])

### Changed
- Bump `pem-rfc7468` dependency to v0.2 ([#552])

[#552]: https://github.com/RustCrypto/utils/pull/552
[#554]: https://github.com/RustCrypto/utils/pull/554