### PR TITLE
zeroize v1.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "zeroize_derive",
 ]

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.5 (2022-04-30)
+### Added
+- Impl `Zeroize` for std::ffi::CString ([#759])
+- `AsRef<T>` and `AsMut<T>` impls for `Zeroizing` ([#761])
+
+[#759]: https://github.com/RustCrypto/utils/pull/759
+[#761]: https://github.com/RustCrypto/utils/pull/761
+
 ## 1.5.4 (2022-03-16)
 ### Added
 - Nightly-only upport for zeroizing ARM64 SIMD registers ([#749])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version = "1.5.4"
+version = "1.5.5"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"


### PR DESCRIPTION
### Added
- Impl `Zeroize` for `std::ffi::CString` ([#759])
- `AsRef<T>` and `AsMut<T>` impls for `Zeroizing` ([#761])

[#759]: https://github.com/RustCrypto/utils/pull/759
[#761]: https://github.com/RustCrypto/utils/pull/761