### PR TITLE
cmov v0.2.0

### DIFF
--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,23 +51,23 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.59.0 # MSRV
+            rust: 1.60.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.59.0 # MSRV
+            rust: 1.60.0 # MSRV
 
           # 64-bit Windows
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
-            rust: 1.59.0 # MSRV
+            rust: 1.60.0 # MSRV
 
           # 64-bit macOS
           - target: x86_64-apple-darwin
             platform: macos-latest
-            rust: 1.59.0 # MSRV
+            rust: 1.60.0 # MSRV
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -89,13 +89,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.59.0 # MSRV
+            rust: 1.60.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.59.0 # MSRV
+            rust: 1.60.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.2.0-pre"
+version = "0.2.0"
 
 [[package]]
 name = "collectable"

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2023-02-26)
+### Added
+- `Condition` alias for `u8` ([#830])
+
+### Changed
+- Redesigned trait-based API ([#830])
+  - Built around a `Cmov` trait
+  - Trait is impl'd for `u8`, `u16`, `u32`, `u64`, `u128`
+  - Accepts a `Condition` (i.e. `u8`) as a predicate
+- MSRV 1.60 ([#839])
+
+[#830]: https://github.com/RustCrypto/utils/pull/830
+[#839]: https://github.com/RustCrypto/utils/pull/839
+
 ## 0.1.1 (2022-03-02)
 ### Added
 - `cmovz`/`cmovnz`-alike support for AArch64 targets ([#744])

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -6,7 +6,7 @@ constant-time and not be rewritten as branches by the compiler.
 Provides wrappers for the CMOV family of instructions on x86/x86_64
 and CSEL on AArch64.
 """
-version = "0.2.0-pre"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/cmov"
@@ -14,4 +14,4 @@ categories = ["cryptography", "hardware-support", "no-std"]
 keywords = ["crypto", "intrinsics"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"

--- a/cmov/README.md
+++ b/cmov/README.md
@@ -1,4 +1,4 @@
-# [RustCrypto]: Conditional Move Intrinsics
+# [RustCrypto]: CMOV (Conditional Move)
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -10,7 +10,8 @@ Conditional move CPU intrinsics which are guaranteed to execute in
 constant-time and not be rewritten as branches by the compiler.
 
 Provides wrappers for the [CMOV family] of instructions on x86/x86_64 and
-the [CSEL] instruction on AArch64 CPUs.
+the [CSEL] instruction on AArch64 CPUs, along with a portable fallback
+implementation for other CPU architectures.
 
 [Documentation][docs-link]
 
@@ -50,7 +51,7 @@ Please open an issue with your desired CPU architecture if this interests you.
 
 ## Minimum Supported Rust Version
 
-Rust **1.59** or newer.
+Rust **1.60** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -78,7 +79,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/cmov/badge.svg
 [docs-link]: https://docs.rs/cmov/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[msrv-image]: https://img.shields.io/badge/rustc-1.59+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/cmov.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/cmov.yml
 

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -17,6 +17,7 @@ mod x86;
 pub type Condition = u8;
 
 /// Conditional move
+// TODO(tarcieri): make one of `cmovz`/`cmovnz` a provided method which calls the other?
 pub trait Cmov {
     /// Move if zero.
     ///


### PR DESCRIPTION
### Added
- `Condition` alias for `u8` ([#830])

### Changed
- Redesigned trait-based API ([#830])
  - Built around a `Cmov` trait
  - Trait is impl'd for `u8`, `u16`, `u32`, `u64`, `u128`
  - Accepts a `Condition` (i.e. `u8`) as a predicate
- MSRV 1.60 ([#839])

[#830]: https://github.com/RustCrypto/utils/pull/830
[#839]: https://github.com/RustCrypto/utils/pull/839