### PR TITLE
zeroize_derive v1.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.3 (2022-11-30)
+### Fixed
+- Deriving `ZeroizeOnDrop` on items with generics ([#787])
+
+[#787]: https://github.com/RustCrypto/utils/pull/787
+
 ## 1.3.2 (2022-02-18)
 ### Fixed
 - Min versions build ([#732])

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"


### PR DESCRIPTION
### Fixed
- Deriving `ZeroizeOnDrop` on items with generics ([#787])

[#787]: https://github.com/RustCrypto/utils/pull/787