### PR TITLE
cpufeatures: support freestanding/UEFI `x86` targets

### DIFF
--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -14,11 +14,11 @@ macro_rules! __unless_target_features {
     ($($tf:tt),+ => $body:expr ) => {{
         #[cfg(not(all($(target_feature=$tf,)*)))]
         {
-            #[cfg(not(target_env = "sgx"))]
+            #[cfg(not(any(target_env = "sgx", target_os = "none", target_os = "uefi")))]
             $body
 
-            // CPUID is not available on SGX targets
-            #[cfg(target_env = "sgx")]
+            // CPUID is not available on SGX, freestanding and UEFI targets
+            #[cfg(any(target_env = "sgx", target_os = "none", target_os = "uefi"))]
             false
         }
 


### PR DESCRIPTION
This fixes compilation of dependent crates for these targets.

For example, `sha2`:

Before:
```
$ cargo build --target x86_64-unknown-none --no-default-features
   Compiling sha2 v0.10.6 (/home/rvolosatovs/src/github.com/rustcrypto/hashes/sha2)
LLVM ERROR: Do not know how to split the result of this operator!

error: could not compile `sha2`
$ cargo build --target x86_64-unknown-uefi --no-default-features
   Compiling sha2 v0.10.6 (/home/rvolosatovs/src/github.com/rustcrypto/hashes/sha2)
LLVM ERROR: Do not know how to split the result of this operator!

error: could not compile `sha2`
```

After:
```
$ cargo build --target x86_64-unknown-none --no-default-features
   Compiling cpufeatures v0.2.5 (/home/rvolosatovs/src/github.com/rustcrypto/utils/cpufeatures)
   Compiling sha2 v0.10.6 (/home/rvolosatovs/src/github.com/rustcrypto/hashes/sha2)
    Finished dev [optimized + debuginfo] target(s) in 0.19s
$ cargo build --target x86_64-unknown-uefi --no-default-features
   Compiling cpufeatures v0.2.5 (/home/rvolosatovs/src/github.com/rustcrypto/utils/cpufeatures)
   Compiling sha2 v0.10.6 (/home/rvolosatovs/src/github.com/rustcrypto/hashes/sha2)
    Finished dev [optimized + debuginfo] target(s) in 0.19s
```