### PR TITLE
zeroize: note `aarch64` crate feature works on stable

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -98,15 +98,17 @@ jobs:
       - run: rm ../Cargo.toml
       - run: ${{ matrix.deps }}
       - run: cargo test
-      - run: cargo test --features alloc,derive,std
+      - run: cargo test --all-features
 
-  # Feature-gated ARM64 SIMD register support (nightly-only)
+  # Feature-gated ARM64 SIMD register support (MSRV 1.59)
   aarch64:
     strategy:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            rust: nightly
+            rust: 1.59.0
+          - target: aarch64-unknown-linux-gnu
+            rust: stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -1,7 +1,7 @@
 //! [`Zeroize`] impls for ARM64 SIMD registers.
 //!
-//! Support for this is gated behind an `aarch64` feature because
-//! support for `core::arch::aarch64` is currently nightly-only.
+//! Gated behind the `aarch64` feature: MSRV 1.59
+//! (the overall crate is MSRV 1.51)
 
 use crate::{atomic_fence, volatile_write, Zeroize};
 


### PR DESCRIPTION
The required APIs are stable as of Rust 1.59.

Unfortunately we can't yet enable it by default as the overall crate's MSRV is 1.51. It will be possible if we bump MSRV to >=1.59.

This commit also adjusts the CI job to test the `aarch64` feature works on `1.59.0` and `stable` compilers.