### PR TITLE
zeroize v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.0-pre"
+version = "1.5.0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.0 (2022-01-14)
+### Added
+- `Zeroize` impls for `PhantomData`, `PhantomPinned`, and tuples with 0-10 elements ([#660])
+- `#[zeroize(bound = "T: MyTrait")]` ([#663])
+- `ZeroizeOnDrop` trait and custom derive ([#699], [#700], [#703])
+
+[#660]: https://github.com/RustCrypto/utils/pull/660
+[#663]: https://github.com/RustCrypto/utils/pull/663
+[#699]: https://github.com/RustCrypto/utils/pull/699
+[#700]: https://github.com/RustCrypto/utils/pull/700
+[#703]: https://github.com/RustCrypto/utils/pull/703
+
 ## 1.4.3 (2021-11-04)
 ### Added
 - Implement `Zeroize` for `NonZeroX`

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version = "1.5.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "1.5.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_root_url = "https://docs.rs/zeroize/1.5.0"
+)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
 //! Securely zero memory with a simple trait ([`Zeroize`]) built on stable Rust
 //! primitives which guarantee the operation will not be "optimized away".
 //!
@@ -220,15 +229,6 @@
 //! [these remarks have been removed]: https://github.com/rust-lang/rust/pull/60972
 //! [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
 //! [`Ordering::SeqCst`]: core::sync::atomic::Ordering::SeqCst
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/zeroize/1.5.0-pre"
-)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(test, macro_use)]


### PR DESCRIPTION
### Added
- `Zeroize` impls for `PhantomData`, `PhantomPinned`, and tuples with 0-10 elements ([#660])
- `#[zeroize(bound = "T: MyTrait")]` ([#663])
- `ZeroizeOnDrop` trait and custom derive ([#699], [#700], [#703])

[#660]: https://github.com/RustCrypto/utils/pull/660
[#663]: https://github.com/RustCrypto/utils/pull/663
[#699]: https://github.com/RustCrypto/utils/pull/699
[#700]: https://github.com/RustCrypto/utils/pull/700
[#703]: https://github.com/RustCrypto/utils/pull/703