### PR TITLE
Update libc deps to 0.2.95

### DIFF
--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2018"
 readme = "README.md"
 
 [target.aarch64-apple-darwin.dependencies]
-libc = "0.2.68"
+libc = "0.2.95"
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-libc = "0.2.68"
+libc = "0.2.95"
 
 [target.aarch64-linux-android.dependencies]
-libc = "0.2.68"
+libc = "0.2.95"


### PR DESCRIPTION
Fixes https://github.com/RustCrypto/utils/issues/788. I'm not sure if all targets need to be updated or just `aarch64` (probably just `aarch64`). If so I can remove bumping the version in other targets

HWCAP_* consts for aarch64 were added to libc in https://github.com/rust-lang/libc/pull/2172 and released in [v0.2.95](https://github.com/rust-lang/libc/releases/tag/0.2.95)

It looks like these constants were imported into cpufeatures in https://github.com/RustCrypto/utils/pull/456 and the libc version was bumped to 0.2.95 accordingly. But then in https://github.com/RustCrypto/utils/pull/732 libc version was bumped down. I think the minimum libc version should be bumped back up to 0.2.95 to include these constants