### PR TITLE
crypto-bigint v0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "generic-array",
  "hex-literal 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto-bigint/CHANGELOG.md
+++ b/crypto-bigint/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.7 (2021-09-12)
+### Added
+- `UInt::shl_vartime` ([#622]) 
+
+### Fixed
+- `add_mod` overflow handling ([#619])
+
+[#619]: https://github.com/RustCrypto/utils/pull/619
+[#622]: https://github.com/RustCrypto/utils/pull/622
+
 ## 0.2.6 (2021-09-08)
 ### Added
 - `Integer` trait ([#612])

--- a/crypto-bigint/Cargo.toml
+++ b/crypto-bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.6" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.7" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/crypto-bigint/src/lib.rs
+++ b/crypto-bigint/src/lib.rs
@@ -30,7 +30,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.6"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.7"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `UInt::shl_vartime` ([#622]) 

### Fixed
- `add_mod` overflow handling ([#619])

[#619]: https://github.com/RustCrypto/utils/pull/619
[#622]: https://github.com/RustCrypto/utils/pull/622