### PR TITLE
Import `zeroize` and `zeroize_derive`

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -1,0 +1,60 @@
+name: zeroize
+
+on:
+  pull_request:
+    paths:
+      - "zeroize/**"
+      - "Cargo.*"
+  push:
+    branches: main
+
+defaults:
+  run:
+    working-directory: zeroize
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0 # MSRV
+          - stable
+        target:
+          - armv7a-none-eabi
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+          profile: minimal
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
+  test:
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        toolchain:
+          - 1.51.0 # MSRV
+          - stable
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+          profile: minimal
+      - run: cargo test --release
+      - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,4 +182,21 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.4.2"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.2.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,6 @@ members = [
     "hex-literal",
     "opaque-debug",
     "wycheproof2blb",
+    "zeroize",
+    "zeroize/derive"
 ]

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -1,0 +1,144 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.4.2 (2021-09-21)
+### Added
+- Derive `Default` on `Zeroizing`
+
+## 1.4.1 (2021-07-20)
+### Added
+- Implement Zeroize for `[MaybeUninit<Z>]`
+
+## 1.4.0 (2021-07-18)
+NOTE: This release includes an MSRV bump to Rust 1.51. Please use `zeroize = "1.3.0"`
+if you would like to support older Rust versions.
+
+### Added
+- Use const generics to impl `Zeroize` for `[Z; N]`; MSRV 1.51
+- `Zeroizing::clone_from` now zeroizes the destination before cloning
+
+## 1.3.0 (2021-04-19)
+### Added
+- impl `Zeroize` for `Box<[Z]>`
+- Clear residual space within `Option
+
+### Changed
+- Ensure `Option` is `None` when zeroized
+- Bump MSRV to 1.47
+
+## 1.2.0 (2020-12-09)
+### Added
+- `Zeroize` support for x86(_64) SIMD registers
+
+### Changed
+- Simplify `String::zeroize`
+- MSRV 1.44+
+
+## 1.1.1 (2020-09-15)
+- Add `doc_cfg`
+- zeroize entire capacity of `String`
+- zeroize entire capacity of `Vec`
+
+## 1.1.0 (2019-12-02)
+- Add `TryZeroize` trait
+- Add `From<Z: Zeroize>` impl for `Zeroizing<Z>`
+- Remove `bytes-preview` feature
+
+## 1.0.0 (2019-10-13)
+- Initial 1.0 release 🎉
+- zeroize_derive: Remove legacy `no_drop` attribute support
+- Rename `bytes` feature to `bytes-preview`
+- Further relax `Zeroize` trait bounds for `Vec`
+- Derive `Clone`, `Debug`, and `Eq` for `Zeroizing`
+
+## 1.0.0-pre (2019-09-30)
+- Loosen `Vec` trait bounds for `Zeroize`
+
+## 0.10.1 (2019-09-03)
+- (Optionally) Impl `Zeroize` for `Bytes` and `BytesMut`
+
+## 0.10.0 (2019-08-19)
+Barring unforeseen circumstances, this release aims to be the last `0.x`
+release prior to a `zeroize` 1.0 release.
+
+- Disable `zeroize_derive` Cargo feature by default
+- Remove `std` feature in favor of `alloc`; MSRV 1.36+
+- Deprecate `#[zeroize(no_drop)]` attribute
+- Use 1.0 `proc-macro2`, `quote`, and `syn` crates
+
+## 0.9.3 (2019-07-27)
+- Improved attribute parser; fixes nightly build
+
+## 0.9.2 (2019-06-28)
+- README.md: add Gitter badges; update image links
+
+## 0.9.1 (2019-06-04)
+- Impl `Zeroize` for `Option<Z: Zeroize>`
+
+## 0.9.0 (2019-06-04)
+**NOTICE**: This release changes the default behavior of `derive(Zeroize)`
+to no longer derive a `Drop` impl. If you wish to derive `Drop`, you must
+now explicitly add a `#[zeroize(drop)]` attribute on the type for which you
+are deriving `Zeroize`.
+
+- Remove CPU fences
+- Remove scary language about undefined behavior
+- Bound blanket array impls on `Zeroize` instead of `DefaultIsZeroes`
+- Require `zeroize(drop)` or `zeroize(no_drop)` attributes when deriving
+  `Zeroize` .
+- Support stablized 'alloc' crate
+
+## 0.8.0 (2019-05-20)
+- Impl `Drop` by default when deriving `Zeroize`
+
+## 0.7.0 (2019-05-19)
+- Use synstructure for custom derive
+- Add explicit array impls for `DefaultIsZeroes`
+- Remove `nightly` feature
+- Add `Zeroizing<Z>` to zeroize values on drop
+
+## 0.6.0 (2019-03-23)
+- Add ZeroizeOnDrop marker trait + custom derive
+- Custom derive support for `Zeroize`
+- Rename `ZeroizeWithDefault` to `DefaultIsZeroes`
+
+## 0.5.2 (2018-12-25)
+- Add `debug_assert!` to ensure string interiors are zeroized
+
+## 0.5.1 (2018-12-24)
+- Avoid re-exporting the whole prelude
+
+## 0.5.0 (2018-12-24)
+This release is a rewrite which replaces FFI bindings to OS-specific APIs with
+a pure Rust solution.
+
+- Use `core::sync::atomic` fences
+- Test wasm target
+- Rewrite using `core::ptr::write_volatile`
+
+## 0.4.2 (2018-10-12)
+- Fix ldd scraper for older glibc versions
+
+## 0.4.1 (2018-10-12)
+- Support musl-libc
+
+## 0.4.0 (2018-10-12)
+- Impl `Zeroize` trait on concrete types
+
+## 0.3.0 (2018-10-11)
+- Replace `secure_zero_memory` with `Zeroize`
+
+## 0.2.0 (2018-10-11)
+- Add `Zeroize` trait
+
+## 0.1.2 (2018-10-03)
+- README.md: Fix intrinsic links
+
+## 0.1.1 (2018-10-03)
+- Documentation improvements
+
+## 0.1.0 (2018-10-03)
+- Initial release

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "zeroize"
+description = """
+Securely clear secrets from memory with a simple trait built on
+stable Rust primitives which guarantee memory is zeroed using an
+operation will not be 'optimized away' by the compiler.
+Uses a portable pure Rust implementation that works everywhere,
+even WASM!
+"""
+version = "1.4.2" # Also update html_root_url in lib.rs when bumping this
+authors = ["The RustCrypto Project Developers"]
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"
+readme = "README.md"
+categories = ["cryptography", "memory-management", "no-std", "os"]
+keywords = ["memory", "memset", "secure", "volatile", "zero"]
+edition = "2018"
+
+[dependencies]
+zeroize_derive = { version = "1", path = "derive", optional = true }
+
+[features]
+default = ["alloc"]
+alloc = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/zeroize/LICENSE-APACHE
+++ b/zeroize/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zeroize/LICENSE-MIT
+++ b/zeroize/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2021 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -1,0 +1,82 @@
+# [RustCrypto]: zeroize
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache 2.0/MIT Licensed][license-image]
+![MSRV][rustc-image]
+[![Build Status][build-image]][build-link]
+
+Securely zero memory (a.k.a. [zeroize]) while avoiding compiler optimizations.
+
+This crate implements a portable approach to securely zeroing memory using
+techniques which guarantee they won't be "optimized away" by the compiler.
+
+The [`Zeroize` trait] is the crate's primary API.
+
+[Documentation]
+
+## About
+
+[Zeroing memory securely is hard] - compilers optimize for performance, and
+in doing so they love to "optimize away" unnecessary zeroing calls. There are
+many documented "tricks" to attempt to avoid these optimizations and ensure
+that a zeroing routine is performed reliably.
+
+This crate isn't about tricks: it uses [core::ptr::write_volatile]
+and [core::sync::atomic] memory fences to provide easy-to-use, portable
+zeroing behavior which works on all of Rust's core number types and slices
+thereof, implemented in pure Rust with no usage of FFI or assembly.
+
+- No insecure fallbacks!
+- No dependencies!
+- No FFI or inline assembly! **WASM friendly** (and tested)!
+- `#![no_std]` i.e. **embedded-friendly**!
+- No functionality besides securely zeroing memory!
+- (Optional) Custom derive support for zeroing complex structures
+
+## Minimum Supported Rust Version
+
+Rust **1.51** or newer.
+
+In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
+for this crate's SemVer guarantees), however when we do it will be accompanied by
+a minor version bump.
+
+## License
+
+Licensed under either of:
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/zeroize.svg
+[crate-link]: https://crates.io/crates/zeroize
+[docs-image]: https://docs.rs/zeroize/badge.svg
+[docs-link]: https://docs.rs/zeroize/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[build-image]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml
+
+[//]: # (general links)
+
+[RustCrypto]: https://github.com/RustCrypto
+[zeroize]: https://en.wikipedia.org/wiki/Zeroisation
+[`Zeroize` trait]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
+[Documentation]: https://docs.rs/zeroize/
+[Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+[core::ptr::write_volatile]: https://doc.rust-lang.org/core/ptr/fn.write_volatile.html
+[core::sync::atomic]: https://doc.rust-lang.org/stable/core/sync/atomic/index.html
+[good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
+[LICENSE]: https://github.com/RustCrypto/utils/blob/main/LICENSE
+[LICENSE-MIT]: https://github.com/RustCrypto/utils/blob/main/zeroize/LICENSE-MIT

--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.2.0 (2021-09-21)
+### Changed
+- Bump MSRV to 1.51+
+- Reject `#[zeroize(drop)]` on struct/enum fields, enum variants
+
+## 1.1.1 (2021-10-09)
+### Changed
+- Backport 1.2.0 `#[zeroize(drop)]` fixes but with a 1.47+ MSRV.
+
+## 1.1.0 (2021-04-19)
+### Changed
+- Bump MSRV to 1.47+
+
+## 1.0.1 (2019-09-15)
+### Added
+- Add docs for the `Zeroize` proc macro
+
+## 1.0.0 (2019-10-13)
+
+- Initial 1.0 release

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "zeroize_derive"
+description = "Custom derive support for zeroize"
+version = "1.2.0"
+authors = ["The RustCrypto Project Developers"]
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"
+readme = "README.md"
+categories = ["cryptography", "memory-management", "no-std", "os"]
+keywords = ["memory", "memset", "secure", "volatile", "zero"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = "1"
+synstructure = "0.12"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--document-private-items"]

--- a/zeroize/derive/LICENSE-APACHE
+++ b/zeroize/derive/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zeroize/derive/LICENSE-MIT
+++ b/zeroize/derive/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2021 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/zeroize/derive/README.md
+++ b/zeroize/derive/README.md
@@ -1,0 +1,51 @@
+# [RustCrypto]: `zeroize_derive`
+
+[![Crate][crate-image]][crate-link]
+![Apache 2.0 Licensed/MIT][license-image]
+![MSRV][rustc-image]
+[![Build Status][build-image]][build-link]
+
+Custom derive support for [zeroize]: a crate for securely zeroing memory
+while avoiding compiler optimizations.
+
+This crate isn't intended to be used directly.
+See [zeroize] crate for documentation.
+
+## Minimum Supported Rust Version
+
+Rust **1.51** or newer.
+
+In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
+for this crate's SemVer guarantees), however when we do it will be accompanied by
+a minor version bump.
+
+## License
+
+Licensed under either of:
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/zeroize_derive.svg
+[crate-link]: https://crates.io/crates/zeroize_derive
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[build-image]: https://github.com/RustCrypto/utils/workflows/Rust/badge.svg?branch=main&event=push
+[build-link]: https://github.com/RustCrypto/utils/actions
+
+[//]: # (general links)
+
+[RustCrypto]: https://github.com/RustCrypto
+[zeroize]: https://github.com/RustCrypto/utils/tree/main/zeroize
+[LICENSE]: https://github.com/RustCrypto/utils/blob/main/LICENSE
+[LICENSE-MIT]: https://github.com/RustCrypto/utils/blob/main/zeroize/LICENSE-MIT

--- a/zeroize/derive/src/lib.rs
+++ b/zeroize/derive/src/lib.rs
@@ -1,0 +1,394 @@
+//! Custom derive support for `zeroize`
+
+#![crate_type = "proc-macro"]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, trivial_casts, unused_qualifications)]
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Attribute, Meta, NestedMeta};
+use synstructure::{decl_derive, BindStyle, BindingInfo, VariantInfo};
+
+decl_derive!(
+    [Zeroize, attributes(zeroize)] =>
+
+    /// Derive the `Zeroize` trait.
+    ///
+    /// Supports the following attribute:
+    ///
+    /// - `#[zeroize(drop)]`: derives the `Drop` trait, calling `zeroize()`
+    ///   when this item is dropped.
+    derive_zeroize
+);
+
+/// Name of zeroize-related attributes
+const ZEROIZE_ATTR: &str = "zeroize";
+
+/// Custom derive for `Zeroize`
+fn derive_zeroize(s: synstructure::Structure<'_>) -> TokenStream {
+    let attributes = ZeroizeAttrs::parse(&s);
+
+    // NOTE: These are split into named functions to simplify testing with
+    // synstructure's `test_derive!` macro.
+    if attributes.drop {
+        derive_zeroize_with_drop(s)
+    } else {
+        derive_zeroize_without_drop(s)
+    }
+}
+
+/// Custom derive attributes for `Zeroize`
+#[derive(Default)]
+struct ZeroizeAttrs {
+    /// Derive a `Drop` impl which calls zeroize on this type
+    drop: bool,
+}
+
+impl ZeroizeAttrs {
+    /// Parse attributes from the incoming AST
+    fn parse(s: &synstructure::Structure<'_>) -> Self {
+        let mut result = Self::default();
+
+        for attr in s.ast().attrs.iter() {
+            result.parse_attr(attr, None, None);
+        }
+        for v in s.variants().iter() {
+            // only process actual enum variants here, as we don't want to process struct attributes twice
+            if v.prefix.is_some() {
+                for attr in v.ast().attrs.iter() {
+                    result.parse_attr(attr, Some(v), None);
+                }
+            }
+            for binding in v.bindings().iter() {
+                for attr in binding.ast().attrs.iter() {
+                    result.parse_attr(attr, Some(v), Some(binding));
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Parse attribute and handle `#[zeroize(...)]` attributes
+    fn parse_attr(
+        &mut self,
+        attr: &Attribute,
+        variant: Option<&VariantInfo<'_>>,
+        binding: Option<&BindingInfo<'_>>,
+    ) {
+        let meta_list = match attr
+            .parse_meta()
+            .unwrap_or_else(|e| panic!("error parsing attribute: {:?} ({})", attr, e))
+        {
+            Meta::List(list) => list,
+            _ => return,
+        };
+
+        // Ignore any non-zeroize attributes
+        if !meta_list.path.is_ident(ZEROIZE_ATTR) {
+            return;
+        }
+
+        for nested_meta in &meta_list.nested {
+            if let NestedMeta::Meta(meta) = nested_meta {
+                self.parse_meta(meta, variant, binding);
+            } else {
+                panic!("malformed #[zeroize] attribute: {:?}", nested_meta);
+            }
+        }
+    }
+
+    /// Parse `#[zeroize(...)]` attribute metadata (e.g. `drop`)
+    fn parse_meta(
+        &mut self,
+        meta: &Meta,
+        variant: Option<&VariantInfo<'_>>,
+        binding: Option<&BindingInfo<'_>>,
+    ) {
+        if meta.path().is_ident("drop") {
+            assert!(!self.drop, "duplicate #[zeroize] drop flags");
+
+            match (variant, binding) {
+                (_variant, Some(_binding)) => {
+                    // structs don't have a variant prefix, and only structs have bindings outside of a variant
+                    let item_kind = match variant.and_then(|variant| variant.prefix) {
+                        Some(_) => "enum",
+                        None => "struct",
+                    };
+                    panic!(
+                        concat!(
+                            "The #[zeroize(drop)] attribute is not allowed on {} fields. ",
+                            "Use it on the containing {} instead.",
+                        ),
+                        item_kind, item_kind,
+                    )
+                }
+                (Some(_variant), None) => panic!(concat!(
+                    "The #[zeroize(drop)] attribute is not allowed on enum variants. ",
+                    "Use it on the containing enum instead.",
+                )),
+                (None, None) => (),
+            };
+
+            self.drop = true;
+        } else {
+            panic!("unknown #[zeroize] attribute type: {:?}", meta.path());
+        }
+    }
+}
+
+/// Custom derive for `Zeroize` (without `Drop`)
+fn derive_zeroize_without_drop(mut s: synstructure::Structure<'_>) -> TokenStream {
+    s.bind_with(|_| BindStyle::RefMut);
+
+    let zeroizers = s.each(|bi| quote! { #bi.zeroize(); });
+
+    s.bound_impl(
+        quote!(zeroize::Zeroize),
+        quote! {
+            fn zeroize(&mut self) {
+                match self {
+                    #zeroizers
+                }
+            }
+        },
+    )
+}
+
+/// Custom derive for `Zeroize` and `Drop`
+fn derive_zeroize_with_drop(s: synstructure::Structure<'_>) -> TokenStream {
+    let drop_impl = s.gen_impl(quote! {
+        gen impl Drop for @Self {
+            fn drop(&mut self) {
+                self.zeroize();
+            }
+        }
+    });
+
+    let zeroize_impl = derive_zeroize_without_drop(s);
+
+    quote! {
+        #zeroize_impl
+
+        #[doc(hidden)]
+        #drop_impl
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+    use synstructure::{test_derive, Structure};
+
+    #[test]
+    fn zeroize_without_drop() {
+        test_derive! {
+            derive_zeroize_without_drop {
+                struct Z {
+                    a: String,
+                    b: Vec<u8>,
+                    c: [u8; 3],
+                }
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                #[doc(hidden)]
+                const _DERIVE_zeroize_Zeroize_FOR_Z: () = {
+                    extern crate zeroize;
+                    impl zeroize::Zeroize for Z {
+                        fn zeroize(&mut self) {
+                            match self {
+                                Z {
+                                    a: ref mut __binding_0,
+                                    b: ref mut __binding_1,
+                                    c: ref mut __binding_2,
+                                } => {
+                                    { __binding_0.zeroize(); }
+                                    { __binding_1.zeroize(); }
+                                    { __binding_2.zeroize(); }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+            no_build // tests the code compiles are in the `zeroize` crate
+        }
+    }
+
+    #[test]
+    fn zeroize_with_drop() {
+        test_derive! {
+            derive_zeroize_with_drop {
+                struct Z {
+                    a: String,
+                    b: Vec<u8>,
+                    c: [u8; 3],
+                }
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                #[doc(hidden)]
+                const _DERIVE_zeroize_Zeroize_FOR_Z: () = {
+                    extern crate zeroize;
+                    impl zeroize::Zeroize for Z {
+                        fn zeroize(&mut self) {
+                            match self {
+                                Z {
+                                    a: ref mut __binding_0,
+                                    b: ref mut __binding_1,
+                                    c: ref mut __binding_2,
+                                } => {
+                                    { __binding_0.zeroize(); }
+                                    { __binding_1.zeroize(); }
+                                    { __binding_2.zeroize(); }
+                                }
+                            }
+                        }
+                    }
+                };
+                #[doc(hidden)]
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_Drop_FOR_Z: () = {
+                    impl Drop for Z {
+                        fn drop(&mut self) {
+                            self.zeroize();
+                        }
+                    }
+                };
+            }
+            no_build // tests the code compiles are in the `zeroize` crate
+        }
+    }
+
+    #[test]
+    fn zeroize_on_struct() {
+        parse_zeroize_test(stringify!(
+            #[zeroize(drop)]
+            struct Z {
+                a: String,
+                b: Vec<u8>,
+                c: [u8; 3],
+            }
+        ));
+    }
+
+    #[test]
+    fn zeroize_on_enum() {
+        parse_zeroize_test(stringify!(
+            #[zeroize(drop)]
+            enum Z {
+                Variant1 { a: String, b: Vec<u8>, c: [u8; 3] },
+            }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on struct fields")]
+    fn zeroize_on_struct_field() {
+        parse_zeroize_test(stringify!(
+            struct Z {
+                #[zeroize(drop)]
+                a: String,
+                b: Vec<u8>,
+                c: [u8; 3],
+            }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on struct fields")]
+    fn zeroize_on_tuple_struct_field() {
+        parse_zeroize_test(stringify!(
+            struct Z(#[zeroize(drop)] String);
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on struct fields")]
+    fn zeroize_on_second_field() {
+        parse_zeroize_test(stringify!(
+            struct Z {
+                a: String,
+                #[zeroize(drop)]
+                b: Vec<u8>,
+                c: [u8; 3],
+            }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on enum fields")]
+    fn zeroize_on_tuple_enum_variant_field() {
+        parse_zeroize_test(stringify!(
+            enum Z {
+                Variant(#[zeroize(drop)] String),
+            }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on enum fields")]
+    fn zeroize_on_enum_variant_field() {
+        parse_zeroize_test(stringify!(
+            enum Z {
+                Variant {
+                    #[zeroize(drop)]
+                    a: String,
+                    b: Vec<u8>,
+                    c: [u8; 3],
+                },
+            }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on enum fields")]
+    fn zeroize_on_enum_second_variant_field() {
+        parse_zeroize_test(stringify!(
+            enum Z {
+                Variant1 {
+                    a: String,
+                    b: Vec<u8>,
+                    c: [u8; 3],
+                },
+                Variant2 {
+                    #[zeroize(drop)]
+                    a: String,
+                    b: Vec<u8>,
+                    c: [u8; 3],
+                },
+            }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on enum variants")]
+    fn zeroize_on_enum_variant() {
+        parse_zeroize_test(stringify!(
+            enum Z {
+                #[zeroize(drop)]
+                Variant,
+            }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[zeroize(drop)] attribute is not allowed on enum variants")]
+    fn zeroize_on_enum_second_variant() {
+        parse_zeroize_test(stringify!(
+            enum Z {
+                Variant1,
+                #[zeroize(drop)]
+                Variant2,
+            }
+        ));
+    }
+
+    fn parse_zeroize_test(unparsed: &str) -> TokenStream {
+        derive_zeroize(Structure::new(
+            &parse_str(unparsed).expect("Failed to parse test input"),
+        ))
+    }
+}

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -1,0 +1,696 @@
+//! Securely zero memory with a simple trait ([`Zeroize`]) built on stable Rust
+//! primitives which guarantee the operation will not be "optimized away".
+//!
+//! ## About
+//!
+//! [Zeroing memory securely is hard] - compilers optimize for performance, and
+//! in doing so they love to "optimize away" unnecessary zeroing calls. There are
+//! many documented "tricks" to attempt to avoid these optimizations and ensure
+//! that a zeroing routine is performed reliably.
+//!
+//! This crate isn't about tricks: it uses [`core::ptr::write_volatile`]
+//! and [`core::sync::atomic`] memory fences to provide easy-to-use, portable
+//! zeroing behavior which works on all of Rust's core number types and slices
+//! thereof, implemented in pure Rust with no usage of FFI or assembly.
+//!
+//! - No insecure fallbacks!
+//! - No dependencies!
+//! - No FFI or inline assembly! **WASM friendly** (and tested)!
+//! - `#![no_std]` i.e. **embedded-friendly**!
+//! - No functionality besides securely zeroing memory!
+//! - (Optional) Custom derive support for zeroing complex structures
+//!
+//! ## Minimum Supported Rust Version
+//!
+//! Requires Rust **1.51** or newer.
+//!
+//! In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
+//! for this crate's SemVer guarantees), however when we do it will be accompanied
+//! by a minor version bump.
+//!
+//! ## Usage
+//!
+//! ```
+//! use zeroize::Zeroize;
+//!
+//! fn main() {
+//!     // Protip: don't embed secrets in your source code.
+//!     // This is just an example.
+//!     let mut secret = b"Air shield password: 1,2,3,4,5".to_vec();
+//!     // [ ... ] open the air shield here
+//!
+//!     // Now that we're done using the secret, zero it out.
+//!     secret.zeroize();
+//! }
+//! ```
+//!
+//! The [`Zeroize`] trait is impl'd on all of Rust's core scalar types including
+//! integers, floats, `bool`, and `char`.
+//!
+//! Additionally, it's implemented on slices and `IterMut`s of the above types.
+//!
+//! When the `alloc` feature is enabled (which it is by default), it's also
+//! impl'd for `Vec<T>` for the above types as well as `String`, where it provides
+//! [`Vec::clear`] / [`String::clear`]-like behavior (truncating to zero-length)
+//! but ensures the backing memory is securely zeroed with some caveats.
+//! (NOTE: see "Stack/Heap Zeroing Notes" for important `Vec`/`String` details)
+//!
+//! The [`DefaultIsZeroes`] marker trait can be impl'd on types which also
+//! impl [`Default`], which implements [`Zeroize`] by overwriting a value with
+//! the default value.
+//!
+//! ## Custom Derive Support
+//!
+//! This crate has custom derive support for the `Zeroize` trait,
+//! gated under the `zeroize` crate's `zeroize_derive` Cargo feature,
+//! which automatically calls `zeroize()` on all members of a struct
+//! or tuple struct.
+//!
+//! Additionally it supports the following attribute:
+//!
+//! - `#[zeroize(drop)]`: call `zeroize()` when this item is dropped
+//!
+//! Example which derives `Drop`:
+//!
+//! ```
+//! # #[cfg(feature = "derive")]
+//! # {
+//! use zeroize::Zeroize;
+//!
+//! // This struct will be zeroized on drop
+//! #[derive(Zeroize)]
+//! #[zeroize(drop)]
+//! struct MyStruct([u8; 32]);
+//! # }
+//! ```
+//!
+//! Example which does not derive `Drop` (useful for e.g. `Copy` types)
+//!
+//! ```
+//! #[cfg(feature = "derive")]
+//! # {
+//! use zeroize::Zeroize;
+//!
+//! // This struct will *NOT* be zeroized on drop
+//! #[derive(Copy, Clone, Zeroize)]
+//! struct MyStruct([u8; 32]);
+//! # }
+//! ```
+//!
+//! ## `Zeroizing<Z>`: wrapper for zeroizing arbitrary values on drop
+//!
+//! `Zeroizing<Z: Zeroize>` is a generic wrapper type that impls `Deref`
+//! and `DerefMut`, allowing access to an inner value of type `Z`, and also
+//! impls a `Drop` handler which calls `zeroize()` on its contents:
+//!
+//! ```
+//! use zeroize::Zeroizing;
+//!
+//! fn main() {
+//!     let mut secret = Zeroizing::new([0u8; 5]);
+//!
+//!     // Set the air shield password
+//!     // Protip (again): don't embed secrets in your source code.
+//!     secret.copy_from_slice(&[1, 2, 3, 4, 5]);
+//!     assert_eq!(secret.as_ref(), &[1, 2, 3, 4, 5]);
+//!
+//!     // The contents of `secret` will be automatically zeroized on drop
+//! }
+//! ```
+//!
+//! ## What guarantees does this crate provide?
+//!
+//! This crate guarantees the following:
+//!
+//! 1. The zeroing operation can't be "optimized away" by the compiler.
+//! 2. All subsequent reads to memory will see "zeroized" values.
+//!
+//! LLVM's volatile semantics ensure #1 is true.
+//!
+//! Additionally, thanks to work by the [Unsafe Code Guidelines Working Group],
+//! we can now fairly confidently say #2 is true as well. Previously there were
+//! worries that the approach used by this crate (mixing volatile and
+//! non-volatile accesses) was undefined behavior due to language contained
+//! in the documentation for `write_volatile`, however after some discussion
+//! [these remarks have been removed] and the specific usage pattern in this
+//! crate is considered to be well-defined.
+//!
+//! Additionally this crate leverages [`core::sync::atomic::compiler_fence`]
+//! with the strictest ordering
+//! ([`Ordering::SeqCst`]) as a
+//! precaution to help ensure reads are not reordered before memory has been
+//! zeroed.
+//!
+//! All of that said, there is still potential for microarchitectural attacks
+//! (ala Spectre/Meltdown) to leak "zeroized" secrets through covert channels.
+//! This crate makes no guarantees that zeroized values cannot be leaked
+//! through such channels, as they represent flaws in the underlying hardware.
+//!
+//! ## Stack/Heap Zeroing Notes
+//!
+//! This crate can be used to zero values from either the stack or the heap.
+//!
+//! However, be aware several operations in Rust can unintentionally leave
+//! copies of data in memory. This includes but is not limited to:
+//!
+//! - Moves and [`Copy`]
+//! - Heap reallocation when using [`Vec`] and [`String`]
+//! - Borrowers of a reference making copies of the data
+//!
+//! [`Pin`][`core::pin::Pin`] can be leveraged in conjunction with this crate
+//! to ensure data kept on the stack isn't moved.
+//!
+//! The `Zeroize` impls for `Vec` and `String` zeroize the entire capacity of
+//! their backing buffer, but cannot guarantee copies of the data were not
+//! previously made by buffer reallocation. It's therefore important when
+//! attempting to zeroize such buffers to initialize them to the correct
+//! capacity, and take care to prevent subsequent reallocation.
+//!
+//! The `secrecy` crate provides higher-level abstractions for eliminating
+//! usage patterns which can cause reallocations:
+//!
+//! <https://crates.io/crates/secrecy>
+//!
+//! ## What about: clearing registers, mlock, mprotect, etc?
+//!
+//! This crate is focused on providing simple, unobtrusive support for reliably
+//! zeroing memory using the best approach possible on stable Rust.
+//!
+//! Clearing registers is a difficult problem that can't easily be solved by
+//! something like a crate, and requires either inline ASM or rustc support.
+//! See <https://github.com/rust-lang/rust/issues/17046> for background on
+//! this particular problem.
+//!
+//! Other memory protection mechanisms are interesting and useful, but often
+//! overkill (e.g. defending against RAM scraping or attackers with swap access).
+//! In as much as there may be merit to these approaches, there are also many
+//! other crates that already implement more sophisticated memory protections.
+//! Such protections are explicitly out-of-scope for this crate.
+//!
+//! Zeroing memory is [good cryptographic hygiene] and this crate seeks to promote
+//! it in the most unobtrusive manner possible. This includes omitting complex
+//! `unsafe` memory protection systems and just trying to make the best memory
+//! zeroing crate available.
+//!
+//! [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+//! [Unsafe Code Guidelines Working Group]: https://github.com/rust-lang/unsafe-code-guidelines
+//! [these remarks have been removed]: https://github.com/rust-lang/rust/pull/60972
+//! [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
+//! [`Ordering::SeqCst`]: core::sync::atomic::Ordering::SeqCst
+
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(html_root_url = "https://docs.rs/zeroize/1.4.2")]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(test, macro_use)]
+extern crate alloc;
+
+#[cfg(feature = "zeroize_derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize_derive")))]
+pub use zeroize_derive::Zeroize;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86;
+
+use core::mem::{self, MaybeUninit};
+use core::num::{
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+};
+use core::{ops, ptr, slice::IterMut, sync::atomic};
+
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+/// Trait for securely erasing types from memory
+pub trait Zeroize {
+    /// Zero out this object from memory using Rust intrinsics which ensure the
+    /// zeroization operation is not "optimized away" by the compiler.
+    fn zeroize(&mut self);
+}
+
+/// Marker trait for types whose `Default` is the desired zeroization result
+pub trait DefaultIsZeroes: Copy + Default + Sized {}
+
+impl<Z> Zeroize for Z
+where
+    Z: DefaultIsZeroes,
+{
+    fn zeroize(&mut self) {
+        volatile_write(self, Z::default());
+        atomic_fence();
+    }
+}
+
+macro_rules! impl_zeroize_with_default {
+    ($($type:ty),+) => {
+        $(impl DefaultIsZeroes for $type {})+
+    };
+}
+
+impl_zeroize_with_default!(i8, i16, i32, i64, i128, isize);
+impl_zeroize_with_default!(u8, u16, u32, u64, u128, usize);
+impl_zeroize_with_default!(f32, f64, char, bool);
+
+macro_rules! impl_zeroize_for_non_zero {
+    ($($type:ty),+) => {
+        $(impl Zeroize for $type
+        {
+            fn zeroize(&mut self) {
+                volatile_write(self, unsafe { <$type>::new_unchecked(1) });
+                atomic_fence();
+            }
+        })+
+    };
+}
+
+impl_zeroize_for_non_zero!(
+    NonZeroI8,
+    NonZeroI16,
+    NonZeroI32,
+    NonZeroI64,
+    NonZeroI128,
+    NonZeroIsize
+);
+impl_zeroize_for_non_zero!(
+    NonZeroU8,
+    NonZeroU16,
+    NonZeroU32,
+    NonZeroU64,
+    NonZeroU128,
+    NonZeroUsize
+);
+
+/// Implement `Zeroize` on arrays of types that impl `Zeroize`
+impl<Z, const N: usize> Zeroize for [Z; N]
+where
+    Z: Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.iter_mut().zeroize();
+    }
+}
+
+impl<'a, Z> Zeroize for IterMut<'a, Z>
+where
+    Z: Zeroize,
+{
+    fn zeroize(&mut self) {
+        for elem in self {
+            elem.zeroize();
+        }
+    }
+}
+
+impl<Z> Zeroize for Option<Z>
+where
+    Z: Zeroize,
+{
+    fn zeroize(&mut self) {
+        if let Some(value) = self {
+            value.zeroize();
+
+            // Ensures self is None and that the value was dropped. Without the take, the drop
+            // of the (zeroized) value isn't called, which might lead to a leak or other
+            // unexpected behavior. For example, if this were Option<Vec<T>>, the above call to
+            // zeroize would not free the allocated memory, but the the `take` call will.
+            self.take();
+        }
+
+        // Ensure that if the `Option` were previously `Some` but a value was copied/moved out
+        // that the remaining space in the `Option` is zeroized.
+        //
+        // Safety:
+        //
+        // The memory pointed to by `self` is valid for `mem::size_of::<Self>()` bytes.
+        // It is also properly aligned, because `u8` has an alignment of `1`.
+        unsafe {
+            volatile_set(self as *mut _ as *mut u8, 0, mem::size_of::<Self>());
+        }
+
+        // Ensures self is overwritten with the default bit pattern. volatile_write can't be
+        // used because Option<Z> is not copy.
+        //
+        // Safety:
+        //
+        // self is safe to replace with the default, which the take() call above should have
+        // already done semantically. Any value which needed to be dropped will have been
+        // done so by take().
+        unsafe { ptr::write_volatile(self, Option::default()) }
+
+        atomic_fence();
+    }
+}
+
+/// Impl `Zeroize` on slices of MaybeUninit types
+/// This impl can eventually be optimized using an memset intrinsic,
+/// such as `core::intrinsics::volatile_set_memory`.
+/// This fills the slice with zeros
+/// Note that this ignore invariants that Z might have, because MaybeUninit removes all invariants.
+impl<Z> Zeroize for [MaybeUninit<Z>] {
+    fn zeroize(&mut self) {
+        let ptr = self.as_mut_ptr() as *mut MaybeUninit<u8>;
+        let size = self.len().checked_mul(mem::size_of::<Z>()).unwrap();
+        assert!(size <= core::isize::MAX as usize);
+        // Safety:
+        //
+        // This is safe, because every valid pointer is well aligned for u8
+        // and it is backed by a single allocated object for at least `self.len() * size_pf::<Z>()` bytes.
+        // and 0 is a valid value for `MaybeUninit<Z>`
+        // The memory of the slice should not wrap around the address space.
+        unsafe { volatile_set(ptr, MaybeUninit::new(0), size) }
+        atomic_fence();
+    }
+}
+
+/// Impl `Zeroize` on slices of types that can be zeroized with `Default`.
+///
+/// This impl can eventually be optimized using an memset intrinsic,
+/// such as `core::intrinsics::volatile_set_memory`. For that reason the blanket
+/// impl on slices is bounded by `DefaultIsZeroes`.
+///
+/// To zeroize a mut slice of `Z: Zeroize` which does not impl
+/// `DefaultIsZeroes`, call `iter_mut().zeroize()`.
+impl<Z> Zeroize for [Z]
+where
+    Z: DefaultIsZeroes,
+{
+    fn zeroize(&mut self) {
+        assert!(self.len() <= core::isize::MAX as usize);
+        // Safety:
+        //
+        // This is safe, because the slice is well aligned and is backed by a single allocated
+        // object for at least `self.len()` elements of type `Z`.
+        // `self.len()` is also not larger than an `isize`, because of the assertion above.
+        // The memory of the slice should not wrap around the address space.
+        unsafe { volatile_set(self.as_mut_ptr(), Z::default(), self.len()) };
+        atomic_fence();
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<Z> Zeroize for Vec<Z>
+where
+    Z: Zeroize,
+{
+    /// "Best effort" zeroization for `Vec`.
+    ///
+    /// Ensures the entire capacity of the `Vec` is zeroed. Cannot ensure that
+    /// previous reallocations did not leave values on the heap.
+    fn zeroize(&mut self) {
+        use core::slice;
+        // Zeroize all the initialized elements.
+        self.iter_mut().zeroize();
+
+        // Set the Vec's length to 0 and drop all the elements.
+        self.clear();
+        // Zero the full capacity of `Vec`.
+        // Safety:
+        //
+        // This is safe, because `Vec` never allocates more than `isize::MAX` bytes.
+        // This exact use case is even mentioned in the documentation of `pointer::add`.
+        // This is safe because MaybeUninit ignores all invariants,
+        // so we can create a slice of MaybeUninit<Z> using the full capacity of the Vec
+        let uninit_slice = unsafe {
+            slice::from_raw_parts_mut(self.as_mut_ptr() as *mut MaybeUninit<Z>, self.capacity())
+        };
+        uninit_slice.zeroize();
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<Z> Zeroize for Box<[Z]>
+where
+    Z: Zeroize,
+{
+    /// Unlike `Vec`, `Box<[Z]>` cannot reallocate, so we can be sure that we are not leaving
+    /// values on the heap.
+    fn zeroize(&mut self) {
+        self.iter_mut().zeroize();
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Zeroize for String {
+    fn zeroize(&mut self) {
+        unsafe { self.as_mut_vec() }.zeroize();
+    }
+}
+
+/// Fallible trait for representing cases where zeroization may or may not be
+/// possible.
+///
+/// This is primarily useful for scenarios like reference counted data, where
+/// zeroization is only possible when the last reference is dropped.
+pub trait TryZeroize {
+    /// Try to zero out this object from memory using Rust intrinsics which
+    /// ensure the zeroization operation is not "optimized away" by the
+    /// compiler.
+    #[must_use]
+    fn try_zeroize(&mut self) -> bool;
+}
+
+/// `Zeroizing` is a a wrapper for any `Z: Zeroize` type which implements a
+/// `Drop` handler which zeroizes dropped values.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct Zeroizing<Z: Zeroize>(Z);
+
+impl<Z> Zeroizing<Z>
+where
+    Z: Zeroize,
+{
+    /// Move value inside a `Zeroizing` wrapper which ensures it will be
+    /// zeroized when it's dropped.
+    pub fn new(value: Z) -> Self {
+        value.into()
+    }
+}
+
+impl<Z: Zeroize + Clone> Clone for Zeroizing<Z> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.0.zeroize();
+        self.0.clone_from(&source.0);
+    }
+}
+
+impl<Z> From<Z> for Zeroizing<Z>
+where
+    Z: Zeroize,
+{
+    fn from(value: Z) -> Zeroizing<Z> {
+        Zeroizing(value)
+    }
+}
+
+impl<Z> ops::Deref for Zeroizing<Z>
+where
+    Z: Zeroize,
+{
+    type Target = Z;
+
+    fn deref(&self) -> &Z {
+        &self.0
+    }
+}
+
+impl<Z> ops::DerefMut for Zeroizing<Z>
+where
+    Z: Zeroize,
+{
+    fn deref_mut(&mut self) -> &mut Z {
+        &mut self.0
+    }
+}
+
+impl<Z> Zeroize for Zeroizing<Z>
+where
+    Z: Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl<Z> Drop for Zeroizing<Z>
+where
+    Z: Zeroize,
+{
+    fn drop(&mut self) {
+        self.0.zeroize()
+    }
+}
+
+/// Use fences to prevent accesses from being reordered before this
+/// point, which should hopefully help ensure that all accessors
+/// see zeroes after this point.
+#[inline]
+fn atomic_fence() {
+    atomic::compiler_fence(atomic::Ordering::SeqCst);
+}
+
+/// Perform a volatile write to the destination
+#[inline]
+fn volatile_write<T: Copy + Sized>(dst: &mut T, src: T) {
+    unsafe { ptr::write_volatile(dst, src) }
+}
+
+/// Perform a volatile `memset` operation which fills a slice with a value
+///
+/// Safety:
+/// The memory pointed to by `dst` must be a single allocated object that is valid for `count`
+/// contiguous elements of `T`.
+/// `count` must not be larger than an `isize`.
+/// `dst` being offset by `mem::size_of::<T> * count` bytes must not wrap around the address space.
+/// Also `dst` must be properly aligned.
+#[inline]
+unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
+    // TODO(tarcieri): use `volatile_set_memory` when stabilized
+    for i in 0..count {
+        // Safety:
+        //
+        // This is safe because there is room for at least `count` objects of type `T` in the
+        // allocation pointed to by `dst`, because `count <= isize::MAX` and because
+        // `dst.add(count)` must not wrap around the address space.
+        let ptr = dst.add(i);
+        // Safety:
+        //
+        // This is safe, because the pointer is valid and because `dst` is well aligned for `T` and
+        // `ptr` is an offset of `dst` by a multiple of `mem::size_of::<T>()` bytes.
+        ptr::write_volatile(ptr, src);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "alloc")]
+    use alloc::boxed::Box;
+
+    #[test]
+    fn non_zero() {
+        macro_rules! non_zero_test {
+            ($($type:ty),+) => {
+                $(let mut value = <$type>::new(42).unwrap();
+                value.zeroize();
+                assert_eq!(value.get(), 1);)+
+            };
+        }
+
+        non_zero_test!(
+            NonZeroI8,
+            NonZeroI16,
+            NonZeroI32,
+            NonZeroI64,
+            NonZeroI128,
+            NonZeroIsize
+        );
+        non_zero_test!(
+            NonZeroU8,
+            NonZeroU16,
+            NonZeroU32,
+            NonZeroU64,
+            NonZeroU128,
+            NonZeroUsize
+        );
+    }
+
+    #[test]
+    fn zeroize_byte_arrays() {
+        let mut arr = [42u8; 137];
+        arr.zeroize();
+        assert_eq!(arr.as_ref(), [0u8; 137].as_ref());
+    }
+
+    #[test]
+    fn zeroize_maybeuninit_byte_arrays() {
+        let mut arr = [MaybeUninit::new(42u64); 64];
+        arr.zeroize();
+        let arr_init: [u64; 64] = unsafe { core::mem::transmute(arr) };
+        assert_eq!(arr_init, [0u64; 64]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn zeroize_vec() {
+        let mut vec = vec![42; 3];
+        vec.zeroize();
+        assert!(vec.is_empty());
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn zeroize_vec_entire_capacity() {
+        #[derive(Clone)]
+        struct PanicOnNonZeroDrop(u64);
+
+        impl Zeroize for PanicOnNonZeroDrop {
+            fn zeroize(&mut self) {
+                self.0 = 0;
+            }
+        }
+
+        impl Drop for PanicOnNonZeroDrop {
+            fn drop(&mut self) {
+                if self.0 != 0 {
+                    panic!("dropped non-zeroized data");
+                }
+            }
+        }
+
+        // Ensure that the entire capacity of the vec is zeroized and that no unitinialized data
+        // is ever interpreted as initialized
+        let mut vec = vec![PanicOnNonZeroDrop(42); 2];
+
+        unsafe {
+            vec.set_len(1);
+        }
+
+        vec.zeroize();
+
+        unsafe {
+            vec.set_len(2);
+        }
+
+        drop(vec);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn zeroize_string() {
+        let mut string = String::from("Hello, world!");
+        string.zeroize();
+        assert!(string.is_empty());
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn zeroize_string_entire_capacity() {
+        let mut string = String::from("Hello, world!");
+        string.truncate(5);
+
+        string.zeroize();
+
+        // convert the string to a vec to easily access the unused capacity
+        let mut as_vec = string.into_bytes();
+        unsafe { as_vec.set_len(as_vec.capacity()) };
+
+        assert!(as_vec.iter().all(|byte| *byte == 0));
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn zeroize_box() {
+        let mut boxed_arr = Box::new([42u8; 3]);
+        boxed_arr.zeroize();
+        assert_eq!(boxed_arr.as_ref(), &[0u8; 3]);
+    }
+}

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -1,0 +1,40 @@
+//! [`Zeroize`] impls for x86 SIMD registers
+
+use crate::{atomic_fence, volatile_write, Zeroize};
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+macro_rules! impl_zeroize_for_simd_register {
+    ($type:ty, $feature:expr, $zero_value:ident) => {
+        #[cfg_attr(docsrs, doc(cfg(target_arch = "x86")))] // also `x86_64`
+        #[cfg_attr(docsrs, doc(cfg(target_feature = $feature)))]
+        impl Zeroize for $type {
+            fn zeroize(&mut self) {
+                volatile_write(self, unsafe { $zero_value() });
+                atomic_fence();
+            }
+        }
+    };
+}
+
+#[cfg(target_feature = "sse")]
+impl_zeroize_for_simd_register!(__m128, "sse", _mm_setzero_ps);
+
+#[cfg(target_feature = "sse2")]
+impl_zeroize_for_simd_register!(__m128d, "sse2", _mm_setzero_pd);
+
+#[cfg(target_feature = "sse2")]
+impl_zeroize_for_simd_register!(__m128i, "sse2", _mm_setzero_si128);
+
+#[cfg(target_feature = "avx")]
+impl_zeroize_for_simd_register!(__m256, "avx", _mm256_setzero_ps);
+
+#[cfg(target_feature = "avx")]
+impl_zeroize_for_simd_register!(__m256d, "avx", _mm256_setzero_pd);
+
+#[cfg(target_feature = "avx")]
+impl_zeroize_for_simd_register!(__m256i, "avx", _mm256_setzero_si256);

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -1,0 +1,107 @@
+//! Integration tests for `zeroize_derive` proc macros
+
+#[cfg(feature = "zeroize_derive")]
+mod custom_derive_tests {
+    use zeroize::Zeroize;
+
+    #[test]
+    fn derive_tuple_struct_test() {
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        struct Z([u8; 3]);
+
+        let mut value = Z([1, 2, 3]);
+        value.zeroize();
+        assert_eq!(&value.0, &[0, 0, 0])
+    }
+
+    #[test]
+    fn derive_struct_test() {
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        struct Z {
+            string: String,
+            vec: Vec<u8>,
+            bytearray: [u8; 3],
+            number: usize,
+            boolean: bool,
+        }
+
+        let mut value = Z {
+            string: String::from("Hello, world!"),
+            vec: vec![1, 2, 3],
+            bytearray: [4, 5, 6],
+            number: 42,
+            boolean: true,
+        };
+
+        value.zeroize();
+
+        assert!(value.string.is_empty());
+        assert!(value.vec.is_empty());
+        assert_eq!(&value.bytearray, &[0, 0, 0]);
+        assert_eq!(value.number, 0);
+        assert!(!value.boolean);
+    }
+
+    #[test]
+    fn derive_enum_test() {
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        enum Z {
+            #[allow(dead_code)]
+            Variant1,
+            Variant2(usize),
+        }
+
+        let mut value = Z::Variant2(26);
+
+        value.zeroize();
+
+        assert!(matches!(value, Z::Variant2(0)));
+    }
+
+    /// Test that the custom macro actually derived `Drop` for `Z`
+    #[test]
+    fn derive_struct_drop() {
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        struct Z([u8; 3]);
+
+        assert!(std::mem::needs_drop::<Z>());
+    }
+
+    /// Test that the custom macro actually derived `Drop` for `Z`
+    #[test]
+    fn derive_enum_drop() {
+        #[allow(dead_code)]
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        enum Z {
+            Variant1,
+            Variant2(usize),
+        }
+
+        assert!(std::mem::needs_drop::<Z>());
+    }
+
+    /// Test that `Drop` is not derived in the following case by defining a
+    /// `Drop` impl which should conflict if the custom derive defined one too
+    #[allow(dead_code)]
+    #[derive(Zeroize)]
+    struct ZeroizeNoDropStruct([u8; 3]);
+
+    impl Drop for ZeroizeNoDropStruct {
+        fn drop(&mut self) {}
+    }
+
+    #[allow(dead_code)]
+    #[derive(Zeroize)]
+    enum ZeroizeNoDropEnum {
+        Variant([u8; 3]),
+    }
+
+    impl Drop for ZeroizeNoDropEnum {
+        fn drop(&mut self) {}
+    }
+}


### PR DESCRIPTION
Moves the source code for the `zeroize` and `zeroize_derive` crates into this repository. History is not preserved.

Sources are imported with some minor modifications to URLs and documentation as of this commit:

https://github.com/iqlusioninc/crates/commit/880f4569f652cf2804d8130e718b59497ff75c85

    Author: Tony Arcieri (iqlusion) <tony@iqlusion.io>
    Date:   Thu Nov 4 18:10:33 2021 -0700
    Remove `harp` crate (#905)