### PR TITLE
zeroize_derive v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.0-pre"
+version = "1.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -17,11 +17,12 @@ keywords = ["memory", "memset", "secure", "volatile", "zero"]
 edition = "2018"
 
 [dependencies]
-zeroize_derive = { version = "=1.3.0-pre", path = "derive", optional = true }
+zeroize_derive = { version = "1.3", path = "derive", optional = true }
 
 [features]
 default = ["alloc"]
 alloc = []
+derive = ["zeroize_derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (2021-01-14)
+### Added
+- `#[zeroize(bound = "T: MyTrait")]` ([#663])
+- Custom derive for `ZeroizeOnDrop` ([#699], [#700])
+
+[#663]: https://github.com/RustCrypto/utils/pull/663
+[#699]: https://github.com/RustCrypto/utils/pull/699
+[#700]: https://github.com/RustCrypto/utils/pull/700
+
 ## 1.2.2 (2021-11-04)
 ### Added
 - `#[zeroize(skip)]` attribute ([#654])

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.3.0-pre"
+version = "1.3.0"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"


### PR DESCRIPTION
### Added
- `#[zeroize(bound = "T: MyTrait")]` ([#663])
- Custom derive for `ZeroizeOnDrop` ([#699], [#700])

[#663]: https://github.com/RustCrypto/utils/pull/663
[#699]: https://github.com/RustCrypto/utils/pull/699
[#700]: https://github.com/RustCrypto/utils/pull/700