### PR TITLE
x509: `cargo audit` workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "x509"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "der",
  "spki",

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509"
-version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.0.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -8,7 +8,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/x509/0.0.0"
+    html_root_url = "https://docs.rs/x509/0.0.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
This is effectively a bug in `cargo audit` where it sees a yanked `x509` crate published to crates.io and confuses it with the workspace member.

To work around the issue, this commit bumps the version of the `x509` crate in the workspace to v0.0.1, which hasn't been yanked.