### PR TITLE
cmov v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "collectable"

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2022-03-02)
+### Added
+- `cmovz`/`cmovnz`-alike support for AArch64 targets ([#744])
+
+[#744]: https://github.com/RustCrypto/utils/pull/744
+
 ## 0.1.0 (2022-02-27)
 - Initial release

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -3,9 +3,10 @@ name = "cmov"
 description = """
 Conditional move CPU intrinsics which are guaranteed to execute in
 constant-time and not be rewritten as branches by the compiler.
-Provides wrappers for the CMOV family of instructions on x86/x86_64/aarch64 CPUs.
+Provides wrappers for the CMOV family of instructions on x86/x86_64
+and CSEL on AArch64.
 """
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/cmov"

--- a/cmov/README.md
+++ b/cmov/README.md
@@ -2,20 +2,21 @@
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache 2.0/MIT Licensed][license-image]
 ![MSRV][msrv-image]
-[![Build Status][build-image]][build-link]
 
 Conditional move CPU intrinsics which are guaranteed to execute in
 constant-time and not be rewritten as branches by the compiler.
 
-Provides wrappers for the [CMOV family] of instructions on x86/x86_64 and AArch64 CPUs.
+Provides wrappers for the [CMOV family] of instructions on x86/x86_64 and
+the [CSEL] instruction on AArch64 CPUs.
 
 [Documentation][docs-link]
 
 ## About
 
-Conditional move intrinsics are a form of [predication] which allows selection
+Conditional move intrinsics provide [predication] which allows selection
 of one or more values without using branch instructions, thus making the
 selection constant-time with respect to the values, and not subject to CPU
 execution features which might introduce timing or other microarchitectural
@@ -26,8 +27,8 @@ Intel has confirmed that all extant CPUs implement the CMOV family of
 instructions in constant-time, and that this property will hold for future
 Intel CPUs as well.
 
-This crate provides wrappers for the CMOV instructions implemented in terms
-of inline assembly as stabilized in Rust 1.59. This means the implementation
+This crate provides wrappers for the CMOV/CSEL instructions implemented using
+inline assembly as stabilized in Rust 1.59. This means the implementation
 is a black box that will not be rewritten by e.g. LLVM's architecture-specific
 lowerings, such as the [x86-cmov-conversion] pass.
 
@@ -37,15 +38,14 @@ This crate provides guaranteed constant-time operation using inline assembly
 on the following CPU architectures:
 
 - [x] `x86` (`CMOVZ`, `CMOVNZ`)
-- [x] `x86_64` (`CMOVZ`, CMOVNZ`)
+- [x] `x86_64` (`CMOVZ`, `CMOVNZ`)
 - [x] `aarch64` (`CSEL`)
 
 On other target architectures, a "best effort" portable fallback implementation
 based on bitwise arithmetic is used instead. However, we cannot guarantee that
 this implementation generates branch-free code.
 
-It may be possible to extend constant-time guarantees to other CPU
-architectures by taking advantage of things like [LL/SC] instructions.
+It's possible to extend constant-time guarantees to other CPU  architectures.
 Please open an issue with your desired CPU architecture if this interests you.
 
 ## Minimum Supported Rust Version
@@ -86,6 +86,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/RustCrypto
 [CMOV family]: https://www.jaist.ac.jp/iscenter-new/mpc/altix/altixdata/opt/intel/vtune/doc/users_guide/mergedProjects/analyzer_ec/mergedProjects/reference_olh/mergedProjects/instructions/instruct32_hh/vc35.htm
+[CSEL]: https://developer.arm.com/documentation/dui0802/b/CSEL
 [predication]: https://en.wikipedia.org/wiki/Predication_(computer_architecture)
 [x86-cmov-conversion]: https://dsprenkels.com/cmov-conversion.html
-[LL/SC]: https://en.wikipedia.org/wiki/Load-link/store-conditional


### PR DESCRIPTION
### Added
- `cmovz`/`cmovnz`-alike support for AArch64 targets ([#744])

[#744]: https://github.com/RustCrypto/utils/pull/744