### PR TITLE
cpufeatures: Disable all target features under miri

### DIFF
--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -59,12 +59,17 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 
+#[cfg(not(miri))]
 #[cfg(all(target_arch = "aarch64"))]
 #[doc(hidden)]
 pub mod aarch64;
 
+#[cfg(not(miri))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
+
+#[cfg(miri)]
+mod miri;
 
 #[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
 compile_error!("This crate works only on `aarch64`, `x86`, and `x86-64` targets.");

--- a/cpufeatures/src/miri.rs
+++ b/cpufeatures/src/miri.rs
@@ -1,0 +1,20 @@
+//! Minimal miri support.
+//!
+//! Miri is an interpreter, and though it tries to emulate the target CPU
+//! it does not support any target features.
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __unless_target_features {
+    ($($tf:tt),+ => $body:expr ) => {
+        false
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __detect_target_features {
+    ($($tf:tt),+) => {
+        false
+    };
+}


### PR DESCRIPTION
~~[miri](https://github.com/rust-lang/miri) is an interpreter and doesn't support inline assembly. Fortunately, we already have precedent for an x86 target without cpuid: SGX. Treat miri like SGX: only features that are enabled at compile time are available at run time.~~

[miri](https://github.com/rust-lang/miri) is an interpreter, and though it tries to emulate the target CPU it does not support any target features.

Fixes #778.