### PR TITLE
zeroize v1.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "zeroize_derive",
 ]

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.6 (2022-06-29)
+### Added
+- `#[inline(always)]` annotations ([#772])
+- `#[ignore]` attribute on flaky CString test ([#776])
+
+### Changed
+- Factor integration tests into `tests/` ([#771])
+
+[#771]: https://github.com/RustCrypto/utils/pull/771
+[#772]: https://github.com/RustCrypto/utils/pull/772
+[#776]: https://github.com/RustCrypto/utils/pull/776
+
 ## 1.5.5 (2022-04-30)
 ### Added
 - Impl `Zeroize` for std::ffi::CString ([#759])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version = "1.5.5"
+version = "1.5.6"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"


### PR DESCRIPTION
### Added
- `#[inline(always)]` annotations ([#772])
- `#[ignore]` attribute on flaky CString test ([#776])

### Changed
- Factor integration tests into `tests/` ([#771])

[#771]: https://github.com/RustCrypto/utils/pull/771
[#772]: https://github.com/RustCrypto/utils/pull/772
[#776]: https://github.com/RustCrypto/utils/pull/776