### PR TITLE
Initial `cmov` crate

### DIFF
--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -22,6 +22,28 @@ jobs:
     with:
       working-directory: ${{ github.workflow }}
 
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.59.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo build --release --target ${{ matrix.target }}
+
   test:
     strategy:
       matrix:
@@ -42,6 +64,11 @@ jobs:
             platform: windows-latest
             rust: 1.59.0 # MSRV
 
+          # 64-bit macOS
+          - target: x86_64-apple-darwin
+            platform: macos-latest
+            rust: 1.59.0 # MSRV
+
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -54,3 +81,33 @@ jobs:
           override: true
       - run: ${{ matrix.deps }}
       - run: cargo test --release
+
+  # Cross-compiled tests
+  cross:
+    strategy:
+      matrix:
+        include:
+          # ARM64
+          - target: aarch64-unknown-linux-gnu
+            rust: 1.59.0 # MSRV
+          - target: aarch64-unknown-linux-gnu
+            rust: stable
+
+          # PPC32
+          - target: powerpc-unknown-linux-gnu
+            rust: 1.59.0 # MSRV
+          - target: powerpc-unknown-linux-gnu
+            rust: stable
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+      - uses: RustCrypto/actions/cross-install@master
+      - run: cross test --release --target ${{ matrix.target }}

--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -1,0 +1,56 @@
+name: cmov
+
+on:
+  pull_request:
+    paths:
+      - "cmov/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: cmov
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      working-directory: ${{ github.workflow }}
+
+  test:
+    strategy:
+      matrix:
+        include:
+          # 32-bit Linux
+          - target: i686-unknown-linux-gnu
+            platform: ubuntu-latest
+            rust: 1.59.0 # MSRV
+            deps: sudo apt update && sudo apt install gcc-multilib
+
+          # 64-bit Linux
+          - target: x86_64-unknown-linux-gnu
+            platform: ubuntu-latest
+            rust: 1.59.0 # MSRV
+
+          # 64-bit Windows
+          - target: x86_64-pc-windows-msvc
+            platform: windows-latest
+            rust: 1.59.0 # MSRV
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+      - run: ${{ matrix.deps }}
+      - run: cargo test --release

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0 # Highest MSRV in repo
+          toolchain: 1.59.0 # Highest MSRV in repo
           components: clippy
           override: true
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.0.0"
+
+[[package]]
 name = "collectable"
 version = "0.0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "blobby",
     "block-buffer",
     "collectable",
+    "cmov",
     "cpufeatures",
     "dbl",
     "hex-literal",

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cmov"
+description = """
+Conditional move CPU intrinsics which are guaranteed to execute in
+constant-time and not be rewritten as branches by the compiler.
+Provides wrappers for the CMOV family of instructions on x86/x86_64 CPUs.
+"""
+version = "0.0.0"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/utils/tree/master/cmov"
+categories = ["cryptography"]
+keywords = ["crypto", "intrinsics"]
+readme = "README.md"
+edition = "2018" # Can't bump to 2021 due to pre-1.56 MSRV crates in the same workspace
+rust-version = "1.59"

