### PR TITLE
cpufeatures: check AVX availability when detecting AVX2 and FMA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.0.2"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.2.3 (2022-08-18)
 ### Changed
+- Update `libc` version to v0.2.95 ([#789])
+- Disable all target features under MIRI ([#779])
 - Check AVX availability when detecting AVX2 and FMA ([#792])
 
+[#779]: https://github.com/RustCrypto/utils/pull/779
+[#789]: https://github.com/RustCrypto/utils/pull/789
 [#792]: https://github.com/RustCrypto/utils/pull/792
 
 ## 0.2.2 (2022-03-18)

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2022-08-18)
+### Changed
+- Check AVX availability when detecting AVX2 and FMA ([#792])
+
+[#792]: https://github.com/RustCrypto/utils/pull/792
+
 ## 0.2.2 (2022-03-18)
 ### Added
 - Support for Android on `aarch64` ([#752])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.3"
 description = """
 Lightweight runtime CPU feature detection for x86/x86_64 and aarch64 with
 no_std support and support for mobile targets including Android and iOS


### PR DESCRIPTION
We must do it according to the [Intel manual](https://www.intel.com/content/dam/develop/external/us/en/documents/36945). Our non-conformance has [caused](https://github.com/RustCrypto/hashes/pull/386) issues with the `sha2` crate.

Strictly speaking, during detection of AVX we also should use XGETBV to check whether XMM and YMM states are enabled by OS, but I think it's worth to do it later in a separate PR.

cc @brocaar