### PR TITLE
Document `#[zeroize(skip)]` in the zeroize crate

### DIFF
--- a/zeroize/derive/src/lib.rs
+++ b/zeroize/derive/src/lib.rs
@@ -14,13 +14,14 @@ decl_derive!(
 
     /// Derive the `Zeroize` trait.
     ///
-    /// Supports the following attribute:
+    /// Supports the following attributes:
     ///
-    /// - `#[zeroize(drop)]`: derives the `Drop` trait, calling `zeroize()`
-    ///   when this item is dropped.
-    /// - `#[zeroize(skip)]`: skips this field or variant when calling
-    ///   `zeroize()`.
-    derive_zeroize
+    /// On the item level:
+    /// - `#[zeroize(drop)]`: call `zeroize()` when this item is dropped
+    ///
+    /// On the field level:
+    /// - `#[zeroize(skip)]`: skips this field or variant when calling `zeroize()`
+derive_zeroize
 );
 
 /// Name of zeroize-related attributes

--- a/zeroize/derive/src/lib.rs
+++ b/zeroize/derive/src/lib.rs
@@ -21,7 +21,7 @@ decl_derive!(
     ///
     /// On the field level:
     /// - `#[zeroize(skip)]`: skips this field or variant when calling `zeroize()`
-derive_zeroize
+    derive_zeroize
 );
 
 /// Name of zeroize-related attributes

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -69,6 +69,7 @@
 //! Additionally it supports the following attribute:
 //!
 //! - `#[zeroize(drop)]`: call `zeroize()` when this item is dropped
+//! - `#[zeroize(skip)]`: skips this field or variant when calling `zeroize()`
 //!
 //! Example which derives `Drop`:
 //!

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -66,9 +66,12 @@
 //! which automatically calls `zeroize()` on all members of a struct
 //! or tuple struct.
 //!
-//! Additionally it supports the following attribute:
+//! Additionally it supports the following attributes:
 //!
+//! On the item level:
 //! - `#[zeroize(drop)]`: call `zeroize()` when this item is dropped
+//!
+//! On the field level:
 //! - `#[zeroize(skip)]`: skips this field or variant when calling `zeroize()`
 //!
 //! Example which derives `Drop`:


### PR DESCRIPTION
This actually documents the `#[zeroize(skip)]` functionality in the zeroize crate, until now it was only documented in the `zeroize_derive` crate.