### PR TITLE
block-buffer: Return Iterators instead of Block Slices

### DIFF
--- a/block-buffer/tests/mod.rs
+++ b/block-buffer/tests/mod.rs
@@ -30,7 +30,7 @@ fn test_eager_digest_pad() {
             n += 1;
             assert_eq!(i, j);
             assert_eq!(b.len(), exp.len());
-            assert!(b.iter().zip(exp.iter()).all(|v| v.0[..] == v.1[..]));
+            assert!(b.zip(exp.iter()).all(|v| v.0[..] == v.1[..]));
         });
         assert_eq!(exp_poses[i], buf.get_pos());
     }
@@ -64,7 +64,7 @@ fn test_lazy_digest_pad() {
             n += 1;
             assert_eq!(i, j);
             assert_eq!(b.len(), exp.len());
-            assert!(b.iter().zip(exp.iter()).all(|v| v.0[..] == v.1[..]));
+            assert!(b.zip(exp.iter()).all(|v| v.0[..] == v.1[..]));
         });
         assert_eq!(exp_poses[i], buf.get_pos());
     }


### PR DESCRIPTION
This draft PR is meant to discuss a possible change in the `block-buffer` crate, which requires changes in the dependencies as well. The main advantage is to avoid the use of `unsafe`.

Currently, `block-buffer` works with raw pointers to transmute the incoming byte slices to block slices. I would like to propose returning an `Iterator` instead. To evaluate the possiblity, the `digest_block()` method is changed to work with iterators.

What do you think about this? Are there any limitations that are not considered?

#### Impact
I have not yet adapted other crates, which uses `block-buffer`. Thus, I don't have any numbers. If this seems like a valuable approach, I would setup a PoC adapting the `digest` and `sha2` crate to create some performance benchmarks. 

#### Open Points
Chaining Iterators would allow to call the `compress` function only once. Depending on the use-case, this could improve performance. As `ExactSizeIterators` and `chain` are not working together a different workaround is needed. Maybe working with `HintSize` can be a solution.