### PR TITLE
Improve `panic!` messages in `hex-literal`

### DIFF
--- a/hex-literal/CHANGELOG.md
+++ b/hex-literal/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Changed
+- Provide more info in `panic!` messages
+
+### Added
+- More tests for `hex!()` macro
+- More internal documentation
+
 ## 0.3.3 (2021-07-17)
 ### Added
 - Accept sequence of string literals ([#519])

--- a/hex-literal/src/lib.rs
+++ b/hex-literal/src/lib.rs
@@ -119,7 +119,8 @@ impl TokenTreeIter {
                 b'A'..=b'F' => v - 55,
                 b'a'..=b'f' => v - 87,
                 b' ' | b'\r' | b'\n' | b'\t' => continue,
-                c => panic!("encountered invalid character: `{}`", c as char),
+                0..=127 => panic!("encountered invalid character: `{}`", v as char),
+                _ => panic!("encountered invalid non-ASCII character"),
             };
             return Some(n);
         }

--- a/hex-literal/tests/basic.rs
+++ b/hex-literal/tests/basic.rs
@@ -1,0 +1,77 @@
+use hex_literal::hex;
+
+#[test]
+fn single_literal() {
+    assert_eq!(hex!("ff e4"), [0xff, 0xe4]);
+}
+
+#[test]
+fn upper_case() {
+    assert_eq!(hex!("AE DF 04 B2"), [0xae, 0xdf, 0x04, 0xb2]);
+    assert_eq!(hex!("FF BA 8C 00 01"), [0xff, 0xba, 0x8c, 0x00, 0x01]);
+}
+
+#[test]
+fn mixed_case() {
+    assert_eq!(hex!("bF dd E4 Cd"), [0xbf, 0xdd, 0xe4, 0xcd]);
+}
+
+#[test]
+fn multiple_literals() {
+    assert_eq!(
+        hex!(
+            "01 dd f7 7f"
+            "ee f0 d8"
+        ),
+        [0x01, 0xdd, 0xf7, 0x7f, 0xee, 0xf0, 0xd8]
+    );
+    assert_eq!(
+        hex!(
+            "ff"
+            "e8 d0"
+            ""
+            "01 1f"
+            "ab"
+        ),
+        [0xff, 0xe8, 0xd0, 0x01, 0x1f, 0xab]
+    );
+}
+
+#[test]
+fn no_spacing() {
+    assert_eq!(hex!("abf0d8bb0f14"), [0xab, 0xf0, 0xd8, 0xbb, 0x0f, 0x14]);
+    assert_eq!(
+        hex!("09FFd890cbcCd1d08F"),
+        [0x09, 0xff, 0xd8, 0x90, 0xcb, 0xcc, 0xd1, 0xd0, 0x8f]
+    );
+}
+
+#[test]
+fn allows_various_spacing() {
+    // newlines
+    assert_eq!(
+        hex!(
+            "f
+            f
+            d
+            0
+            e
+            
+            8
+            "
+        ),
+        [0xff, 0xd0, 0xe8]
+    );
+    // tabs
+    assert_eq!(
+        hex!("9f d   1       f07 3   01"),
+        [0x9f, 0xd1, 0xf0, 0x73, 0x01]
+    );
+    // spaces
+    assert_eq!(hex!(" e    e d0  9 1   f  f  "), [0xee, 0xd0, 0x91, 0xff]);
+}
+
+#[test]
+fn can_use_const() {
+    const _: [u8; 4] = hex!("ff d3 01 7f");
+}

--- a/hex-literal/tests/basic.rs
+++ b/hex-literal/tests/basic.rs
@@ -6,6 +6,15 @@ fn single_literal() {
 }
 
 #[test]
+fn empty() {
+    let nothing: [u8; 0] = hex!();
+    let empty_literals: [u8; 0] = hex!("" "" "");
+    let expected: [u8; 0] = [];
+    assert_eq!(nothing, expected);
+    assert_eq!(empty_literals, expected);
+}
+
+#[test]
 fn upper_case() {
     assert_eq!(hex!("AE DF 04 B2"), [0xae, 0xdf, 0x04, 0xb2]);
     assert_eq!(hex!("FF BA 8C 00 01"), [0xff, 0xba, 0x8c, 0x00, 0x01]);
@@ -63,10 +72,7 @@ fn allows_various_spacing() {
         [0xff, 0xd0, 0xe8]
     );
     // tabs
-    assert_eq!(
-        hex!("9f d   1       f07 3   01"),
-        [0x9f, 0xd1, 0xf0, 0x73, 0x01]
-    );
+    assert_eq!(hex!("9f	d		1		f07	3		01	"), [0x9f, 0xd1, 0xf0, 0x73, 0x01]);
     // spaces
     assert_eq!(hex!(" e    e d0  9 1   f  f  "), [0xee, 0xd0, 0x91, 0xff]);
 }

--- a/hex-literal/tests/comments.rs
+++ b/hex-literal/tests/comments.rs
@@ -1,0 +1,41 @@
+use hex_literal::hex;
+
+#[test]
+fn single_line_comments() {
+    assert_eq!(hex!("dd 03 // comment"), [0xdd, 0x03]);
+    assert_eq!(
+        hex!(
+            "00 04 f0 // a comment here
+            54 fe // another comment"
+        ),
+        [0x00, 0x04, 0xf0, 0x54, 0xfe]
+    );
+    assert_eq!(
+        hex!(
+            "// initial comment
+            01 02"
+        ),
+        [0x01, 0x02]
+    );
+}
+
+#[test]
+fn block_comments() {
+    assert_eq!(
+        hex!("00 01 02 /* intervening comment */ 03 04"),
+        [0x00, 0x01, 0x02, 0x03, 0x04]
+    );
+    assert_eq!(hex!("/* initial comment */ ff df dd"), [0xff, 0xdf, 0xdd]);
+    assert_eq!(
+        hex!(
+            "8f ff 7d /*
+            comment
+            on
+            several
+            lines
+            */
+            d0 a3"
+        ),
+        [0x8f, 0xff, 0x7d, 0xd0, 0xa3]
+    );
+}


### PR DESCRIPTION
Thanks for making the `hex-literal` crate! I was using it with an escaped hex string I'd copied from a C program, but ran into a panic because I'd accidentally left a semicolon after the strings I was calling `hex!()` on. It took me an embarrassing amount of time to discover the mistake, but I thought the panic messages might be able to provide a bit more info about what caused the failure.

This PR does only a few small things:
-  I added a bit more info to the panic messages when you encounter a non-literal, invalid character, or odd number of hex characters, to give you context about what's causing the issue. 
- I also added some internal documentation on some of the `TokenTreeIter` functions. 
- Lastly, I added some tests for the core `hex!()` macro functionality in the `tests/` directory (this was the only way I could find to set this up so the tests could invoke `hex!()`).

I didn't touch the changelog because I figure if this gets merged it's not a substantial enough change to warrant that. Thanks and I'd appreciate any feedback.