### PR TITLE
block-padding: add sanity assert

### DIFF
--- a/block-padding/CHANGELOG.md
+++ b/block-padding/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.1 (2022-02-10)
+## 0.3.2 (2022-03-10)
+### Fixed
+- Potential unsoundness for incorrect `Padding` implementations ([#748])
+
+[#748]: https://github.com/RustCrypto/utils/pull/748
+
+## 0.3.1 (2022-02-10) [YANKED]
 ### Fixed
 - Fix doc build on docs.rs by optionally enabling the `doc_cfg` feature ([#733])
 
 [#733]: https://github.com/RustCrypto/utils/pull/733
 
-## 0.3.0 (2022-02-10)
+## 0.3.0 (2022-02-10) [YANKED]
 ### Added
 - `Iso10126` padding algorithm ([#643])
 - `PadType` enum, `Padding::TYPE` associated constant, and `Padding::unpad_blocks` method ([#675])

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
 description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/block-padding/src/lib.rs
+++ b/block-padding/src/lib.rs
@@ -7,7 +7,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/block-padding/0.3.1"
+    html_root_url = "https://docs.rs/block-padding/0.3.2"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms)]
@@ -60,6 +60,7 @@ pub trait Padding<BlockSize: ArrayLength<u8>> {
             (_, PadType::NoPadding) => bs * blocks.len(),
             (Some(last_block), _) => {
                 let n = Self::unpad(last_block)?.len();
+                assert!(n <= bs);
                 n + bs * (blocks.len() - 1)
             }
             (None, PadType::Ambiguous) => 0,


### PR DESCRIPTION
This PR adds assert which prevents potential unsoundness in cases when the `Padding` trait is implemented incorrectly. For correct implementations compiler should be able to remove the panic branch.