### PR TITLE
dbl: Refactor to avoid unsafe

### DIFF
--- a/dbl/src/lib.rs
+++ b/dbl/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -10,7 +11,7 @@ extern crate generic_array;
 use generic_array::typenum::{U16, U32, U8};
 use generic_array::GenericArray;
 
-use core::mem;
+use core::{convert::TryInto, mem::size_of};
 
 const C64: u64 = 0b1_1011;
 const C128: u64 = 0b1000_0111;
@@ -37,38 +38,36 @@ pub trait Dbl {
 }
 
 impl Dbl for GenericArray<u8, U8> {
+    #[inline]
     fn dbl(self) -> Self {
-        let mut val: u64 = unsafe { mem::transmute_copy(&self) };
-        val = val.to_be();
+        let mut val = u64::from_be_bytes(self.into());
+
         let a = val >> 63;
         val <<= 1;
         val ^= a * C64;
-        unsafe { mem::transmute(val.to_be()) }
+
+        val.to_be_bytes().into()
     }
 
+    #[inline]
     fn inv_dbl(self) -> Self {
-        let mut val: u64 = unsafe { mem::transmute_copy(&self) };
-        val = val.to_be();
+        let mut val = u64::from_be_bytes(self.into());
 
         let a = val & 1;
         val >>= 1;
         val ^= a * ((1 << 63) ^ (C64 >> 1));
 
-        unsafe { mem::transmute(val.to_be()) }
-    }
-}
-
-#[inline(always)]
-fn to_be(val: &mut [u64]) {
-    for v in val.iter_mut() {
-        *v = v.to_be();
+        val.to_be_bytes().into()
     }
 }
 
 impl Dbl for GenericArray<u8, U16> {
+    #[inline]
     fn dbl(self) -> Self {
-        let mut val: [u64; 2] = unsafe { mem::transmute_copy(&self) };
-        to_be(&mut val);
+        let mut val = [
+            u64::from_be_bytes(self[..8].try_into().unwrap()),
+            u64::from_be_bytes(self[8..].try_into().unwrap()),
+        ];
 
         let b = val[1] >> 63;
         let a = val[0] >> 63;
@@ -78,13 +77,18 @@ impl Dbl for GenericArray<u8, U16> {
         val[1] <<= 1;
         val[1] ^= a * C128;
 
-        to_be(&mut val);
-        unsafe { mem::transmute(val) }
+        let mut res = Self::default();
+        res[..8].copy_from_slice(&val[0].to_be_bytes());
+        res[8..].copy_from_slice(&val[1].to_be_bytes());
+        res
     }
 
+    #[inline]
     fn inv_dbl(self) -> Self {
-        let mut val: [u64; 2] = unsafe { mem::transmute_copy(&self) };
-        to_be(&mut val);
+        let mut val = [
+            u64::from_be_bytes(self[..8].try_into().unwrap()),
+            u64::from_be_bytes(self[8..].try_into().unwrap()),
+        ];
 
         let a = (val[0] & 1) << 63;
         let b = val[1] & 1;
@@ -95,15 +99,20 @@ impl Dbl for GenericArray<u8, U16> {
         val[0] ^= b * (1 << 63);
         val[1] ^= b * (C128 >> 1);
 
-        to_be(&mut val);
-        unsafe { mem::transmute(val) }
+        let mut res = Self::default();
+        res[..8].copy_from_slice(&val[0].to_be_bytes());
+        res[8..].copy_from_slice(&val[1].to_be_bytes());
+        res
     }
 }
 
 impl Dbl for GenericArray<u8, U32> {
+    #[inline]
     fn dbl(self) -> Self {
-        let mut val: [u64; 4] = unsafe { mem::transmute_copy(&self) };
-        to_be(&mut val);
+        let mut val = [0u64; 4];
+        for (s, v) in self.chunks_exact(size_of::<u64>()).zip(val.iter_mut()) {
+            *v = u64::from_be_bytes(s.try_into().unwrap());
+        }
 
         let a = val[0] >> 63;
         let b = val[1] >> 63;
@@ -119,13 +128,19 @@ impl Dbl for GenericArray<u8, U32> {
         val[3] <<= 1;
         val[3] ^= a * C256;
 
-        to_be(&mut val);
-        unsafe { mem::transmute(val) }
+        let mut val_u8 = [0u8; 32];
+        for (vu8, v) in val_u8.chunks_exact_mut(size_of::<u64>()).zip(val.iter()) {
+            vu8.copy_from_slice(&v.to_be_bytes());
+        }
+        val_u8.into()
     }
 
+    #[inline]
     fn inv_dbl(self) -> Self {
-        let mut val: [u64; 4] = unsafe { mem::transmute_copy(&self) };
-        to_be(&mut val);
+        let mut val = [0u64; 4];
+        for (s, v) in self.chunks_exact(size_of::<u64>()).zip(val.iter_mut()) {
+            *v = u64::from_be_bytes(s.try_into().unwrap());
+        }
 
         let a = (val[0] & 1) << 63;
         let b = (val[1] & 1) << 63;
@@ -143,7 +158,10 @@ impl Dbl for GenericArray<u8, U32> {
         val[0] ^= d * (1 << 63);
         val[3] ^= d * (C256 >> 1);
 
-        to_be(&mut val);
-        unsafe { mem::transmute(val) }
+        let mut val_u8 = [0u8; 32];
+        for (vu8, v) in val_u8.chunks_exact_mut(size_of::<u64>()).zip(val.iter()) {
+            vu8.copy_from_slice(&v.to_be_bytes());
+        }
+        val_u8.into()
     }
 }


### PR DESCRIPTION
`MACs/cmac` benchmarks were used to evaluate the refactoring, as `dbl` does not contain its own. The refactoring of `dbl` seems to have no effect on the `MACs/cmac` performance.

Benchmarks results with `dbl` refactored:
```
$ git checkout 90c46e717ab2321022104ead2f9060b1327f5710; rustup run nightly cargo bench
Previous HEAD position was 9d876cb Bump digest from 0.10.0 to 0.10.1 (#100)
HEAD is now at 90c46e7 Test dbl safe code
    Finished bench [optimized] target(s) in 0.02s
     Running unittests (/home/alwagner/working_directory/tests/MACs/target/release/deps/cmac-5a75094f2021ff95)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (/home/alwagner/working_directory/tests/MACs/target/release/deps/aes128_cmac-7ce19bbcc576eef1)

running 4 tests
test bench1_10    ... bench:         235 ns/iter (+/- 102) = 42 MB/s
test bench2_100   ... bench:       2,294 ns/iter (+/- 55) = 43 MB/s
test bench3_1000  ... bench:      22,824 ns/iter (+/- 1,547) = 43 MB/s
test bench3_10000 ... bench:     228,810 ns/iter (+/- 16,931) = 43 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 5.51s

     Running unittests (/home/alwagner/working_directory/tests/MACs/target/release/deps/aes256_cmac-e6b672d2c21213f3)

running 4 tests
test bench1_10    ... bench:         312 ns/iter (+/- 10) = 32 MB/s
test bench2_100   ... bench:       3,030 ns/iter (+/- 159) = 33 MB/s
test bench3_1000  ... bench:      30,607 ns/iter (+/- 2,214) = 32 MB/s
test bench3_10000 ... bench:     303,722 ns/iter (+/- 16,212) = 32 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 3.86s
```

Benchmark results with `dbl` untouched:
```
$ git checkout 9d876cb237bbbddee527d8126663268bea91b6e9; rustup run nightly cargo bench
Previous HEAD position was 90c46e7 Test dbl safe code
HEAD is now at 9d876cb Bump digest from 0.10.0 to 0.10.1 (#100)
    Finished bench [optimized] target(s) in 0.02s
     Running unittests (/home/alwagner/working_directory/tests/MACs/target/release/deps/cmac-b1ec60cee9662e1a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (/home/alwagner/working_directory/tests/MACs/target/release/deps/aes128_cmac-137d219e2208c539)

running 4 tests
test bench1_10    ... bench:         236 ns/iter (+/- 13) = 42 MB/s
test bench2_100   ... bench:       2,286 ns/iter (+/- 124) = 43 MB/s
test bench3_1000  ... bench:      22,978 ns/iter (+/- 1,822) = 43 MB/s
test bench3_10000 ... bench:     228,643 ns/iter (+/- 10,610) = 43 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 1.73s

     Running unittests (/home/alwagner/working_directory/tests/MACs/target/release/deps/aes256_cmac-b77e6ae6be42117d)

running 4 tests
test bench1_10    ... bench:         312 ns/iter (+/- 54) = 32 MB/s
test bench2_100   ... bench:       3,070 ns/iter (+/- 128) = 32 MB/s
test bench3_1000  ... bench:      30,668 ns/iter (+/- 2,124) = 32 MB/s
test bench3_10000 ... bench:     304,873 ns/iter (+/- 15,266) = 32 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 12.60s
```