### PR TITLE
Small typo in docstring

### DIFF
--- a/block-padding/src/lib.rs
+++ b/block-padding/src/lib.rs
@@ -25,7 +25,7 @@ pub enum PadType {
     Reversible,
     /// Ambiguous padding
     Ambiguous,
-    /// No padding, message must be mutliple of block size
+    /// No padding, message must be multiple of block size
     NoPadding,
 }
 


### PR DESCRIPTION
I noticed a small typo while reading the documentation.