### PR TITLE
crypto-bigint: expose `limb` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "generic-array",
  "hex-literal 0.3.1",

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -46,13 +46,12 @@ extern crate alloc;
 #[macro_use]
 mod macros;
 
-mod limb;
-mod traits;
-mod uint;
-
 #[cfg(feature = "generic-array")]
 mod array;
 mod checked;
+pub mod limb;
+mod traits;
+mod uint;
 mod wrapping;
 
 pub use crate::{checked::Checked, limb::Limb, traits::*, uint::*, wrapping::Wrapping};

--- a/crypto-bigint/src/limb.rs
+++ b/crypto-bigint/src/limb.rs
@@ -1,4 +1,5 @@
-//! Limb newtype.
+//! Big integers are represented as an array of smaller CPU word-size integers
+//! called "limbs".
 
 #![allow(clippy::derive_hash_xor_eq)]
 
@@ -20,30 +21,45 @@ use subtle::{Choice, ConditionallySelectable};
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 
-/// Size of the inner integer in bits
-#[cfg(target_pointer_width = "32")]
-pub(crate) const BIT_SIZE: usize = 32;
-#[cfg(target_pointer_width = "64")]
-pub(crate) const BIT_SIZE: usize = 64;
+//
+// 32-bit definitions
+//
 
-/// Size of the inner integer in bytes
+/// Size of the inner integer in bits.
 #[cfg(target_pointer_width = "32")]
-pub(crate) const BYTE_SIZE: usize = 4;
-#[cfg(target_pointer_width = "64")]
-pub(crate) const BYTE_SIZE: usize = 8;
+pub const BIT_SIZE: usize = 32;
 
-/// Inner integer type.
-// TODO(tarcieri): expose this?
+/// Size of the inner integer in bytes.
 #[cfg(target_pointer_width = "32")]
-pub(crate) type Inner = u32;
-#[cfg(target_pointer_width = "64")]
-pub(crate) type Inner = u64;
+pub const BYTE_SIZE: usize = 4;
+
+/// Inner integer type that the [`Limb`] newtype wraps.
+#[cfg(target_pointer_width = "32")]
+pub type Inner = u32;
 
 /// Wide integer type: double the width of [`Inner`].
 #[cfg(target_pointer_width = "32")]
-pub(crate) type Wide = u64;
+pub type Wide = u64;
+
+//
+// 64-bit definitions
+//
+
+/// Size of the inner integer in bits.
 #[cfg(target_pointer_width = "64")]
-pub(crate) type Wide = u128;
+pub const BIT_SIZE: usize = 64;
+
+/// Size of the inner integer in bytes.
+#[cfg(target_pointer_width = "64")]
+pub const BYTE_SIZE: usize = 8;
+
+/// Inner integer type that the [`Limb`] newtype wraps.
+#[cfg(target_pointer_width = "64")]
+pub type Inner = u64;
+
+/// Wide integer type: double the width of [`Inner`].
+#[cfg(target_pointer_width = "64")]
+pub type Wide = u128;
 
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".


### PR DESCRIPTION
This allows the `nlimbs!` macro to work, but also can provide the basis for expanded limb-related conversions, such as converting to an array of the inner integers.

cc @dignifiedquire 