### PR TITLE
cmov: add `miri` support by forcing the `portable` backend

### DIFF
--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -6,10 +6,15 @@
 )]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
+#[cfg(not(miri))]
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
-#[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(
+    not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")),
+    miri
+))]
 mod portable;
+#[cfg(not(miri))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
 


### PR DESCRIPTION
I'm not too sure if these `cfg`s are the most optimised - feel free to request any adjustments!

Currently `miri` doesn't have support for inline ASM, so any usage of the `cmov` crate (on inline ASM-utilising architectures) causes a failure. I scoured `miri`'s docs for a solution, but this also works.

I have tested these changes locally - all architectures build, and `miri` works too!

I'm unsure whether or not this should be included in the README, it wasn't [here](https://github.com/RustCrypto/utils/commit/8e74aa5b4bd2d1f7c3428649b7c9578592f10f0b) but it's no hassle either way.