### PR TITLE
block-buffer: eliminate unreachable panic in LazyBuffer::digest_blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "generic-array",
 ]

--- a/block-buffer/CHANGELOG.md
+++ b/block-buffer/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.2 (2021-02-08)
+### Fixed
+- Eliminate unreachable panic in `LazyBuffer::digest_blocks` ([#731])
+
+[#731]: https://github.com/RustCrypto/utils/pull/731
+
 ## 0.10.1 (2021-02-05)
 ### Fixed
 - Use `as_mut_ptr` to get a pointer for mutation in the `set_data` method ([#728])

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.2" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Buffer type for block processing of data"

--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/block-buffer/0.10.1"
+    html_root_url = "https://docs.rs/block-buffer/0.10.2"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/block-buffer/src/sealed.rs
+++ b/block-buffer/src/sealed.rs
@@ -43,13 +43,15 @@ impl Sealed for super::Lazy {
 
     #[inline(always)]
     fn split_blocks<N: ArrayLength<u8>>(data: &[u8]) -> (&[Block<N>], &[u8]) {
-        let nb = if data.is_empty() || data.len() % N::USIZE != 0 {
-            data.len() / N::USIZE
+        let (nb, tail_len) = if data.is_empty() {
+            (0, 0)
+        } else if data.len() % N::USIZE == 0 {
+            (data.len() / N::USIZE - 1, N::USIZE)
         } else {
-            data.len() / N::USIZE - 1
+            let nb = data.len() / N::USIZE;
+            (nb, data.len() - nb * N::USIZE)
         };
         let blocks_len = nb * N::USIZE;
-        let tail_len = data.len() - blocks_len;
         // SAFETY: we guarantee that created slices do not point
         // outside of `data`
         unsafe {

--- a/block-buffer/src/sealed.rs
+++ b/block-buffer/src/sealed.rs
@@ -43,9 +43,10 @@ impl Sealed for super::Lazy {
 
     #[inline(always)]
     fn split_blocks<N: ArrayLength<u8>>(data: &[u8]) -> (&[Block<N>], &[u8]) {
-        let (nb, tail_len) = if data.is_empty() {
-            (0, 0)
-        } else if data.len() % N::USIZE == 0 {
+        if data.is_empty() {
+            return (&[], &[]);
+        }
+        let (nb, tail_len) = if data.len() % N::USIZE == 0 {
             (data.len() / N::USIZE - 1, N::USIZE)
         } else {
             let nb = data.len() / N::USIZE;


### PR DESCRIPTION
With the previous code the compiler was unable to infer that `tail_len` is always smaller or equal to block size.