### PR TITLE
`hex-literal`: ensure '/' as last byte causes error in `hex!()`

### DIFF
--- a/hex-literal/CHANGELOG.md
+++ b/hex-literal/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More tests for `hex!()` macro
 - More internal documentation
 
+### Fixed
+- Make `hex!()` error when forward slash encountered as last byte
+
 ## 0.3.3 (2021-07-17)
 ### Added
 - Accept sequence of string literals ([#519])

--- a/hex-literal/src/comments.rs
+++ b/hex-literal/src/comments.rs
@@ -28,8 +28,8 @@ impl<I: Iterator<Item = u8>> Iterator for ExcludingComments<I> {
                 State::BlockComment | State::PotentiallyLeavingBlockComment => {
                     panic!("block comment not terminated with */")
                 }
-                // No more bytes after a single '/': let next_hex_val() identify it as invalid
-                State::PotentialComment { previous } => return Some(previous),
+                // No more bytes after a single '/'
+                State::PotentialComment { .. } => panic!("encountered invalid character: `/`"),
                 _ => {}
             }
         }

--- a/hex-literal/src/comments.rs
+++ b/hex-literal/src/comments.rs
@@ -28,6 +28,8 @@ impl<I: Iterator<Item = u8>> Iterator for ExcludingComments<I> {
                 State::BlockComment | State::PotentiallyLeavingBlockComment => {
                     panic!("block comment not terminated with */")
                 }
+                // No more bytes after a single '/': let next_hex_val() identify it as invalid
+                State::PotentialComment { previous } => return Some(previous),
                 _ => {}
             }
         }


### PR DESCRIPTION
Hello again,

I noticed that, because the way comment exclusion works, having a single forward slash `/` as the last byte given to `hex!()` causes no error to be given where there should be one. For instance, the following program compiles without error:
```rust
let _: [u8; 0] = hex!("/");
```
Note that this doesn't happen if there are bytes after the `/` (in which a case it errors).

My fix adds a check in the implementation of `Iterator` for `ExcludingComments` for if there are no more bytes and we're in the `PotentialComment` state. In this case it simply yields the previous byte (which was the foward slash) so that `next_hex_val()` will try to parse it as hex and panic with "invalid character". This has the nice property that it's consistent with the error you get currently if a single slash is encountered not at the end of the stream.