### PR TITLE
Fix ambiguous method for `AssertZeroizeOnDrop`

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -271,7 +271,7 @@ pub mod __internal {
         fn zeroize_or_on_drop(self);
     }
 
-    impl<T: ZeroizeOnDrop> AssertZeroizeOnDrop for &mut T {
+    impl<T: ZeroizeOnDrop> AssertZeroizeOnDrop for &&mut T {
         fn zeroize_or_on_drop(self) {}
     }
 

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -242,11 +242,41 @@ mod custom_derive_tests {
     }
 
     #[test]
-    fn derive_only_zeroize_on_drop() {
+    fn derive_inherit_zeroize_on_drop() {
         #[derive(ZeroizeOnDrop)]
         struct X([u8; 3]);
 
         #[derive(ZeroizeOnDrop)]
+        struct Z(X);
+
+        let mut value = Z(X([1, 2, 3]));
+        unsafe {
+            std::ptr::drop_in_place(&mut value);
+        }
+        assert_eq!(&value.0 .0, &[0, 0, 0])
+    }
+
+    #[test]
+    fn derive_inherit_from_both() {
+        #[derive(Zeroize, ZeroizeOnDrop)]
+        struct X([u8; 3]);
+
+        #[derive(ZeroizeOnDrop)]
+        struct Z(X);
+
+        let mut value = Z(X([1, 2, 3]));
+        unsafe {
+            std::ptr::drop_in_place(&mut value);
+        }
+        assert_eq!(&value.0 .0, &[0, 0, 0])
+    }
+
+    #[test]
+    fn derive_inherit_both() {
+        #[derive(Zeroize, ZeroizeOnDrop)]
+        struct X([u8; 3]);
+
+        #[derive(Zeroize, ZeroizeOnDrop)]
         struct Z(X);
 
         let mut value = Z(X([1, 2, 3]));


### PR DESCRIPTION
I added another level of indirection to fix #724 and a couple of tests to make sure.

I believe the edge-cases arisen so far are because autoref-specialization is usually not applied on methods needing `&mut self`, so I was lacking a bit of experience here.

I hope we covered all edge-cases now.