### PR TITLE
zeroize v1.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "zeroize_derive",
 ]

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.4 (2022-03-16)
+### Added
+- Nightly-only upport for zeroizing ARM64 SIMD registers ([#749])
+
+[#749]: https://github.com/RustCrypto/utils/pull/749
+
 ## 1.5.3 (2022-02-25)
 ### Fixed
 - Deriving `ZeroizeOnDrop` on `DerefMut` ([#739])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version = "1.5.3" # Also update html_root_url in lib.rs when bumping this
+version = "1.5.4"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -2,8 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/zeroize/1.5.3"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- Nightly-only upport for zeroizing ARM64 SIMD registers ([#749])

[#749]: https://github.com/RustCrypto/utils/pull/749