### PR TITLE
Fix double `mut` on `AssertZeroizeOnDrop`

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -268,11 +268,11 @@ pub mod __internal {
 
     /// Auto-deref workaround for deriving `ZeroizeOnDrop`.
     pub trait AssertZeroizeOnDrop {
-        fn zeroize_or_on_drop(&mut self);
+        fn zeroize_or_on_drop(self);
     }
 
     impl<T: ZeroizeOnDrop> AssertZeroizeOnDrop for &mut T {
-        fn zeroize_or_on_drop(&mut self) {}
+        fn zeroize_or_on_drop(self) {}
     }
 
     /// Auto-deref workaround for deriving `ZeroizeOnDrop`.

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -240,4 +240,19 @@ mod custom_derive_tests {
 
         assert_eq!(value.0, 0);
     }
+
+    #[test]
+    fn derive_only_zeroize_on_drop() {
+        #[derive(ZeroizeOnDrop)]
+        struct X([u8; 3]);
+
+        #[derive(ZeroizeOnDrop)]
+        struct Z(X);
+
+        let mut value = Z(X([1, 2, 3]));
+        unsafe {
+            std::ptr::drop_in_place(&mut value);
+        }
+        assert_eq!(&value.0 .0, &[0, 0, 0])
+    }
 }


### PR DESCRIPTION
I found that this doesn't work. I hope this is not considered a breaking change?