### PR TITLE
zeroize_derive v1.2.2

### DIFF
--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.2 (2021-11-04)
+### Added
+- `#[zeroize(skip)]` attribute ([#654])
+
+[#654]: https://github.com/RustCrypto/utils/pull/654
+
 ## 1.2.1 (2021-11-04)
 ### Changed
 - Moved to `RustCrypto/utils` repository

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"


### PR DESCRIPTION
### Added
- `#[zeroize(skip)]` attribute ([#654])

[#654]: https://github.com/RustCrypto/utils/pull/654