--- a/cmov/LICENSE-APACHE
+++ b/cmov/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cmov/LICENSE-MIT
+++ b/cmov/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmov/README.md
+++ b/cmov/README.md
@@ -1,0 +1,91 @@
+# [RustCrypto]: Conditional Move Intrinsics
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache 2.0/MIT Licensed][license-image]
+![MSRV][rustc-image]
+[![Build Status][build-image]][build-link]
+
+Conditional move CPU intrinsics which are guaranteed to execute in
+constant-time and not be rewritten as branches by the compiler.
+
+Provides wrappers for the [CMOV family] of instructions on x86/x86_64 CPUs.
+
+[Documentation][docs-link]
+
+## About
+
+Conditional move intrinsics are a form of [predication] which allows selection
+of one or more values without using branch instructions, thus making the
+selection constant-time with respect to the values, and not subject to CPU
+execution features which might introduce timing or other microarchitectural
+sidechannels introduced by branch prediction or other speculative execution
+features.
+
+Intel has confirmed that all extant CPUs implement the CMOV family of
+instructions in constant-time, and that this property will hold for future
+Intel CPUs as well.
+
+This crate provides wrappers for the CMOV instructions implemented in terms
+of inline assembly as stabilized in Rust 1.59. This means the implementation
+is a black box that will not be rewritten by e.g. LLVM's architecture-specific
+lowerings, such as the [x86-cmov-conversion] pass.
+
+## Supported target architectures
+
+This crate will only compile on the following target architectures:
+
+- [x] `x86`
+- [x] `x86_64`
+- [ ] `aarch64`
+- [ ] Others?
+
+Use the following syntax in `Cargo.toml` to conditionally include it:
+
+```toml
+[target.'cfg(any(target_arch = "x86", target_arch = "x86"))'.dependencies]
+cmov = "0"
+```
+
+Please open an issue inquiring about support for other architectures.
+
+## Minimum Supported Rust Version
+
+Rust **1.59** or newer.
+
+In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
+for this crate's SemVer guarantees), however when we do it will be accompanied by
+a minor version bump.
+
+## License
+
+Licensed under either of:
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/cmov.svg
+[crate-link]: https://crates.io/crates/cmov
+[docs-image]: https://docs.rs/cmov/badge.svg
+[docs-link]: https://docs.rs/cmov/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[build-image]: https://github.com/RustCrypto/utils/actions/workflows/cmov.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/utils/actions/workflows/cmov.yml
+
+[//]: # (general links)
+
+[RustCrypto]: https://github.com/RustCrypto
+[CMOV family]: https://www.jaist.ac.jp/iscenter-new/mpc/altix/altixdata/opt/intel/vtune/doc/users_guide/mergedProjects/analyzer_ec/mergedProjects/reference_olh/mergedProjects/instructions/instruct32_hh/vc35.htm
+[predication]: https://en.wikipedia.org/wiki/Predication_(computer_architecture)
+[x86-cmov-conversion]: https://dsprenkels.com/cmov-conversion.html

--- a/cmov/README.md
+++ b/cmov/README.md
@@ -33,21 +33,19 @@ lowerings, such as the [x86-cmov-conversion] pass.
 
 ## Supported target architectures
 
-This crate will only compile on the following target architectures:
+This crate provides guaranteed constant-time operation using inline assembly
+on the following CPU architectures:
 
 - [x] `x86`
 - [x] `x86_64`
-- [ ] `aarch64`
-- [ ] Others?
 
-Use the following syntax in `Cargo.toml` to conditionally include it:
+On other target architectures, a "best effort" portable fallback implementation
+based on bitwise arithmetic is used instead. However, we cannot guarantee that
+this implementation generates branch-free code.
 
-```toml
-[target.'cfg(any(target_arch = "x86", target_arch = "x86"))'.dependencies]
-cmov = "0"
-```
-
-Please open an issue inquiring about support for other architectures.
+It may be possible to extend constant-time guarantees to other CPU
+architectures by taking advantage of things like [LL/SC] instructions.
+Please open an issue with your desired CPU architecture if this interests you.
 
 ## Minimum Supported Rust Version
 
@@ -89,3 +87,4 @@ dual licensed as above, without any additional terms or conditions.
 [CMOV family]: https://www.jaist.ac.jp/iscenter-new/mpc/altix/altixdata/opt/intel/vtune/doc/users_guide/mergedProjects/analyzer_ec/mergedProjects/reference_olh/mergedProjects/instructions/instruct32_hh/vc35.htm
 [predication]: https://en.wikipedia.org/wiki/Predication_(computer_architecture)
 [x86-cmov-conversion]: https://dsprenkels.com/cmov-conversion.html
+[LL/SC]: https://en.wikipedia.org/wiki/Load-link/store-conditional

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -55,10 +55,8 @@ pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(never)]
 pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
-    let zero_flag = 1 ^ is_non_zero(condition);
-    let src_mask = zero_flag.wrapping_mul(usize::MAX);
-    let dst_mask = zero_flag.wrapping_sub(1);
-    *dst = (*dst & dst_mask) | (src & src_mask);
+    let mask = (1 ^ is_non_zero(condition)).wrapping_sub(1);
+    *dst = (*dst & mask) | (src & !mask);
 }
 
 /// Move if not zero (portable fallback implementation).
@@ -69,10 +67,8 @@ pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(never)]
 pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
