### PR TITLE
Add `parser-implementations` category to parser Cargo.toml(s)

### DIFF
--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 documentation = "https://docs.rs/pkcs8"
 repository = "https://github.com/RustCrypto/utils/tree/master/base64ct"
-categories = ["cryptography", "encoding", "no-std"]
+categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["base64", "phc"]
 readme = "README.md"
 

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -11,7 +11,7 @@ heapless no_std (i.e. embedded) support
 """
 documentation = "https://docs.rs/const-oid"
 repository = "https://github.com/RustCrypto/utils"
-categories = ["cryptography", "data-structures", "encoding", "no-std"]
+categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
 keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"
 

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 repository = "https://github.com/RustCrypto/utils/tree/master/der"
-categories = ["cryptography", "data-structures", "encoding", "no-std"]
+categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
 keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -12,8 +12,8 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 repository = "https://github.com/RustCrypto/utils/tree/master/pem-rfc7468"
-categories = ["cryptography", "data-structures", "encoding", "no-std"]
-keywords = ["crypto", "key", "pkcs", "rsa"]
+categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
+keywords = ["crypto", "key", "pem", "pkcs", "rsa"]
 readme = "README.md"
 
 [dependencies]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 repository = "https://github.com/RustCrypto/utils/tree/master/pkcs1"
-categories = ["cryptography", "data-structures", "encoding", "no-std"]
-keywords = ["crypto", "key", "pkcs", "rsa"]
+categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
+keywords = ["crypto", "key", "pem", "pkcs", "rsa"]
 readme = "README.md"
 
 [dependencies]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -17,6 +17,7 @@ readme = "README.md"
 der = { version = "0.4", features = ["oid"], path = "../der" }
 spki = { version = "0.4", path = "../spki" }
 
+# optional dependencies
 aes = { version = "0.7.4", optional = true }
 block-modes = { version = "0.8", optional = true, default-features = false }
 hmac = { version = "0.11", optional = true, default-features = false }

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 repository = "https://github.com/RustCrypto/utils/tree/master/pkcs8"
-categories = ["cryptography", "data-structures", "encoding", "no-std"]
+categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 


### PR DESCRIPTION
Adds this category to all crates which implement format parsers