### PR TITLE
wycheproof2blb: secp384r1 support

### DIFF
--- a/wycheproof2blb/src/ecdsa.rs
+++ b/wycheproof2blb/src/ecdsa.rs
@@ -55,7 +55,7 @@ pub fn generator(data: &[u8], algorithm: &str, _key_size: u32) -> Vec<TestInfo> 
     let mut infos = vec![];
     for g in &suite.test_groups {
         assert_eq!(g.key.curve, algorithm);
-        assert_eq!(g.sha, "SHA-256");
+        assert!(matches!(g.sha.as_str(), "SHA-256" | "SHA-384"));
         for tc in &g.tests {
             if tc.case.result == crate::wycheproof::CaseResult::Acceptable {
                 // TODO: figure out what to do with test cases that pass but which have weak params

--- a/wycheproof2blb/src/main.rs
+++ b/wycheproof2blb/src/main.rs
@@ -121,6 +121,10 @@ fn main() {
             file: "ecdsa_secp256k1_sha256_test.json",
             generator: ecdsa::generator,
         },
+        "secp384r1" => Algorithm {
+            file: "ecdsa_secp384r1_sha384_test.json",
+            generator: ecdsa::generator,
+        },
         _ => panic!("Unrecognized algorithm '{}'", algorithm),
     };
 


### PR DESCRIPTION
Adds support for extracting secp384r1 test vectors from Wycheproof, in order to test the `p384` crate.