### PR TITLE
crypto-bigint v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "generic-array",
  "hex-literal 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto-bigint/CHANGELOG.md
+++ b/crypto-bigint/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.6 (2021-09-08)
+### Added
+- `Integer` trait ([#612])
+- `ShrAssign` impl for `UInt` ([#615])
+- Recursive Length Prefix (RLP) encoding support for `UInt` ([#616])
+
+[#612]: https://github.com/RustCrypto/utils/pull/612
+[#615]: https://github.com/RustCrypto/utils/pull/615
+[#616]: https://github.com/RustCrypto/utils/pull/616
+
 ## 0.2.5 (2021-09-02)
 ### Fixed
 - `ConditionallySelectable` impl for `UInt` ([#609])

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.5" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.6" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -23,11 +23,6 @@
 //!
 //! Please see the [feature wishlist tracking ticket] for more information.
 //!
-//! # `generic-array` interop
-//! When the optional `generic-array` feature is enabled, this library provides
-//! an [`ArrayEncoding`] trait which can be used to serialize/deserialize big
-//! integer values as `GenericArray<u8, N>`.
-//!
 //! [feature wishlist tracking ticket]: https://github.com/RustCrypto/utils/issues/453
 
 #![no_std]
@@ -35,7 +30,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.5"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.6"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/crypto-bigint/src/uint.rs
+++ b/crypto-bigint/src/uint.rs
@@ -42,8 +42,12 @@ use zeroize::DefaultIsZeroes;
 /// [`Encoding`][`crate::Encoding`] trait or various `const fn` decoding and
 /// encoding functions that can be used with [`UInt`] constants.
 ///
-/// Support for Recursive Length Prefix (RLP) encoding is available under the
-/// optional `rlp` crate feature.
+/// Optional crate features for encoding (off-by-default):
+/// - `generic-array`: enables [`ArrayEncoding`][`crate::ArrayEncoding`] trait which can be used to
+///   [`UInt`] as `GenericArray<u8, N>`.
+/// - `rlp`: support for [Recursive Length Prefix (RLP)][RLP] encoding.
+///
+/// [RLP]: https://eth.wiki/fundamentals/rlp
 // TODO(tarcieri): make generic around a specified number of bits.
 #[derive(Copy, Clone, Debug, Hash)]
 pub struct UInt<const LIMBS: usize> {


### PR DESCRIPTION
### Added
- `Integer` trait ([#612])
- `ShrAssign` impl for `UInt` ([#615])
- Recursive Length Prefix (RLP) encoding support for `UInt` ([#616])

[#612]: https://github.com/RustCrypto/utils/pull/612
[#615]: https://github.com/RustCrypto/utils/pull/615
[#616]: https://github.com/RustCrypto/utils/pull/616