### PR TITLE
fiat-constify: initial crate

### DIFF
--- a/.github/workflows/fiat-constify.yml
+++ b/.github/workflows/fiat-constify.yml
@@ -1,0 +1,37 @@
+name: fiat-constify
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/fiat-constify.yml"
+      - "fiat-constify/**"
+      - "Cargo.*"
+  push:
+    branches: main
+
+defaults:
+  run:
+    working-directory: fiat-constify
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        toolchain:
+          - 1.56.0 # MSRV
+          - stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+          profile: minimal
+      - run: cargo test
+      - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-constify"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "cmov",
     "cpufeatures",
     "dbl",
+    "fiat-constify",
     "hex-literal",
     "hybrid-array",
     "inout",

--- a/fiat-constify/CHANGELOG.md
+++ b/fiat-constify/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/fiat-constify/Cargo.toml
+++ b/fiat-constify/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fiat-constify"
+version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+description = """
+Postprocessor for fiat-crypto generated field implementations which rewrites
+them as `const fn`
+"""
+authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/fiat-constify"
+repository = "https://github.com/RustCrypto/utils/tree/master/fiat-constify"
+categories = ["cryptography"]
+keywords = ["fiat-crypto", "field"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.56"
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["extra-traits", "full"] }

--- a/fiat-constify/LICENSE-APACHE
+++ b/fiat-constify/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/fiat-constify/LICENSE-MIT
+++ b/fiat-constify/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2022 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/fiat-constify/README.md
+++ b/fiat-constify/README.md
@@ -1,0 +1,59 @@
+# [RustCrypto]: `const fn` postprocessor for `fiat-crypto`
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+[![Safety Dance][safety-image]][safety-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+
+Postprocessor for [fiat-crypto] generated field implementations which rewrites
+them as `const fn`.
+
+[Documentation][docs-link]
+
+## About
+
+This crate is a workaround for [mit-plv/fiat-crypto#1086] which provides a
+mechanical postprocessing step for [fiat-crypto] generated field
+implementations.
+
+It removes `&mut` references which aren't yet stable with `const fn`, instead
+allocating and returning an array on the stack for results.
+
+## License
+
+Licensed under either of:
+
+- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://buildstats.info/crate/fiat-constify
+[crate-link]: https://crates.io/crates/fiat-constify
+[docs-image]: https://docs.rs/fiat-constify/badge.svg
+[docs-link]: https://docs.rs/fiat-constify/
+[build-image]: https://github.com/RustCrypto/utils/workflows/fiat-constify/badge.svg
+[build-link]: https://github.com/RustCrypto/utils/actions/workflows/fiat-constify.yml
+[safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
+[safety-link]: https://github.com/rust-secure-code/safety-dance/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/rustcrypto
+[fiat-crypto]: https://github.com/mit-plv/fiat-crypto/
+[mit-plv/fiat-crypto#1086]: https://github.com/mit-plv/fiat-crypto/issues/1086

--- a/fiat-constify/src/main.rs
+++ b/fiat-constify/src/main.rs
@@ -1,0 +1,426 @@
+//! Postprocessor for fiat-crypto generated field implementations which rewrites
+//! them as `const fn`.
+//!
+//! Usage: fiat-constify /path/to/field_impl.rs
+
+#![allow(clippy::single_match, clippy::new_without_default)]
+
+use proc_macro2::Span;
+use quote::{quote, ToTokens};
+use std::{collections::BTreeMap as Map, env, fs, ops::Deref};
+use syn::{
+    punctuated::Punctuated,
+    token::{Bang, Brace, Bracket, Colon, Const, Eq, Let, Mut, Paren, Pound, RArrow, Semi},
+    AttrStyle, Attribute, Block, Expr, ExprAssign, ExprCall, ExprLit, ExprPath, ExprReference,
+    ExprRepeat, ExprTuple, FnArg, Ident, Item, ItemFn, ItemType, Lit, LitInt, Local, Pat, PatIdent,
+    PatTuple, PatType, Path, PathArguments, PathSegment, ReturnType, Stmt, Type, TypeArray,
+    TypePath, TypeReference, TypeTuple, UnOp,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = env::args().collect::<Vec<_>>();
+
+    if args.len() != 2 {
+        panic!("Usage: fiat-constify /path/to/field_impl.rs")
+    }
+
+    let code = fs::read_to_string(&args[1])?;
+    let mut ast = syn::parse_file(&code)?;
+
+    // Add lint attributes
+    ast.attrs.push(build_attribute(
+        "allow",
+        &[
+            "dead_code",
+            "rustdoc::broken_intra_doc_links",
+            "unused_assignments",
+            "unused_mut",
+            "unused_variables",
+        ],
+    ));
+
+    let mut type_registry = TypeRegistry::new();
+
+    // Iterate over functions, transforming them into `const fn`
+    for item in &mut ast.items {
+        match item {
+            Item::Fn(func) => rewrite_fn_as_const(func, &type_registry),
+            Item::Type(ty) => type_registry.add(ty),
+            _ => (),
+        }
+    }
+
+    println!("#![doc = \" fiat-crypto output postprocessed by fiat-constify: https://github.com/rustcrypto/utils\"]");
+    println!("{}", ast.into_token_stream());
+    Ok(())
+}
+
+/// Build a toplevel attribute with the given name and comma-separated values.
+fn build_attribute(name: &str, values: &[&str]) -> Attribute {
+    let span = Span::call_site();
+    let values = values
+        .iter()
+        .map(|value| build_path(value))
+        .collect::<Vec<_>>();
+
+    Attribute {
+        pound_token: Pound { spans: [span] },
+        style: AttrStyle::Inner(Bang { spans: [span] }),
+        bracket_token: Bracket { span },
+        path: build_path(name),
+        tokens: quote! { (#(#values),*) },
+    }
+}
+
+/// Parse a path from a double-colon-delimited string.
+fn build_path(path: &str) -> Path {
+    let span = Span::call_site();
+    let mut segments = Punctuated::new();
+
+    for segment in path.split("::") {
+        segments.push(PathSegment {
+            ident: Ident::new(segment, span),
+            arguments: PathArguments::None,
+        });
+    }
+
+    Path {
+        leading_colon: None,
+        segments,
+    }
+}
+
+/// Get an `Ident` from a `Pat::Ident`.
+fn get_ident_from_pat(pat: &Pat) -> Ident {
+    match pat {
+        Pat::Ident(pat_ident) => pat_ident.ident.clone(),
+        other => panic!("unexpected `Pat`: {:?} (expecting `Pat::Ident`)", other),
+    }
+}
+
+/// Rewrite a fiat-crypto generated `fn` as a `const fn`, making the necessary
+/// transformations to the code in order for it to work in that context.
+fn rewrite_fn_as_const(func: &mut ItemFn, type_registry: &TypeRegistry) {
+    let span = Span::call_site();
+
+    // Mark function as being `const fn`.
+    func.sig.constness = Some(Const { span });
+
+    // Transform mutable arguments into return values.
+    let mut inputs = Punctuated::new();
+    let mut outputs = Outputs::new();
+
+    for arg in &func.sig.inputs {
+        // Transform mutable function arguments into return values
+        if let FnArg::Typed(t) = arg {
+            match &*t.ty {
+                Type::Reference(TypeReference {
+                    mutability: Some(_), // look for mutable references
+                    elem,
+                    ..
+                }) => {
+                    outputs.add(get_ident_from_pat(&t.pat), elem.deref().clone());
+                    continue;
+                }
+                _ => (),
+            }
+        }
+
+        // If the argument wasn't a mutable reference, add it as an input.
+        inputs.push(arg.clone());
+    }
+
+    // Replace inputs with ones where the mutable references have been filtered out
+    func.sig.inputs = inputs;
+    func.sig.output = outputs.to_return_type();
+    func.block = Box::new(rewrite_fn_body(&func.block.stmts, &outputs, type_registry));
+}
+
+/// Rewrite the function body, adding let bindings with `Default::default()`
+/// values for outputs, removing mutable references, and adding a return
+/// value/tuple.
+fn rewrite_fn_body(statements: &[Stmt], outputs: &Outputs, registry: &TypeRegistry) -> Block {
+    let span = Span::call_site();
+    let mut stmts = Vec::new();
+
+    stmts.extend(outputs.to_let_bindings(registry).into_iter());
+
+    for stmt in statements {
+        let mut stmt = stmt.clone();
+        rewrite_fn_stmt(&mut stmt);
+        stmts.push(stmt.clone());
+    }
+
+    stmts.push(outputs.to_return_value());
+
+    Block {
+        brace_token: Brace { span },
+        stmts,
+    }
+}
+
+/// Rewrite an expression in the function body, transforming mutable reference
+/// operations into value assignments.
+fn rewrite_fn_stmt(stmt: &mut Stmt) {
+    match stmt {
+        Stmt::Semi(expr, _) => match expr {
+            Expr::Assign(ExprAssign { left, .. }) => match *left.clone() {
+                Expr::Unary(unary) => {
+                    // Remove deref since we're removing mutable references
+                    if matches!(unary.op, UnOp::Deref(_)) {
+                        *left = unary.expr;
+                    }
+                }
+                _ => (),
+            },
+            Expr::Call(call) => {
+                *stmt = Stmt::Local(rewrite_fn_call(call.clone()));
+            }
+            _ => (),
+        },
+        _ => (),
+    }
+}
+
+/// Rewrite a function call, removing the mutable reference arguments and
+/// let-binding return values for them instead.
+fn rewrite_fn_call(mut call: ExprCall) -> Local {
+    let mut args = Punctuated::new();
+    let mut output = Punctuated::new();
+
+    for arg in &call.args {
+        if let Expr::Reference(ExprReference {
+            mutability: Some(_),
+            expr,
+            ..
+        }) = arg
+        {
+            match expr.deref() {
+                Expr::Path(ExprPath {
+                    path: Path { segments, .. },
+                    ..
+                }) => {
+                    assert_eq!(segments.len(), 1, "expected only one segment in fn arg");
+                    let ident = segments.first().unwrap().ident.clone();
+
+                    output.push(Pat::Ident(PatIdent {
+                        attrs: Vec::new(),
+                        by_ref: None,
+                        mutability: None,
+                        ident,
+                        subpat: None,
+                    }));
+                }
+                other => panic!("unexpected expr in fn arg: {:?}", other),
+            }
+
+            continue;
+        }
+
+        args.push(arg.clone());
+    }
+
+    // Overwrite call arguments with the ones that aren't mutable references
+    call.args = args;
+
+    let span = Span::call_site();
+
+    let pat = Pat::Tuple(PatTuple {
+        attrs: Vec::new(),
+        paren_token: Paren { span },
+        elems: output,
+    });
+
+    Local {
+        attrs: Vec::new(),
+        let_token: Let { span },
+        pat,
+        init: Some((Eq { spans: [span] }, Box::new(Expr::Call(call)))),
+        semi_token: Semi { spans: [span] },
+    }
+}
+
+/// Registry of types defined by the module being processed.
+pub struct TypeRegistry(Map<Ident, Type>);
+
+impl TypeRegistry {
+    /// Create a new type registry.
+    pub fn new() -> Self {
+        Self(Map::new())
+    }
+
+    /// Add a type to the type registry.
+    pub fn add(&mut self, item_type: &ItemType) {
+        if self
+            .0
+            .insert(item_type.ident.clone(), item_type.ty.deref().clone())
+            .is_some()
+        {
+            panic!("duplicate type name: {}", &item_type.ident);
+        }
+    }
+
+    /// Get a type from the registry by its ident.
+    pub fn get(&self, ident: &Ident) -> Option<&Type> {
+        self.0.get(ident)
+    }
+}
+
+/// Output values, which in regular `fiat-crypto` are passed as mutable references, e.g.:
+///
+/// ```
+/// out1: &mut ..., out2: &mut ...
+/// ```
+///
+/// This type stores the outputs and uses them to build the return type
+/// (i.e. `Signature::output`), `let mut` bindings in place of the mutable
+/// references, and a return value instead of using side effects to write to
+/// mutable references.
+#[derive(Debug)]
+pub struct Outputs(Map<Ident, Type>);
+
+impl Outputs {
+    /// Create new output storage.
+    pub fn new() -> Self {
+        Self(Map::new())
+    }
+
+    /// Add an output variable with the given name and type.
+    ///
+    /// Panics if the name is duplicated.
+    pub fn add(&mut self, name: Ident, ty: Type) {
+        if self.0.insert(name.clone(), ty).is_some() {
+            panic!("duplicate output name: {}", name);
+        }
+    }
+
+    /// Generate `let mut outN: Ty = <zero>` bindings at the start
+    /// of the function.
+    pub fn to_let_bindings(&self, registry: &TypeRegistry) -> Vec<Stmt> {
+        let span = Span::call_site();
+
+        self.0
+            .iter()
+            .map(|(ident, ty)| {
+                Stmt::Local(Local {
+                    attrs: Vec::new(),
+                    let_token: Let { span },
+                    pat: Pat::Type(PatType {
+                        attrs: Vec::new(),
+                        pat: Box::new(Pat::Ident(PatIdent {
+                            attrs: Vec::new(),
+                            by_ref: None,
+                            mutability: Some(Mut { span }),
+                            ident: ident.clone(),
+                            subpat: None,
+                        })),
+                        colon_token: Colon { spans: [span] },
+                        ty: Box::new(ty.clone()),
+                    }),
+                    init: Some((Eq { spans: [span] }, Box::new(default_for(ty, registry)))),
+                    semi_token: Semi { spans: [span] },
+                })
+            })
+            .collect()
+    }
+
+    /// Finish annotating outputs, updating the provided `Signature`.
+    pub fn to_return_type(&self) -> ReturnType {
+        let span = Span::call_site();
+        let rarrow = RArrow {
+            spans: [span, span],
+        };
+
+        let ret = match self.0.len() {
+            0 => panic!("expected at least one output"),
+            1 => self.0.values().next().unwrap().clone(),
+            _ => {
+                let mut elems = Punctuated::new();
+
+                for ty in self.0.values() {
+                    elems.push(ty.clone());
+                }
+
+                Type::Tuple(TypeTuple {
+                    paren_token: Paren { span },
+                    elems,
+                })
+            }
+        };
+
+        ReturnType::Type(rarrow, Box::new(ret))
+    }
+
+    /// Generate the return value for the statement as a tuple of the outputs.
+    pub fn to_return_value(&self) -> Stmt {
+        let span = Span::call_site();
+
+        let mut elems = self.0.iter().map(|(ident, _)| {
+            let mut segments = Punctuated::new();
+            segments.push(PathSegment {
+                ident: ident.clone(),
+                arguments: PathArguments::None,
+            });
+
+            let path = Path {
+                leading_colon: None,
+                segments,
+            };
+
+            Expr::Path(ExprPath {
+                attrs: Vec::new(),
+                qself: None,
+                path,
+            })
+        });
+
+        if elems.len() == 1 {
+            Stmt::Expr(elems.next().unwrap())
+        } else {
+            Stmt::Expr(Expr::Tuple(ExprTuple {
+                attrs: Vec::new(),
+                paren_token: Paren { span },
+                elems: elems.collect(),
+            }))
+        }
+    }
+}
+
+/// Get a default value for the given type.
+fn default_for(ty: &Type, registry: &TypeRegistry) -> Expr {
+    let span = Span::call_site();
+    let zero = Expr::Lit(ExprLit {
+        attrs: Vec::new(),
+        lit: Lit::Int(LitInt::new("0", span)),
+    });
+
+    match ty {
+        Type::Array(TypeArray { len, .. }) => Expr::Repeat(ExprRepeat {
+            attrs: Vec::new(),
+            bracket_token: Bracket { span },
+            expr: Box::new(zero),
+            semi_token: Semi { spans: [span] },
+            len: Box::new(len.clone()),
+        }),
+        Type::Path(TypePath { path, .. }) => {
+            assert_eq!(
+                path.segments.len(),
+                1,
+                "wasn't expecting multiple segments in path"
+            );
+
+            let ident = path.segments.first().unwrap().ident.clone();
+
+            // Attempt to look up type in the registry
+            if let Some(registry_ty) = registry.get(&ident) {
+                // If we got a type from the registry, recurse
+                default_for(registry_ty, registry)
+            } else if matches!(ident.to_string().as_str(), "u8" | "u32" | "u64") {
+                zero
+            } else {
+                panic!("unsupported type: {:?}", ty)
+            }
+        }
+        _ => panic!("don't know how to build default value for {:?}", ty),
+    }
+}


### PR DESCRIPTION
This crate is a tool for transforming `fiat-crypto`-generated field arithmetic into `const fn` form.

It performs mechanical translation to the parsed AST of the code, making some assumptions about how it's structured and rewriting the usages of mutable references into a functional form.

Manual tests confirm the output from the p386 base field compiles.