### PR TITLE
zeroize_derive v1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.3.0 (2021-01-14)
+## 1.3.1 (2021-01-14)
+### Removed
+- `ZeroizeOnDrop` implementation for `#[zeroize(drop)]` ([#715])
+
+[#715]: https://github.com/RustCrypto/utils/pull/715
+
+## 1.3.0 (2021-01-14) [YANKED]
 ### Added
 - `#[zeroize(bound = "T: MyTrait")]` ([#663])
 - Custom derive for `ZeroizeOnDrop` ([#699], [#700])

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"


### PR DESCRIPTION
### Removed
- `ZeroizeOnDrop` implementation for `#[zeroize(drop)]` ([#715])

[#715]: https://github.com/RustCrypto/utils/pull/715