### PR TITLE
Add cmovz/cmovnz support for aarch64.

### DIFF
--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -3,7 +3,7 @@ name = "cmov"
 description = """
 Conditional move CPU intrinsics which are guaranteed to execute in
 constant-time and not be rewritten as branches by the compiler.
-Provides wrappers for the CMOV family of instructions on x86/x86_64 CPUs.
+Provides wrappers for the CMOV family of instructions on x86/x86_64/aarch64 CPUs.
 """
 version = "0.1.0"
 authors = ["RustCrypto Developers"]

--- a/cmov/README.md
+++ b/cmov/README.md
@@ -9,7 +9,7 @@
 Conditional move CPU intrinsics which are guaranteed to execute in
 constant-time and not be rewritten as branches by the compiler.
 
-Provides wrappers for the [CMOV family] of instructions on x86/x86_64 CPUs.
+Provides wrappers for the [CMOV family] of instructions on x86/x86_64 and AArch64 CPUs.
 
 [Documentation][docs-link]
 
@@ -36,8 +36,9 @@ lowerings, such as the [x86-cmov-conversion] pass.
 This crate provides guaranteed constant-time operation using inline assembly
 on the following CPU architectures:
 
-- [x] `x86`
-- [x] `x86_64`
+- [x] `x86` (`CMOVZ`, `CMOVNZ`)
+- [x] `x86_64` (`CMOVZ`, CMOVNZ`)
+- [x] `aarch64` (`CSEL`)
 
 On other target architectures, a "best effort" portable fallback implementation
 based on bitwise arithmetic is used instead. However, we cannot guarantee that


### PR DESCRIPTION
This passes tests and I _believe_ it works, but I also have the assembly programming experience of your average kindergartner, so a second opinion would be worth getting.

Running `cargo rustc --release -- --emit asm` on the portable `cmovz` yields this:

```
        neg     w8, w0
        orr     w8, w8, w0
        ubfx    x8, x8, #7, #1
        ldr     x9, [x2]
        neg     x10, x8
        and     x9, x9, x10
        sub     x8, x8, #1
        and     x8, x8, x1
        orr     x8, x9, x8
        str     x8, [x2]
        ret
```

And a naive, branching version of `cmovz` yields this:

```
        cbz     x0, LBB1_2
        ret
LBB1_2:
        str     x1, [x2]
        ret
```

Which makes me think `cmp`/`csel` is the right choice.