### PR TITLE
zeroize: Implement Zeroize for CString (#650)

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -69,7 +69,7 @@ jobs:
       # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
       - run: rm ../Cargo.toml
       - run: cargo test
-      - run: cargo test --features alloc,derive
+      - run: cargo test --features alloc,derive,std
 
   # Feature-gated ARM64 SIMD register support (nightly-only)
   aarch64:

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -24,6 +24,7 @@ default = ["alloc"]
 aarch64 = []
 alloc = []
 derive = ["zeroize_derive"]
+std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
> Commit Msg:
> This implements Zeroize for std::ffi::CString. As CString is not in
allocate but in std, a new optional std feature is added to depend
on the std library.

I'm not quite sure if my implementation is correct and secure. In the issue linked in #650, it was mentioned that it likely is not possible to implement `Zeroize` for `CString`, due to the requirement that there must be no null bytes in the buffer. One of the comments stated that this problem could maybe be solved in "hacky" way:

>We could do something slightly wacky and overwrite internal bytes with `0xFF` or something, so as to obliterate the data while preserving the "no internal NUL bytes" guarantee.

_Originally posted by @cyberia-ng in https://github.com/iqlusioninc/crates/issues/509#issuecomment-766408309_

However, I think that my implementation of:
```rust
impl Zeroize for CString {
    fn zeroize(&mut self) {
        let this = std::mem::take(self);
        this.into_bytes().zeroize();
    }
}
```
should be correct and secure. `std::mem::take` replaces replaces `self` with a `CString::default`. The original CString is then converted into a `Vec<u8>` (`CString` itself contains a `Box<u8>`), and zeroize is called on that. This should not result in a reallocation as `into_bytes` uses [`into_vec`](https://doc.rust-lang.org/std/primitive.slice.html#method.into_vec) on the internal `Box<u8>` buffer.

I've also added a testcase similar to the one for `String`, but it doesn't actually test if the memory was zeroed, but only that the length of the internal buffer of the `CString` is zero after `zeroize` which is done by the `mem::take`. Any ideas on how to properly test this code?

If the code looks good, I'll also adapt the documentation to reflect the new impl and `std` feature :)
