### PR TITLE
zeroize: add CI for 32-bit environments

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -50,24 +50,53 @@ jobs:
   test:
     strategy:
       matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-        toolchain:
-          - 1.51.0 # MSRV
-          - stable
+        include:
+          # 32-bit Linux
+          - target: i686-unknown-linux-gnu
+            platform: ubuntu-latest
+            rust: 1.51.0 # MSRV
+            deps: sudo apt update && sudo apt install gcc-multilib
+          - target: i686-unknown-linux-gnu
+            platform: ubuntu-latest
+            rust: stable
+            deps: sudo apt update && sudo apt install gcc-multilib
+
+          # 64-bit Linux
+          - target: x86_64-unknown-linux-gnu
+            platform: ubuntu-latest
+            rust: 1.51.0 # MSRV
+          - target: x86_64-unknown-linux-gnu
+            platform: ubuntu-latest
+            rust: stable
+
+          # 64-bit macOS x86_64
+          - target: x86_64-apple-darwin
+            platform: macos-latest
+            rust: 1.51.0 # MSRV
+          - target: x86_64-apple-darwin
+            platform: macos-latest
+            rust: stable
+
+          # 64-bit Windows
+          - target: x86_64-pc-windows-msvc
+            platform: windows-latest
+            rust: 1.51.0 # MSRV
+          - target: x86_64-pc-windows-msvc
+            platform: windows-latest
+            rust: stable
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           profile: minimal
+          override: true
       # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
       - run: rm ../Cargo.toml
+      - run: ${{ matrix.deps }}
       - run: cargo test
       - run: cargo test --features alloc,derive,std
 


### PR DESCRIPTION
Uses a 32-bit Linux target