### PR TITLE
Use as_mut_ptr to get a pointer for mutation

### DIFF
--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -317,8 +317,9 @@ where
 fn to_blocks_mut<N: ArrayLength<u8>>(data: &mut [u8]) -> (&mut [Block<N>], &mut [u8]) {
     let nb = data.len() / N::USIZE;
     let (left, right) = data.split_at_mut(nb * N::USIZE);
-    let p = left.as_ptr() as *mut Block<N>;
-    // SAFETY: we guarantee that `blocks` does not point outside of `data`
+    let p = left.as_mut_ptr() as *mut Block<N>;
+    // SAFETY: we guarantee that `blocks` does not point outside of `data`, and `p` is valid for
+    // mutation
     let blocks = unsafe { slice::from_raw_parts_mut(p, nb) };
     (blocks, right)
 }


### PR DESCRIPTION
The [documentation for `slice::as_mut_ptr`](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.as_ptr) says:

> The caller must also ensure that the memory the pointer (non-transitively) points to is never written to (except inside an UnsafeCell) using this pointer or any pointer derived from it. If you need to mutate the contents of the slice, use as_mut_ptr.

This PR _technically_ fixes UB per the documentation. The existing code also produces an error under Miri with `-Zmiri-tag-raw-pointers`:
```
test test_eager_set_data ... error: Undefined Behavior: trying to reborrow for Unique at alloc81264, but parent tag <215117> does not have an appropriate item in the borrow stack
   --> /home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/raw.rs:130:14
    |
130 |     unsafe { &mut *ptr::slice_from_raw_parts_mut(data, len) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trying to reborrow for Unique at alloc81264, but parent tag <215117> does not have an appropriate item in the borrow stack
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
```

I'm not opposed to adding a Miri check in CI, if you think it's merited. Some/all of `cpufeatures` just needs to be omitted, and I'm not quite sure where to put it in the existing CI configuration.