### PR TITLE
cpufeatures v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-08-26)
+### Removed
+- AArch64 `crypto` target feature ([#594])
+
+[#594]: https://github.com/RustCrypto/utils/pull/594
+
 ## 0.1.5 (2021-06-21)
 ### Added
 - iOS support ([#435], [#501])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.1.5" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Lightweight and efficient no-std compatible alternative to the
 is_x86_feature_detected! macro

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/cpufeatures/0.1.5"
+    html_root_url = "https://docs.rs/cpufeatures/0.2.0"
 )]
 
 #[cfg(all(target_arch = "aarch64"))]


### PR DESCRIPTION
### Removed
- AArch64 `crypto` target feature ([#594])

[#594]: https://github.com/RustCrypto/utils/pull/594