### PR TITLE
`ZeroizeOnDrop` auto-deref

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -263,6 +263,31 @@ pub trait Zeroize {
 #[allow(drop_bounds)]
 pub trait ZeroizeOnDrop: Drop {}
 
+#[doc(hidden)]
+pub mod __internal {
+    use super::*;
+
+    /// Auto-deref workaround for deriving `ZeroizeOnDrop`.
+    pub trait AssertZeroizeOnDrop {
+        fn zeroize_or_on_drop(&mut self);
+    }
+
+    impl<T: ZeroizeOnDrop> AssertZeroizeOnDrop for &mut T {
+        fn zeroize_or_on_drop(&mut self) {}
+    }
+
+    /// Auto-deref workaround for deriving `ZeroizeOnDrop`.
+    pub trait AssertZeroize {
+        fn zeroize_or_on_drop(&mut self);
+    }
+
+    impl<T: Zeroize> AssertZeroize for T {
+        fn zeroize_or_on_drop(&mut self) {
+            self.zeroize()
+        }
+    }
+}
+
 /// Marker trait for types whose `Default` is the desired zeroization result
 pub trait DefaultIsZeroes: Copy + Default + Sized {}
 


### PR DESCRIPTION
This changes nothing from the users perspective, but will enable to implement `ZeroizeOnDrop` for fields that implement it replacing the need to `skip` them instead.

This will also validate that these fields types implement `ZeroizeOnDrop`.

See #652 for further discussion.
Builds on top of #699.

Fixes #652.