-    let nonzero_flag = is_non_zero(condition);
-    let src_mask = nonzero_flag.wrapping_mul(usize::MAX);
-    let dst_mask = nonzero_flag.wrapping_sub(1);
-    *dst = (*dst & dst_mask) | (src & src_mask);
+    let mask = is_non_zero(condition).wrapping_sub(1);
+    *dst = (*dst & mask) | (src & !mask);
 }
 
 /// Check if the given condition value is non-zero

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -1,0 +1,71 @@
+#![no_std]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+compile_error!("the `cmov` crate can only be compiled on x86 and x86_64 target architectures");
+
+use core::arch::asm;
+
+/// Move if zero.
+///
+/// Uses a `test` instruction to check if the given `condition` value is
+/// equal to zero, then calls `cmovz` (a.k.a. `cmove`) to conditionally move
+/// `src` to `dst` when `condition` is equal to zero.
+#[inline(always)]
+pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
+    unsafe {
+        asm! {
+        "test {0}, {0}",
+        "cmovz {1}, {2}",
+        in(reg) condition,
+        inlateout(reg) *dst,
+        in(reg) src
+        };
+    }
+}
+
+/// Move if not zero.
+///
+/// Uses a `test` instruction to check if the given `condition` value is not
+/// equal to zero, then calls `cmovnz` (a.k.a. `cmovne`) to conditionally move
+/// `src` to `dst` when `condition` is nonzero.
+#[inline(always)]
+pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
+    unsafe {
+        asm! {
+        "test {0}, {0}",
+        "cmovnz {1}, {2}",
+        in(reg) condition,
+        inlateout(reg) *dst,
+        in(reg) src
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmovz_works() {
+        let mut n = 24;
+        cmovz(42, 42, &mut n);
+        assert_eq!(n, 24);
+        cmovz(0, 42, &mut n);
+        assert_eq!(n, 42);
+    }
+
+    #[test]
+    fn cmovnz_works() {
+        let mut n = 24;
+        cmovnz(0, 42, &mut n);
+        assert_eq!(n, 24);
+        cmovnz(42, 42, &mut n);
+        assert_eq!(n, 42);
+    }
+}

--- a/dbl/src/lib.rs
+++ b/dbl/src/lib.rs
@@ -29,12 +29,14 @@ pub trait Dbl {
     /// `block<<1`, otherwise `(block<<1)^C`, where `C` is the non-leading
     /// coefficients of the lexicographically first irreducible degree-b binary
     /// polynomial with the minimal number of ones.
+    #[must_use]
     fn dbl(self) -> Self;
 
     /// Reverse double block. (alternatively: divbide block by x)
     ///
     /// If least significant bit of the block equals to zero will return
     /// `block>>1`, otherwise `(block>>1)^(1<<n)^(C>>1)`
+    #[must_use]
     fn inv_dbl(self) -> Self;
 }
 

--- a/wycheproof2blb/src/aes_siv.rs
+++ b/wycheproof2blb/src/aes_siv.rs
@@ -13,6 +13,7 @@ struct TestSuite {
 
 #[derive(Debug, Deserialize)]
 struct TestGroup {
+    #[allow(dead_code)]
     #[serde(flatten)]
     pub group: wycheproof::Group,
     #[serde(rename = "keySize")]

--- a/wycheproof2blb/src/ecdsa.rs
+++ b/wycheproof2blb/src/ecdsa.rs
@@ -13,10 +13,13 @@ struct TestSuite {
 
 #[derive(Debug, Deserialize)]
 struct TestGroup {
+    #[allow(dead_code)]
     #[serde(flatten)]
     pub group: wycheproof::Group,
+    #[allow(dead_code)]
     #[serde(rename = "keyDer")]
     pub key_der: String,
+    #[allow(dead_code)]
     #[serde(rename = "keyPem")]
     pub key_pem: String,
     pub sha: String,
@@ -27,6 +30,7 @@ struct TestGroup {
 #[derive(Debug, Deserialize)]
 struct TestKey {
     curve: String,
+    #[allow(dead_code)]
     #[serde(rename = "type")]
     key_type: String,
     #[serde(with = "hex_string")]

--- a/wycheproof2blb/src/ed25519.rs
+++ b/wycheproof2blb/src/ed25519.rs
@@ -13,10 +13,13 @@ struct TestSuite {
 
 #[derive(Debug, Deserialize)]
 struct TestGroup {
+    #[allow(dead_code)]
     #[serde(flatten)]
     pub group: wycheproof::Group,
+    #[allow(dead_code)]
     #[serde(rename = "keyDer")]
     pub key_der: String,
+    #[allow(dead_code)]
     #[serde(rename = "keyPem")]
     pub key_pem: String,
     pub key: TestKey,

--- a/wycheproof2blb/src/hkdf.rs
+++ b/wycheproof2blb/src/hkdf.rs
@@ -13,8 +13,10 @@ struct TestSuite {
 
 #[derive(Debug, Deserialize)]
 struct TestGroup {
+    #[allow(dead_code)]
     #[serde(flatten)]
     pub group: wycheproof::Group,
+    #[allow(dead_code)]
     #[serde(rename = "keySize")]
     pub key_size: u32,
     pub tests: Vec<TestCase>,

--- a/wycheproof2blb/src/main.rs
+++ b/wycheproof2blb/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
     }
 
     let mut out_file = std::fs::File::create(out_path).unwrap();
-    let blobs: Vec<Vec<u8>> = infos.into_iter().map(|info| info.data).flatten().collect();
+    let blobs: Vec<Vec<u8>> = infos.into_iter().flat_map(|info| info.data).collect();
     let (blb_data, _) = blobby::encode_blobs(&blobs);
     out_file.write_all(&blb_data).unwrap();
 }


### PR DESCRIPTION
Implements safe wrappers for the `cmovz` and `cmovnz` instructions which work on `x86` and `x86_64`, implemented using inline assembly.

Using inline assembly allows us to provide a sort of black box which LLVM will not interfere with, which is otherwise problematic when using anything besides ASM.

It's otherwise not possible to correctly emit CMOV instructions on x86 platforms with LLVM because the `x86-cmov-conversion` pass which will potentially rewrite them as branches.

For more details, see:

https://dsprenkels.com/cmov-conversion.html