### PR TITLE
fiat-constify: fix rustdoc lint warning in output

### DIFF
--- a/fiat-constify/src/main.rs
+++ b/fiat-constify/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("#![doc = \" fiat-crypto output postprocessed by fiat-constify: https://github.com/rustcrypto/utils\"]");
+    println!("#![doc = \" fiat-crypto output postprocessed by fiat-constify: <https://github.com/rustcrypto/utils>\"]");
     println!("{}", ast.into_token_stream());
     Ok(())
 }


### PR DESCRIPTION
The link to the utils repo should be angle-bracketed to make the rustdoc linter happy.