### PR TITLE
cmov: redesigned trait-based API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.1.1"
+version = "0.2.0-pre"
 
 [[package]]
 name = "collectable"

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -6,7 +6,7 @@ constant-time and not be rewritten as branches by the compiler.
 Provides wrappers for the CMOV family of instructions on x86/x86_64
 and CSEL on AArch64.
 """
-version = "0.1.1"
+version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/cmov"

--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -1,0 +1,90 @@
+use crate::{Cmov, Condition};
+use core::arch::asm;
+
+macro_rules! csel {
+    ($cmp:expr, $csel:expr, $dst:expr, $src:expr, $condition:expr) => {
+        unsafe {
+            asm! {
+                $cmp,
+                $csel,
+                in(reg) $condition,
+                inlateout(reg) *$dst,
+                in(reg) $src,
+                in(reg) *$dst,
+                options(pure, nomem, nostack),
+            };
+        }
+    };
+}
+
+impl Cmov for u16 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        csel!(
+            "cmp {0:w}, 0",
+            "csel {1:w}, {2:w}, {3:w}, EQ",
+            self,
+            value,
+            condition
+        );
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        csel!(
+            "cmp {0:w}, 0",
+            "csel {1:w}, {2:w}, {3:w}, NE",
+            self,
+            value,
+            condition
+        );
+    }
+}
+
+impl Cmov for u32 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        csel!(
+            "cmp {0:w}, 0",
+            "csel {1:w}, {2:w}, {3:w}, EQ",
+            self,
+            value,
+            condition
+        );
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        csel!(
+            "cmp {0:w}, 0",
+            "csel {1:w}, {2:w}, {3:w}, NE",
+            self,
+            value,
+            condition
+        );
+    }
+}
+
+impl Cmov for u64 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        csel!(
+            "cmp {0:x}, 0",
+            "csel {1:x}, {2:x}, {3:x}, EQ",
+            self,
+            value,
+            condition
+        );
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        csel!(
+            "cmp {0:x}, 0",
+            "csel {1:x}, {2:x}, {3:x}, NE",
+            self,
+            value,
+            condition
+        );
+    }
+}

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -6,146 +6,69 @@
 )]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
-use core::arch::asm;
-
-/// Move if zero.
-///
-/// Uses a `test` instruction to check if the given `condition` value is
-/// equal to zero, then calls `cmovz` (a.k.a. `cmove`) to conditionally move
-/// `src` to `dst` when `condition` is equal to zero.
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
+mod portable;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[inline(always)]
-pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
-    unsafe {
-        asm! {
-            "test {0}, {0}",
-            "cmovz {1}, {2}",
-            in(reg) condition,
-            inlateout(reg) *dst,
-            in(reg) src,
-            options(pure, nomem, nostack),
-        };
+mod x86;
+
+/// Condition
+pub type Condition = u8;
+
+/// Conditional move
+pub trait Cmov {
+    /// Move if zero.
+    ///
+    /// Uses a `cmp` instruction to check if the given `condition` value is
+    /// equal to zero, and if so, conditionally moves `value` to `self`
+    /// when `condition` is equal to zero.
+    fn cmovz(&mut self, value: Self, condition: Condition);
+
+    /// Move if non-zero.
+    ///
+    /// Uses a `test` instruction to check if the given `condition` value is
+    /// equal to zero, conditionally moves `value` to `self` when `condition` is
+    /// equal to zero.
+    fn cmovnz(&mut self, value: Self, condition: Condition);
+}
+
+impl Cmov for u8 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        let mut tmp = *self as u16;
+        tmp.cmovz(value as u16, condition);
+        *self = tmp as u8;
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        let mut tmp = *self as u16;
+        tmp.cmovnz(value as u16, condition);
+        *self = tmp as u8;
     }
 }
 
-/// Move if zero.
-///
-/// Uses a `cmp` instruction to check if the given `condition` value is
-/// equal to zero, then calls `csel` to conditionally move
-/// `src` to `dst` when `condition` is equal to zero.
-#[cfg(any(target_arch = "aarch64"))]
-#[inline(always)]
-pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
-    unsafe {
-        asm! {
-            "cmp {0}, 0",
-            "csel {1}, {2}, {3}, EQ",
-            in(reg) condition,
-            inlateout(reg) *dst,
-            in(reg) src,
-            in(reg) *dst,
-            options(pure, nomem, nostack),
-        };
-    }
-}
+impl Cmov for u128 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        let mut lo = (*self & u64::MAX as u128) as u64;
+        let mut hi = (*self >> 64) as u64;
 
-/// Move if not zero.
-///
-/// Uses a `cmp` instruction to check if the given `condition` value is not
-/// equal to zero, then calls `csel` to conditionally move
-/// `src` to `dst` when `condition` is nonzero.
-#[cfg(any(target_arch = "aarch64"))]
-#[inline(always)]
-pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
-    unsafe {
-        asm! {
-            "cmp {0}, 0",
-            "csel {1}, {2}, {3}, NE",
-            in(reg) condition,
-            inlateout(reg) *dst,
-            in(reg) src,
-            in(reg) *dst,
-            options(pure, nomem, nostack),
-        };
-    }
-}
+        lo.cmovz((value & u64::MAX as u128) as u64, condition);
+        hi.cmovz((value >> 64) as u64, condition);
 
-/// Move if not zero.
-///
-/// Uses a `test` instruction to check if the given `condition` value is not
-/// equal to zero, then calls `cmovnz` (a.k.a. `cmovne`) to conditionally move
-/// `src` to `dst` when `condition` is nonzero.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[inline(always)]
-pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
-    unsafe {
-        asm! {
-            "test {0}, {0}",
-            "cmovnz {1}, {2}",
-            in(reg) condition,
-            inlateout(reg) *dst,
-            in(reg) src,
-            options(pure, nomem, nostack),
-        };
-    }
-}
-
-/// Move if zero (portable fallback implementation).
-///
-/// This implementation is based on portable bitwise arithmetic but cannot
-/// guarantee that the resulting generated assembly is free of branch
-/// instructions.
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
-#[inline(never)]
-pub fn cmovz(condition: usize, src: usize, dst: &mut usize) {
-    let mask = (1 ^ is_non_zero(condition)).wrapping_sub(1);
-    *dst = (*dst & mask) | (src & !mask);
-}
-
-/// Move if not zero (portable fallback implementation).
-///
-/// This implementation is based on portable bitwise arithmetic but cannot
-/// guarantee that the resulting generated assembly is free of branch
-/// instructions.
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
-#[inline(never)]
-pub fn cmovnz(condition: usize, src: usize, dst: &mut usize) {
-    let mask = is_non_zero(condition).wrapping_sub(1);
-    *dst = (*dst & mask) | (src & !mask);
-}
-
-/// Check if the given condition value is non-zero
-///
-/// # Returns
-/// - `condition` is zero: `0`
-/// - `condition` is non-zero: `1`
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
-#[inline(always)]
-fn is_non_zero(condition: usize) -> usize {
-    const SHIFT_BITS: usize = core::mem::size_of::<usize>() - 1;
-    ((condition | (!condition).wrapping_add(1)) >> SHIFT_BITS) & 1
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cmovz_works() {
-        let mut n = 24;
-        cmovz(42, 42, &mut n);
-        assert_eq!(n, 24);
-        cmovz(0, 42, &mut n);
-        assert_eq!(n, 42);
+        *self = (lo as u128) | (hi as u128) << 64;
     }
 
-    #[test]
-    fn cmovnz_works() {
-        let mut n = 24;
-        cmovnz(0, 42, &mut n);
-        assert_eq!(n, 24);
-        cmovnz(42, 42, &mut n);
-        assert_eq!(n, 42);
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        let mut lo = (*self & u64::MAX as u128) as u64;
+        let mut hi = (*self >> 64) as u64;
+
+        lo.cmovnz((value & u64::MAX as u128) as u64, condition);
+        hi.cmovnz((value >> 64) as u64, condition);
+
+        *self = (lo as u128) | (hi as u128) << 64;
     }
 }

--- a/cmov/src/portable.rs
+++ b/cmov/src/portable.rs
@@ -1,0 +1,67 @@
+//! Portable "best effort" implementation of `Cmov`.
+//!
+//! This implementation is based on portable bitwise arithmetic but cannot
+//! guarantee that the resulting generated assembly is free of branch
+//! instructions.
+
+// TODO(tarcieri): more optimized implementation for small integers
+
+use crate::{Cmov, Condition};
+
+impl Cmov for u16 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        let mut tmp = *self as u64;
+        tmp.cmovz(value as u64, condition);
+        *self = tmp as u16;
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        let mut tmp = *self as u64;
+        tmp.cmovnz(value as u64, condition);
+        *self = tmp as u16;
+    }
+}
+
+impl Cmov for u32 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        let mut tmp = *self as u64;
+        tmp.cmovz(value as u64, condition);
+        *self = tmp as u32;
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        let mut tmp = *self as u64;
+        tmp.cmovnz(value as u64, condition);
+        *self = tmp as u32;
+    }
+}
+
+impl Cmov for u64 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        let mask = (1 ^ is_non_zero(condition)).wrapping_sub(1);
+        *self = (*self & mask) | (value & !mask);
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        let mask = is_non_zero(condition).wrapping_sub(1);
+        *self = (*self & mask) | (value & !mask);
+    }
+}
+
+/// Check if the given condition value is non-zero
+///
+/// # Returns
+/// - `condition` is zero: `0`
+/// - `condition` is non-zero: `1`
+#[inline(always)]
+fn is_non_zero(condition: Condition) -> u64 {
+    const SHIFT_BITS: usize = core::mem::size_of::<u64>() - 1;
+    let condition = condition as u64;
+    ((condition | (!condition).wrapping_add(1)) >> SHIFT_BITS) & 1
+}

--- a/cmov/src/x86.rs
+++ b/cmov/src/x86.rs
@@ -1,0 +1,62 @@
+//! From "AMD64 Architecture Programmer’s Manual, Volume 1: Application Programming"
+//! (Rev. 3.23 - October 2020) page 46:
+//!
+//! <https://www.amd.com/system/files/TechDocs/24592.pdf>
+//!
+//! > The CMOVcc instructions conditionally copy a word, doubleword, or
+//! > quadword from a register or memory location to a register location.
+//! > The source and destination must be of the same size.
+
+use crate::{Cmov, Condition};
+use core::arch::asm;
+
+macro_rules! cmov {
+    ($instruction:expr, $dst:expr, $src:expr, $condition:expr) => {
+        unsafe {
+            asm! {
+                "test {0}, {0}",
+                $instruction,
+                in(reg_byte) $condition,
+                inlateout(reg) *$dst,
+                in(reg) $src,
+                options(pure, nomem, nostack),
+            };
+        }
+    };
+}
+
+impl Cmov for u16 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        cmov!("cmovz {1:e}, {2:e}", self, value, condition);
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
+    }
+}
+
+impl Cmov for u32 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        cmov!("cmovz {1:e}, {2:e}", self, value, condition);
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
+    }
+}
+
+impl Cmov for u64 {
+    #[inline(always)]
+    fn cmovz(&mut self, value: Self, condition: Condition) {
+        cmov!("cmovz {1:r}, {2:r}", self, value, condition);
+    }
+
+    #[inline(always)]
+    fn cmovnz(&mut self, value: Self, condition: Condition) {
+        cmov!("cmovnz {1:r}, {2:r}", self, value, condition);
+    }
+}

--- a/cmov/tests/lib.rs
+++ b/cmov/tests/lib.rs
@@ -1,0 +1,149 @@
+mod u8 {
+    use cmov::Cmov;
+
+    #[test]
+    fn cmovz_works() {
+        let mut n = 0x11u8;
+
+        for cond in 1..0xFF {
+            n.cmovz(0x22, cond);
+            assert_eq!(n, 0x11);
+        }
+
+        n.cmovz(0x22, 0);
+        assert_eq!(n, 0x22);
+    }
+
+    #[test]
+    fn cmovnz_works() {
+        let mut n = 0x11u8;
+        n.cmovnz(0x22, 0);
+        assert_eq!(n, 0x11);
+
+        for cond in 1..0xFF {
+            let mut n = 0x11u8;
+            n.cmovnz(0x22, cond);
+            assert_eq!(n, 0x22);
+        }
+    }
+}
+
+mod u16 {
+    use cmov::Cmov;
+
+    #[test]
+    fn cmovz_works() {
+        let mut n = 0x1111u16;
+
+        for cond in 1..0xFF {
+            n.cmovz(0x2222, cond);
+            assert_eq!(n, 0x1111);
+        }
+
+        n.cmovz(0x2222, 0);
+        assert_eq!(n, 0x2222);
+    }
+
+    #[test]
+    fn cmovnz_works() {
+        let mut n = 0x1111u16;
+        n.cmovnz(0x2222, 0);
+        assert_eq!(n, 0x1111);
+
+        for cond in 1..0xFF {
+            let mut n = 0x1111u16;
+            n.cmovnz(0x2222, cond);
+            assert_eq!(n, 0x2222);
+        }
+    }
+}
+
+mod u32 {
+    use cmov::Cmov;
+
+    #[test]
+    fn cmovz_works() {
+        let mut n = 0x11111111u32;
+
+        for cond in 1..0xFF {
+            n.cmovz(0x22222222, cond);
+            assert_eq!(n, 0x11111111);
+        }
+
+        n.cmovz(0x22222222, 0);
+        assert_eq!(n, 0x22222222);
+    }
+
+    #[test]
+    fn cmovnz_works() {
+        let mut n = 0x11111111u32;
+        n.cmovnz(0x22222222, 0);
+        assert_eq!(n, 0x11111111);
+
+        for cond in 1..0xFF {
+            let mut n = 0x11111111u32;
+            n.cmovnz(0x22222222, cond);
+            assert_eq!(n, 0x22222222);
+        }
+    }
+}
+
+mod u64 {
+    use cmov::Cmov;
+
+    #[test]
+    fn cmovz_works() {
+        let mut n = 0x11111111_11111111u64;
+
+        for cond in 1..0xFF {
+            n.cmovz(0x22222222_22222222, cond);
+            assert_eq!(n, 0x11111111_11111111);
+        }
+
+        n.cmovz(0x22222222_22222222, 0);
+        assert_eq!(n, 0x22222222_22222222);
+    }
+
+    #[test]
+    fn cmovnz_works() {
+        let mut n = 0x11111111_11111111u64;
+        n.cmovnz(0x22222222_22222222, 0);
+        assert_eq!(n, 0x11111111_11111111);
+
+        for cond in 1..0xFF {
+            let mut n = 0x11111111_11111111u64;
+            n.cmovnz(0x22222222_22222222, cond);
+            assert_eq!(n, 0x22222222_22222222);
+        }
+    }
+}
+
+mod u128 {
+    use cmov::Cmov;
+
+    #[test]
+    fn cmovz_works() {
+        let mut n = 0x11111111_11111111_22222222_22222222u128;
+
+        for cond in 1..0xFF {
+            n.cmovz(0x22222222_22222222_33333333_33333333, cond);
+            assert_eq!(n, 0x11111111_11111111_22222222_22222222);
+        }
+
+        n.cmovz(0x22222222_22222222_33333333_33333333, 0);
+        assert_eq!(n, 0x22222222_22222222_33333333_33333333);
+    }
+
+    #[test]
+    fn cmovnz_works() {
+        let mut n = 0x11111111_11111111_22222222_22222222u128;
+        n.cmovnz(0x22222222_22222222_33333333_33333333, 0);
+        assert_eq!(n, 0x11111111_11111111_22222222_22222222);
+
+        for cond in 1..0xFF {
+            let mut n = 0x11111111_11111111u128;
+            n.cmovnz(0x22222222_22222222_33333333_33333333, cond);
+            assert_eq!(n, 0x22222222_22222222_33333333_33333333);
+        }
+    }
+}


### PR DESCRIPTION
Replaces the existing API with a `Cmov` trait which is impl'd for all of the unsigned integer types.

On x86 platforms this adds support for using both EAX and RAX integer operands.

Support for `u8` is impl'd generically via upcasting, and support for `u128` is impl'd generically by splitting the value into two `u64`s and doing two selections.

Platform-by-platform support is now split into `aarch64`, `x86`, and `portable` backend modules.