### PR TITLE
CI: use Rust 1.67 for `clippy`

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.59.0 # Highest MSRV in repo
+          toolchain: 1.67.0 # Pinned to prevent breakages
           components: clippy
           override: true
           profile: minimal

--- a/fiat-constify/src/main.rs
+++ b/fiat-constify/src/main.rs
@@ -357,7 +357,7 @@ impl Outputs {
     pub fn to_return_value(&self) -> Stmt {
         let span = Span::call_site();
 
-        let mut elems = self.0.iter().map(|(ident, _)| {
+        let mut elems = self.0.keys().map(|ident| {
             let mut segments = Punctuated::new();
             segments.push(PathSegment {
                 ident: ident.clone(),

--- a/inout/src/inout.rs
+++ b/inout/src/inout.rs
@@ -71,7 +71,7 @@ impl<'inp, 'out, T: Clone> InOut<'inp, 'out, T> {
     /// Clone input value and return it.
     #[inline(always)]
     pub fn clone_in(&self) -> T {
-        unsafe { (&*self.in_ptr).clone() }
+        unsafe { (*self.in_ptr).clone() }
     }
 }
 


### PR DESCRIPTION
This is primarily to unblock #839