### PR TITLE
pkcs5 v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "block-modes",

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2021-08-30)
+### Changed
+- Bump `scrypt` dependency to 0.8 ([#601])
+- Bump `pbkdf2` dependency to v0.9 ([#605])
+
+[#601]: https://github.com/RustCrypto/utils/pull/601
+[#605]: https://github.com/RustCrypto/utils/pull/605
+
 ## 0.3.0 (2021-06-07)
 ### Changed
 - Bump `der` crate dependency to v0.4 ([#490])

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -18,7 +18,7 @@ der = { version = "0.4", features = ["oid"], path = "../der" }
 spki = { version = "0.4", path = "../spki" }
 
 # optional dependencies
-aes = { version = "0.7.5", optional = true }
+aes = { version = "0.7", optional = true }
 block-modes = { version = "0.8", optional = true, default-features = false }
 hmac = { version = "0.11", optional = true, default-features = false }
 pbkdf2 = { version = "0.9", optional = true, default-features = false }

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.3.0"
+    html_root_url = "https://docs.rs/pkcs5/0.3.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `scrypt` dependency to 0.8 ([#601])
- Bump `pbkdf2` dependency to v0.9 ([#605])

[#601]: https://github.com/RustCrypto/utils/pull/601
[#605]: https://github.com/RustCrypto/utils/pull/605