### PR TITLE
crypto-bigint: implement Hash

### DIFF
--- a/crypto-bigint/src/limb.rs
+++ b/crypto-bigint/src/limb.rs
@@ -45,7 +45,7 @@ pub(crate) type Wide = u128;
 
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Hash)]
 #[repr(transparent)]
 pub struct Limb(pub Inner);
 

--- a/crypto-bigint/src/limb.rs
+++ b/crypto-bigint/src/limb.rs
@@ -1,5 +1,7 @@
 //! Limb newtype.
 
+#![allow(clippy::derive_hash_xor_eq)]
+
 mod add;
 mod bit_and;
 mod bit_or;

--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -1,6 +1,10 @@
 //! Big unsigned integers.
 
-#![allow(clippy::needless_range_loop, clippy::many_single_char_names)]
+#![allow(
+    clippy::needless_range_loop,
+    clippy::many_single_char_names,
+    clippy::derive_hash_xor_eq
+)]
 
 #[macro_use]
 mod macros;

--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -32,7 +32,7 @@ use zeroize::Zeroize;
 ///
 /// Generic over the given number of `LIMBS`
 // TODO(tarcieri): make generic around a specified number of bits.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash)]
 pub struct UInt<const LIMBS: usize> {
     /// Inner limb array. Stored from least significant to most significant.
     limbs: [Limb; LIMBS],


### PR DESCRIPTION
We probably should implement other `std` traits as well.

@tarcieri 
Are there other traits in your opinion in addition to `Eq` with which we should be careful?