### PR TITLE
cmov: Set asm options

### DIFF
--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -23,7 +23,8 @@ pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
             "cmovz {1}, {2}",
             in(reg) condition,
             inlateout(reg) *dst,
-            in(reg) src
+            in(reg) src,
+            options(pure, nomem, nostack),
         };
     }
 }
@@ -44,6 +45,7 @@ pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
             inlateout(reg) *dst,
             in(reg) src,
             in(reg) *dst,
+            options(pure, nomem, nostack),
         };
     }
 }
@@ -64,6 +66,7 @@ pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
             inlateout(reg) *dst,
             in(reg) src,
             in(reg) *dst,
+            options(pure, nomem, nostack),
         };
     }
 }
@@ -82,7 +85,8 @@ pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
             "cmovnz {1}, {2}",
             in(reg) condition,
             inlateout(reg) *dst,
-            in(reg) src
+            in(reg) src,
+            options(pure, nomem, nostack),
         };
     }
 }


### PR DESCRIPTION
Those options tell the compiler that ASM statements do not read or write memory, can be removed if the dst ends up unused during compilation, and that they don't push data to the stack.

This can help compiler generate more optimal code. See https://doc.rust-lang.org/nightly/reference/inline-assembly.html#options for documentation of those options.