### PR TITLE
crypto-bigint v0.2.3

### DIFF
--- a/crypto-bigint/CHANGELOG.md
+++ b/crypto-bigint/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2021-08-16)
+### Fixed
+- `UInt::wrapping_mul` ([#563])
+
+### Added
+- Implement the `Hash` trait for `UInt` and `Limb` ([#579])
+
+[#563]: https://github.com/RustCrypto/utils/pull/563
+[#579]: https://github.com/RustCrypto/utils/pull/579
+
 ## 0.2.2 (2021-06-26)
 ### Added
 - `Limb::is_odd` and `UInt::is_odd` ([#505])

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -35,7 +35,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.2"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.3"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
After pushing this release to crates.io I will yank v0.2.1 and v0.2.2.