### PR TITLE
Add workaround for CPUID bug in std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.0.2"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.5 (2022-09-05)
+## 0.2.5 (2022-09-04)
 ### Fixed
 - Add workaround for [CPUID bug] in `std` ([#800])
 

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.5 (2022-09-05)
+### Fixed
+- Add workaround for [CPUID bug] in `std` ([#800])
+
+[CPUID bug]: https://github.com/rust-lang/rust/issues/101346
+[#800]: https://github.com/RustCrypto/utils/pull/800
+
 ## 0.2.4 (2022-08-22)
 - Re-release v0.2.3 without any changes to fix [#795] ([#796])
 

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.2.4"
+version = "0.2.5"
 description = """
 Lightweight runtime CPU feature detection for x86/x86_64 and aarch64 with
 no_std support and support for mobile targets including Android and iOS

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -33,12 +33,27 @@ macro_rules! __unless_target_features {
 macro_rules! __detect_target_features {
     ($($tf:tt),+) => {{
         #[cfg(target_arch = "x86")]
-        use core::arch::x86::{__cpuid, __cpuid_count};
+        use core::arch::x86::{__cpuid, __cpuid_count, CpuidResult};
         #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::{__cpuid, __cpuid_count};
+        use core::arch::x86_64::{__cpuid, __cpuid_count, CpuidResult};
+
+        // These wrappers are workarounds around
+        // https://github.com/rust-lang/rust/issues/101346
+        //
+        // DO NOT remove it until MSRV is bumped to a version
+        // with the issue fix (at least 1.64).
+        #[inline(never)]
+        unsafe fn cpuid(leaf: u32) -> CpuidResult {
+            __cpuid(leaf)
+        }
+
+        #[inline(never)]
+        unsafe fn cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
+            __cpuid_count(leaf, sub_leaf)
+        }
 
         let cr = unsafe {
-            [__cpuid(1), __cpuid_count(7, 0)]
+            [cpuid(1), cpuid_count(7, 0)]
         };
 
         $($crate::check!(cr, $tf) & )+ true


### PR DESCRIPTION
Relevant issues: https://github.com/rust-lang/rust/issues/101346, https://github.com/RustCrypto/stream-ciphers/issues/304

Forbidding inlining of the CPUID intrinsics should force compiler to generate correct assembly since it can not perform incorrect optimization with register reuse.