### PR TITLE
Fix deriving `ZeroizeOnDrop` on items with generics

### DIFF
--- a/zeroize/derive/src/lib.rs
+++ b/zeroize/derive/src/lib.rs
@@ -71,7 +71,7 @@ fn derive_zeroize(mut s: synstructure::Structure<'_>) -> TokenStream {
 fn derive_zeroize_on_drop(mut s: synstructure::Structure<'_>) -> TokenStream {
     let zeroizers = generate_fields(&mut s, quote! { zeroize_or_on_drop });
 
-    let drop_impl = s.gen_impl(quote! {
+    let drop_impl = s.add_bounds(AddBounds::None).gen_impl(quote! {
         gen impl Drop for @Self {
             fn drop(&mut self) {
                 use zeroize::__internal::AssertZeroize;

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -317,7 +317,11 @@ fn derive_deref() {
 }
 
 #[test]
-fn derive_box() {
-    #[derive(Zeroize, ZeroizeOnDrop)]
-    struct Z<T: Zeroize>(Box<T>);
+#[cfg(feature = "alloc")]
+fn derive_zeroize_on_drop_generic() {
+    #[derive(ZeroizeOnDrop)]
+    struct Y<T: Zeroize>(Box<T>);
+
+    #[derive(ZeroizeOnDrop)]
+    struct Z<T: Zeroize>(Vec<T>);
 }

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -315,3 +315,9 @@ fn derive_deref() {
     }
     assert_eq!(&value.0 .0, &[0, 0, 0])
 }
+
+#[test]
+fn derive_box() {
+    #[derive(Zeroize, ZeroizeOnDrop)]
+    struct Z<T: Zeroize>(Box<T>);
+}


### PR DESCRIPTION
I don't actually know how to test this, because you can't access the dropped memory of a `Box` without a custom allocator I suppose (EDIT: same for `Vec`). So I just made sure it builds.

I'm also not a 100% sure my assumption is correct, but as far as I understand any `Drop` bounds are truly unnecessary in this case.

Fixes #786.