### PR TITLE
cpufeatures: Support dynamic feature detection on iOS and derivative platforms

### DIFF
--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["no-std"]
 edition = "2018"
 readme = "README.md"
 
-[target.aarch64-apple-darwin.dependencies]
+[target.'cfg(all(target_arch = "aarch64", target_vendor = "apple"))'.dependencies]
 libc = "0.2.95"
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]

--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -37,8 +37,8 @@ pub fn getauxval_hwcap() -> u64 {
     unsafe { libc::getauxval(libc::AT_HWCAP) }
 }
 
-// MacOS runtime detection of target CPU features using `sysctlbyname`.
-#[cfg(target_os = "macos")]
+// Apple platform's runtime detection of target CPU features using `sysctlbyname`.
+#[cfg(target_vendor = "apple")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __detect_target_features {
@@ -87,7 +87,7 @@ pub mod hwcaps {
     pub const SHA3: c_ulong = libc::HWCAP_SHA3 | libc::HWCAP_SHA512;
 }
 
-// macOS `check!` macro.
+// Apple OS (macOS, iOS, watchOS, and tvOS) `check!` macro.
 //
 // NOTE: several of these instructions (e.g. `aes`, `sha2`) can be assumed to
 // be present on all Apple ARM64 hardware.
@@ -98,7 +98,7 @@ pub mod hwcaps {
 //
 // See discussion on this issue for more information:
 // <https://github.com/RustCrypto/utils/issues/378>
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! check {
@@ -117,8 +117,8 @@ macro_rules! check {
     };
 }
 
-/// macOS helper function for calling `sysctlbyname`.
-#[cfg(target_os = "macos")]
+/// Apple helper function for calling `sysctlbyname`.
+#[cfg(target_vendor = "apple")]
 pub unsafe fn sysctlbyname(name: &[u8]) -> bool {
     assert_eq!(
         name.last().cloned(),
@@ -143,36 +143,8 @@ pub unsafe fn sysctlbyname(name: &[u8]) -> bool {
     value != 0
 }
 
-// iOS `check!` macro.
-//
-// Unfortunately iOS does not provide access to the `sysctl(3)` API which means
-// we can only return static values for CPU features which  can be assumed to
-// be present on all Apple ARM64 hardware.
-//
-// See discussion on this issue for more information:
-// <https://github.com/RustCrypto/utils/issues/378>
-#[cfg(target_os = "ios")]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! check {
-    ("aes") => {
-        true
-    };
-    ("sha2") => {
-        true
-    };
-    ("sha3") => {
-        false
-    };
-}
-
 // On other targets, runtime CPU feature detection is unavailable
-#[cfg(not(any(
-    target_os = "ios",
-    target_os = "linux",
-    target_os = "android",
-    target_os = "macos"
-)))]
+#[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android",)))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __detect_target_features {


### PR DESCRIPTION
This PR adds support for dynamic feature detection on iOS, watchOS, and tvOS, bringing full support to all of Apple's platforms and following up https://github.com/RustCrypto/utils/pull/435.

I'm not entirely sure what the previous comment about lack of `sysctl(3)` support meant, FWIW. iOS supports the same kernel calls that macOS does (for the most part, but especially low-level ones like this) because they're based on the same kernel and, more importantly, the function appears in the public headers inside each platform's SDK.

To confirm/prove that there wasn't any problematic filtering occurring on iOS, I ran these changes on both the iOS simulator and on a real device (iPad Pro 3rd gen). The results make sense AFAICT because this specific model runs a full-fledged M1 processor in it.

Test code:
```rust
cpufeatures::new!(armcaps, "aes", "sha2", "sha3");

let feature_set = armcaps::init();
if feature_set.get() {
    log::info!("we had support for AES, SHA2, and SHA3 instructions")
} else {
   log::info!("no support for SHA3");
}
```

Results in iOS simulator:
```
INFO  2023-03-16T22:20:04.778 ThreadId(1) we had support for AES, SHA2, and SHA3 instructions
```

Results on physical device:
```
INFO  2023-03-16T22:33:11.875 ThreadId(1) we had support for AES, SHA2, and SHA3 instructions
```