### PR TITLE
zeroize v1.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "serde",
  "zeroize_derive",

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.7 (2022-07-20)
+### Added
+- Optional `serde` support ([#780])
+
+[#780]: https://github.com/RustCrypto/utils/pull/780
+
 ## 1.5.6 (2022-06-29)
 ### Added
 - `#[inline(always)]` annotations ([#772])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version = "1.5.6"
+version = "1.5.7"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"


### PR DESCRIPTION
### Added
- Optional `serde` support ([#780])

[#780]: https://github.com/RustCrypto/utils/pull/780