### PR TITLE
zeroize v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "zeroize_derive",
 ]

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.5.0 (2022-01-14)
+## 1.5.1 (2022-01-27)
+### Fixed
+- Double `mut` on `AssertZeroizeOnDrop` ([#719])
+
+[#719]: https://github.com/RustCrypto/utils/pull/719
+
+## 1.5.0 (2022-01-14) [YANKED]
 ### Added
 - `Zeroize` impls for `PhantomData`, `PhantomPinned`, and tuples with 0-10 elements ([#660])
 - `#[zeroize(bound = "T: MyTrait")]` ([#663])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version = "1.5.0" # Also update html_root_url in lib.rs when bumping this
+version = "1.5.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/zeroize/1.5.0"
+    html_root_url = "https://docs.rs/zeroize/1.5.1"
 )]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Fixed
- Double `mut` on `AssertZeroizeOnDrop` ([#719])

[#719]: https://github.com/RustCrypto/utils/pull/719