### PR TITLE
crypto-bigint: Recursive Length Prefix (RLP) encoding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +121,7 @@ dependencies = [
  "hex-literal 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha",
  "rand_core",
+ "rlp",
  "subtle",
  "zeroize",
 ]
@@ -317,6 +324,22 @@ name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
+name = "rlp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "ryu"

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -20,6 +20,7 @@ subtle = { version = "2.4", default-features = false }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true }
+rlp = { version = "0.5", optional = true, default-features = false }
 zeroize = { version = ">=1, <1.5", optional = true,  default-features = false }
 
 [dev-dependencies]

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -63,6 +63,9 @@ pub use {
     generic_array::{self, typenum::consts},
 };
 
+#[cfg(feature = "rlp")]
+pub use rlp;
+
 #[cfg(feature = "zeroize")]
 pub use zeroize;
 

--- a/crypto-bigint/src/traits.rs
+++ b/crypto-bigint/src/traits.rs
@@ -153,7 +153,7 @@ pub trait Encoding: Sized {
     const BYTE_SIZE: usize;
 
     /// Byte array representation.
-    type Repr: Copy + Clone + AsRef<[u8]> + AsMut<[u8]> + Sized;
+    type Repr: AsRef<[u8]> + AsMut<[u8]> + Copy + Clone + Sized;
 
     /// Decode from big endian bytes.
     fn from_be_bytes(bytes: Self::Repr) -> Self;

--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -36,6 +36,14 @@ use zeroize::DefaultIsZeroes;
 /// Big unsigned integer.
 ///
 /// Generic over the given number of `LIMBS`
+///
+/// # Encoding support
+/// This type supports many different types of encodings, either via the
+/// [`Encoding`][`crate::Encoding`] trait or various `const fn` decoding and
+/// encoding functions that can be used with [`UInt`] constants.
+///
+/// Support for Recursive Length Prefix (RLP) encoding is available under the
+/// optional `rlp` crate feature.
 // TODO(tarcieri): make generic around a specified number of bits.
 #[derive(Copy, Clone, Debug, Hash)]
 pub struct UInt<const LIMBS: usize> {

--- a/crypto-bigint/src/uint/encoding.rs
+++ b/crypto-bigint/src/uint/encoding.rs
@@ -1,7 +1,13 @@
 //! Const-friendly decoding operations for [`UInt`]
 
+mod decoder;
+
+#[cfg(feature = "rlp")]
+mod rlp;
+
 use super::UInt;
-use crate::{limb, Encoding, Limb};
+use crate::{limb, Encoding};
+use decoder::Decoder;
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a new [`UInt`] from the provided big endian bytes.
@@ -116,61 +122,6 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         {
             dst.copy_from_slice(&src.to_le_bytes());
         }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct Decoder<const LIMBS: usize> {
-    /// Limbs being decoded.
-    ///
-    /// Stored from least significant to most significant.
-    limbs: [Limb; LIMBS],
-
-    /// Current limb being decoded.
-    index: usize,
-
-    /// Total number of bytes consumed.
-    bytes: usize,
-}
-
-impl<const LIMBS: usize> Decoder<LIMBS> {
-    /// Create a new decoder.
-    pub const fn new() -> Self {
-        Self {
-            limbs: [Limb::ZERO; LIMBS],
-            index: 0,
-            bytes: 0,
-        }
-    }
-
-    /// Add a byte onto the [`UInt`] being decoded.
-    pub const fn add_byte(mut self, byte: u8) -> Self {
-        if self.bytes == limb::BYTE_SIZE {
-            const_assert!(self.index < LIMBS, "too many bytes in UInt");
-            self.index += 1;
-            self.bytes = 0;
-        }
-
-        self.limbs[self.index].0 |= (byte as limb::Inner) << (self.bytes * 8);
-        self.bytes += 1;
-        self
-    }
-
-    /// Finish decoding a [`UInt`], returning a decoded value only if we've
-    /// received the expected number of bytes.
-    pub const fn finish(self) -> UInt<LIMBS> {
-        const_assert!(self.index == LIMBS - 1, "decoded UInt is missing limbs");
-        const_assert!(
-            self.bytes == limb::BYTE_SIZE,
-            "decoded UInt is missing bytes"
-        );
-        UInt { limbs: self.limbs }
-    }
-}
-
-impl<const LIMBS: usize> Default for Decoder<LIMBS> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crypto-bigint/src/uint/encoding/decoder.rs
+++ b/crypto-bigint/src/uint/encoding/decoder.rs
@@ -1,0 +1,57 @@
+use crate::{limb, Limb, UInt};
+
+/// [`UInt`] decoder.
+#[derive(Clone, Debug)]
+pub(super) struct Decoder<const LIMBS: usize> {
+    /// Limbs being decoded.
+    ///
+    /// Stored from least significant to most significant.
+    limbs: [Limb; LIMBS],
+
+    /// Current limb being decoded.
+    index: usize,
+
+    /// Total number of bytes consumed.
+    bytes: usize,
+}
+
+impl<const LIMBS: usize> Decoder<LIMBS> {
+    /// Create a new decoder.
+    pub const fn new() -> Self {
+        Self {
+            limbs: [Limb::ZERO; LIMBS],
+            index: 0,
+            bytes: 0,
+        }
+    }
+
+    /// Add a byte onto the [`UInt`] being decoded.
+    pub const fn add_byte(mut self, byte: u8) -> Self {
+        if self.bytes == limb::BYTE_SIZE {
+            const_assert!(self.index < LIMBS, "too many bytes in UInt");
+            self.index += 1;
+            self.bytes = 0;
+        }
+
+        self.limbs[self.index].0 |= (byte as limb::Inner) << (self.bytes * 8);
+        self.bytes += 1;
+        self
+    }
+
+    /// Finish decoding a [`UInt`], returning a decoded value only if we've
+    /// received the expected number of bytes.
+    pub const fn finish(self) -> UInt<LIMBS> {
+        const_assert!(self.index == LIMBS - 1, "decoded UInt is missing limbs");
+        const_assert!(
+            self.bytes == limb::BYTE_SIZE,
+            "decoded UInt is missing bytes"
+        );
+        UInt { limbs: self.limbs }
+    }
+}
+
+impl<const LIMBS: usize> Default for Decoder<LIMBS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crypto-bigint/src/uint/encoding/rlp.rs
+++ b/crypto-bigint/src/uint/encoding/rlp.rs
@@ -1,0 +1,79 @@
+//! Recursive Length Prefix (RLP) encoding support.
+
+use crate::{Encoding, UInt};
+use rlp::{DecoderError, Rlp, RlpStream};
+
+#[cfg_attr(docsrs, doc(cfg(feature = "rlp")))]
+impl<const LIMBS: usize> rlp::Encodable for UInt<LIMBS>
+where
+    Self: Encoding,
+{
+    fn rlp_append(&self, stream: &mut RlpStream) {
+        let bytes = self.to_be_bytes();
+        let mut bytes_stripped = bytes.as_ref();
+
+        while bytes_stripped.first().cloned() == Some(0) {
+            bytes_stripped = &bytes_stripped[1..];
+        }
+
+        stream.encoder().encode_value(bytes_stripped);
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "rlp")))]
+impl<const LIMBS: usize> rlp::Decodable for UInt<LIMBS>
+where
+    Self: Encoding,
+    <Self as Encoding>::Repr: Default,
+{
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
+        rlp.decoder().decode_value(|bytes| {
+            if bytes.first().cloned() == Some(0) {
+                Err(rlp::DecoderError::RlpInvalidIndirection)
+            } else {
+                let mut repr = <Self as Encoding>::Repr::default();
+                let offset = repr
+                    .as_ref()
+                    .len()
+                    .checked_sub(bytes.len())
+                    .ok_or(DecoderError::RlpIsTooBig)?;
+
+                repr.as_mut()[offset..].copy_from_slice(bytes);
+                Ok(Self::from_be_bytes(repr))
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::U256;
+    use hex_literal::hex;
+
+    /// U256 test vectors from the `rlp` crate.
+    ///
+    /// <https://github.com/paritytech/parity-common/blob/faad8b6/rlp/tests/tests.rs#L216-L222>
+    const U256_VECTORS: &[(U256, &[u8])] = &[
+        (U256::ZERO, &hex!("80")),
+        (
+            U256::from_be_hex("0000000000000000000000000000000000000000000000000000000001000000"),
+            &hex!("8401000000"),
+        ),
+        (
+            U256::from_be_hex("00000000000000000000000000000000000000000000000000000000ffffffff"),
+            &hex!("84ffffffff"),
+        ),
+        (
+            U256::from_be_hex("8090a0b0c0d0e0f00910203040506077000000000000000100000000000012f0"),
+            &hex!("a08090a0b0c0d0e0f00910203040506077000000000000000100000000000012f0"),
+        ),
+    ];
+
+    #[test]
+    fn round_trip() {
+        for &(uint, expected_bytes) in U256_VECTORS {
+            assert_eq!(rlp::encode(&uint), expected_bytes);
+            assert_eq!(rlp::decode::<U256>(expected_bytes).unwrap(), uint);
+        }
+    }
+}


### PR DESCRIPTION
Adds an off-by-default optional `rlp` crate feature which adds RLP encoding/decoding support for `UInt`.