### PR TITLE
zeroize: 2021 edition upgrade; MSRV 1.56

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -36,8 +36,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
@@ -52,7 +50,7 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -62,16 +60,15 @@ jobs:
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
 
           # 64-bit macOS x86_64
-          # TODO(tarcieri): try re-enabling this when we bump MSRV
-          # - target: x86_64-apple-darwin
-          #  platform: macos-latest
-          #  rust: 1.51.0 # MSRV
+          - target: x86_64-apple-darwin
+            platform: macos-latest
+            rust: 1.56.0 # MSRV
           - target: x86_64-apple-darwin
             platform: macos-latest
             rust: stable
@@ -79,7 +76,7 @@ jobs:
           # 64-bit Windows
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
             rust: stable
@@ -91,8 +88,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }}
       - run: cargo test --target ${{ matrix.target }} --all-features
@@ -116,7 +111,5 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cross-install@master
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cross test --target ${{ matrix.target }} --features aarch64
       - run: cross test --target ${{ matrix.target }} --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0-pre"
 dependencies = [
  "serde",
  "zeroize_derive",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.0-pre"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "zeroize"
+version = "1.6.0-pre"
 description = """
 Securely clear secrets from memory with a simple trait built on
 stable Rust primitives which guarantee memory is zeroed using an
@@ -7,18 +8,18 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version = "1.5.7"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"
 readme = "README.md"
 categories = ["cryptography", "memory-management", "no-std", "os"]
 keywords = ["memory", "memset", "secure", "volatile", "zero"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }
-zeroize_derive = { version = "1.3", path = "derive", optional = true }
+zeroize_derive = { version = "=1.4.0-pre", path = "derive", optional = true }
 
 [features]
 default = ["alloc"]

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -36,7 +36,7 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -64,7 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/zeroize/badge.svg
 [docs-link]: https://docs.rs/zeroize/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml
 

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.3.3"
+version = "1.4.0-pre"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"
 readme = "README.md"
 categories = ["cryptography", "memory-management", "no-std", "os"]
 keywords = ["memory", "memset", "secure", "volatile", "zero"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/zeroize/derive/README.md
+++ b/zeroize/derive/README.md
@@ -13,7 +13,7 @@ See [zeroize] crate for documentation.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -39,7 +39,7 @@ dual licensed as above, without any additional terms or conditions.
 [crate-image]: https://img.shields.io/crates/v/zeroize_derive.svg
 [crate-link]: https://crates.io/crates/zeroize_derive
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml
 


### PR DESCRIPTION
Since #858 needs MSRV 1.56 anyway, this goes ahead and bumps the edition for `zeroize` and `zeroize_derive` to 2021.

This also lets us remove a number of hacks in CI, including commented-out tests.