### PR TITLE
Release block-buffer v0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "generic-array",
 ]

--- a/block-buffer/CHANGELOG.md
+++ b/block-buffer/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.10.3 (2022-09-04)
 ### Added
-- `try_new` method ([#731])
+- `try_new` method ([#799])
 
 [#799]: https://github.com/RustCrypto/utils/pull/799
 

--- a/block-buffer/CHANGELOG.md
+++ b/block-buffer/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2022-09-04)
+### Added
+- `try_new` method ([#731])
+
+[#799]: https://github.com/RustCrypto/utils/pull/799
+
 ## 0.10.2 (2021-02-08)
 ### Fixed
 - Eliminate unreachable panic in `LazyBuffer::digest_blocks` ([#731])

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Buffer type for block processing of data"


### PR DESCRIPTION
### Added
- `try_new` method ([#799])

[#799]: https://github.com/RustCrypto/utils/pull/799