### PR TITLE
base64ct: make `Encoding::decode` reject invalid padding

### DIFF
--- a/base64ct/tests/standard.rs
+++ b/base64ct/tests/standard.rs
@@ -55,6 +55,13 @@ mod padded {
         let mut buf = [0u8; 1024];
         assert_eq!(Base64::decode(input, &mut buf), Err(Error::InvalidEncoding));
     }
+
+    #[test]
+    fn reject_invalid_padding() {
+        let input = "AA/=";
+        let mut buf = [0u8; 1024];
+        assert_eq!(Base64::decode(input, &mut buf), Err(Error::InvalidEncoding));
+    }
 }
 
 /// Standard Base64 *without* padding


### PR DESCRIPTION
When `Variant::PADDED` is `true`, ensure that the decoded data round-trips back to the padded input. If the padding is malformed, returns `Error::InvalidEncoding`.

Note that this commit only impls this check for the non-in-place `decode` method, not for `decode_in_place` yet. Instead, it documents that `decode_in_place` does not yet perform this check, and leaves it to be implemented in a followup. However, it does document that the `decode_in_place` method does not (yet) perform this check

Closes #575.