### PR TITLE
DropTests - alternative tests on zeroize_derive using drop directly

### DIFF
--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -287,7 +287,7 @@ mod custom_derive_tests {
     }
 
     #[test]
-    fn check_actual_memory_vec() {
+    fn check_actual_memory_array() {
         #[derive(Zeroize, ZeroizeOnDrop)]
         struct X([u8; 3]);
 


### PR DESCRIPTION
Hello, I am trying to confirm the below tests are valid. I was surprised that when running `cargo test --all-features` (to turn on the `zeroize_derive` feature tests) and run these that `check_actual_memory_vec` fails but `check_actual_memory_string` succeeds.

```
running 15 tests
test custom_derive_tests::check_actual_memory_string ... ok
test custom_derive_tests::derive_bound ... ok
test custom_derive_tests::derive_enum_drop ... ok
test custom_derive_tests::check_actual_memory_vec ... FAILED
test custom_derive_tests::derive_enum_only_drop ... ok
test custom_derive_tests::derive_enum_skip ... ok
test custom_derive_tests::derive_enum_test ... ok
test custom_derive_tests::derive_inherit_both ... ok
test custom_derive_tests::derive_inherit_from_both ... ok
test custom_derive_tests::derive_inherit_zeroize_on_drop ... ok
test custom_derive_tests::derive_struct_drop ... ok
test custom_derive_tests::derive_struct_only_drop ... ok
test custom_derive_tests::derive_struct_skip ... ok
test custom_derive_tests::derive_struct_test ... ok
test custom_derive_tests::derive_tuple_struct_test ... ok

failures:

---- custom_derive_tests::check_actual_memory_vec stdout ----
thread 'custom_derive_tests::check_actual_memory_vec' panicked at 'assertion failed: `(left == right)`
  left: `[1, 2, 3]`,
 right: `[0, 0, 0]`', zeroize/tests/zeroize_derive.rs:308:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    custom_derive_tests::check_actual_memory_vec

test result: FAILED. 14 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass '--test zeroize_derive'
```

Perhaps I am misunderstanding how `zeroize` should work on `drop` in this situation? My understanding is that`slice` gives me a view of the memory and will reflect underlying changes to it, so if I call `drop(value)` I should expect the `slice` view to show zero'd out memory.