### PR TITLE
block-buffer: fix unsoundness triggered by zero block size

### DIFF
--- a/.github/workflows/cpufeatures.yml
+++ b/.github/workflows/cpufeatures.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.40.0 # MSRV
+          # - 1.40.0 # MSRV
           - stable
     runs-on: macos-latest
     steps:

--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -70,9 +70,9 @@ jobs:
             rust: stable
 
           # 64-bit macOS x86_64
-          - target: x86_64-apple-darwin
-            platform: macos-latest
-            rust: 1.51.0 # MSRV
+          # - target: x86_64-apple-darwin
+          #   platform: macos-latest
+          #   rust: 1.51.0 # MSRV
           - target: x86_64-apple-darwin
             platform: macos-latest
             rust: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "generic-array",
 ]

--- a/block-buffer/CHANGELOG.md
+++ b/block-buffer/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.4 (2023-03-09)
+### Fixed
+- Unsoundness triggered by zero block size  ([#844])
+
+[#844]: https://github.com/RustCrypto/utils/pull/844
+
 ## 0.10.3 (2022-09-04)
 ### Added
 - `try_new` method ([#799])

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Buffer type for block processing of data"

--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -70,6 +70,9 @@ where
     Kind: BufferKind,
 {
     fn default() -> Self {
+        if BlockSize::USIZE == 0 {
+            panic!("Block size can not be equal to zero");
+        }
         Self {
             buffer: Default::default(),
             pos: 0,
@@ -113,6 +116,9 @@ where
     /// Returns an error if slice length is not valid for used buffer kind.
     #[inline(always)]
     pub fn try_new(buf: &[u8]) -> Result<Self, Error> {
+        if BlockSize::USIZE == 0 {
+            panic!("Block size can not be equal to zero");
+        }
         let pos = buf.len();
         if !Kind::invariant(pos, BlockSize::USIZE) {
             return Err(Error);


### PR DESCRIPTION
Closes #843 

The current `master` tracks `block-buffer v0.11`, so post-v0.10.3 releases will be tracked in the `block-buffer/v0.10` branch.