### PR TITLE
block-buffer: add try_new method

### DIFF
--- a/block-buffer/tests/mod.rs
+++ b/block-buffer/tests/mod.rs
@@ -186,3 +186,11 @@ fn test_eager_paddings() {
         [0x42, 0xff, 0x10, 0x11],
     );
 }
+
+#[test]
+fn test_try_new() {
+    assert!(EagerBuffer::<U4>::try_new(&[0; 3]).is_ok());
+    assert!(EagerBuffer::<U4>::try_new(&[0; 4]).is_err());
+    assert!(LazyBuffer::<U4>::try_new(&[0; 4]).is_ok());
+    assert!(LazyBuffer::<U4>::try_new(&[0; 5]).is_err());
+}


### PR DESCRIPTION
try_new creates BlockBuffer or returns an error.

Requested in https://github.com/RustCrypto/traits/pull/1078