### PR TITLE
Fixed deriving `ZeroizeOnDrop` on `DerefMut`

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -271,7 +271,7 @@ pub mod __internal {
         fn zeroize_or_on_drop(self);
     }
 
-    impl<T: ZeroizeOnDrop> AssertZeroizeOnDrop for &&mut T {
+    impl<T: ZeroizeOnDrop + ?Sized> AssertZeroizeOnDrop for &&mut T {
         fn zeroize_or_on_drop(self) {}
     }
 
@@ -280,7 +280,7 @@ pub mod __internal {
         fn zeroize_or_on_drop(&mut self);
     }
 
-    impl<T: Zeroize> AssertZeroize for T {
+    impl<T: Zeroize + ?Sized> AssertZeroize for T {
         fn zeroize_or_on_drop(&mut self) {
             self.zeroize()
         }

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -287,3 +287,31 @@ fn derive_inherit_both() {
     }
     assert_eq!(&value.0 .0, &[0, 0, 0])
 }
+
+#[test]
+fn derive_deref() {
+    struct X([u8; 3]);
+
+    impl std::ops::Deref for X {
+        type Target = [u8];
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl std::ops::DerefMut for X {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    #[derive(Zeroize, ZeroizeOnDrop)]
+    struct Z(X);
+
+    let mut value = Z(X([1, 2, 3]));
+    unsafe {
+        std::ptr::drop_in_place(&mut value);
+    }
+    assert_eq!(&value.0 .0, &[0, 0, 0])
+}


### PR DESCRIPTION
Took some help to figure this one out. Specifically this allows deriving `ZeroizeOnDrop` for items containing `GenericArray`.