### PR TITLE
cpufeatures v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ version = "0.0.2"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2022-03-18)
+### Added
+- Support for Android on `aarch64` ([#752])
+
+### Removed
+- Vestigial code around `crypto` target feature ([#600])
+
+[#600]: https://github.com/RustCrypto/utils/pull/600
+[#752]: https://github.com/RustCrypto/utils/pull/752
+
 ## 0.2.1 (2021-08-26)
 ### Changed
 - Revert [#583] "Use from_bytes_with_nul for string check" ([#597])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "cpufeatures"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
 description = """
-Lightweight and efficient no-std compatible alternative to the
-is_x86_feature_detected! macro
+Lightweight runtime CPU feature detection for x86/x86_64 and aarch64 with
+no_std support and support for mobile targets including Android and iOS
 """
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cpufeatures/README.md
+++ b/cpufeatures/README.md
@@ -7,17 +7,21 @@
 [![Project Chat][chat-image]][chat-link]
 [![Build Status][build-image]][build-link]
 
-Lightweight and efficient `no_std` compatible alternative to the
-`is_x86_feature_detected!` macro providing runtime CPU feature detection
-for x86/x86_64 and ARM64 CPUs.
+Lightweight and efficient runtime CPU feature detection for `aarch64` and
+`x86`/`x86_64` targets.
+
+Supports `no_std` as well as mobile targets including iOS and Android,
+providing an alternative to the `std`-dependent `is_x86_feature_detected!`
+macro.
 
 [Documentation][docs-link]
 
 ## Supported architectures
 
-### `aarch64`: Linux and macOS/M4 only
+### `aarch64`: Android, iOS, Linux, and macOS/M4 only
 
-Note: ARM64 does not support OS-independent feature detection 
+Note: ARM64 does not support OS-independent feature detection, so support must
+be implemented on an OS-by-OS basis.
 
 Target features:
 

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -56,8 +56,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/cpufeatures/0.2.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 
 #[cfg(all(target_arch = "aarch64"))]


### PR DESCRIPTION
### Added
- Support for Android on `aarch64` ([#752])

### Removed
- Vestigial code from removed ARMv8 `crypto` target feature ([#600])

[#600]: https://github.com/RustCrypto/utils/pull/600
[#752]: https://github.com/RustCrypto/utils/pull/752