### PR TITLE
CI: disable macOS builds on MSRV

### DIFF
--- a/.github/workflows/cpufeatures.yml
+++ b/.github/workflows/cpufeatures.yml
@@ -60,7 +60,8 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.40.0 # MSRV
+          # TODO(tarcieri): try re-enabling this when we bump MSRV
+          # - 1.40.0 # MSRV
           - stable
     runs-on: macos-latest
     steps:

--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -70,9 +70,10 @@ jobs:
             rust: stable
 
           # 64-bit macOS x86_64
-          - target: x86_64-apple-darwin
-            platform: macos-latest
-            rust: 1.51.0 # MSRV
+          # TODO(tarcieri): try re-enabling this when we bump MSRV
+          # - target: x86_64-apple-darwin
+          #  platform: macos-latest
+          #  rust: 1.51.0 # MSRV
           - target: x86_64-apple-darwin
             platform: macos-latest
             rust: stable


### PR DESCRIPTION
There are currently build failures on `master` for `cpufeatures` and `zeroize`, which test on macOS runners:

https://github.com/RustCrypto/utils/actions/runs/3733690805/jobs/6594187401#step:6:13

  = note: ld: in /Users/runner/.rustup/toolchains/1.40.0-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libgetopts-1988d9ef7be544ff.rlib(rust.metadata.bin), archive member 'rust.metadata.bin' with length 198423 is not mach-o or llvm bitcode file '/Users/runner/.rustup/toolchains/1.40.0-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libgetopts-1988d9ef7be544ff.rlib'

It seems these older rustc versions do not support linking with the latest macOS compiler toolchain.

The build on `stable` works, so we can continue to test macOS, just not that these two crates are MSRV compatible on macOS.