### PR TITLE
fiat-constify: add clippy allows

### DIFF
--- a/fiat-constify/src/main.rs
+++ b/fiat-constify/src/main.rs
@@ -31,6 +31,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ast.attrs.push(build_attribute(
         "allow",
         &[
+            "clippy::identity_op",
+            "clippy::unnecessary_cast",
             "dead_code",
             "rustdoc::broken_intra_doc_links",
             "unused_assignments",


### PR DESCRIPTION
Adds `allow` directives for the following:

- `clippy::identity_op`
- `clippy::unnecessary_cast`