### PR TITLE
crypto-bigint: bitwise right shift support for `UInt`

### DIFF
--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -16,6 +16,7 @@ mod encoding;
 mod from;
 mod mul;
 mod neg_mod;
+mod shr;
 mod sub;
 mod sub_mod;
 


### PR DESCRIPTION
Supports bitwise right shifts either as a `const fn` or using the `core::ops::Shr` trait.

This implementation is adapted from the one in the `k256` crate.