### PR TITLE
base64ct v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "blobby"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 (2021-08-14)
+### Fixed
+- Make `Encoding::decode` reject invalid padding ([#577])
+
+[#577]: https://github.com/RustCrypto/utils/pull/577
+
 ## 1.0.0 (2021-03-17)
 ### Changed
 - Bump MSRV to 1.47+ ([#334])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.0.0" # Also update html_root_url in lib.rs when bumping this
+version = "1.0.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -76,7 +76,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/1.0.0"
+    html_root_url = "https://docs.rs/base64ct/1.0.1"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
### Fixed
- Make `Encoding::decode` reject invalid padding ([#577])

[#577]: https://github.com/RustCrypto/utils/pull/577