### PR TITLE
cmov: make `Cmov::cmovz` a provided method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.2.0"
+version = "0.3.0-pre"
 
 [[package]]
 name = "collectable"

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -6,7 +6,7 @@ constant-time and not be rewritten as branches by the compiler.
 Provides wrappers for the CMOV family of instructions on x86/x86_64
 and CSEL on AArch64.
 """
-version = "0.2.0"
+version = "0.3.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/cmov"

--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -19,23 +19,23 @@ macro_rules! csel {
 
 impl Cmov for u16 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
         csel!(
             "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, EQ",
+            "csel {1:w}, {2:w}, {3:w}, NE",
             self,
-            value,
+            *value,
             condition
         );
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
         csel!(
             "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, NE",
+            "csel {1:w}, {2:w}, {3:w}, EQ",
             self,
-            value,
+            *value,
             condition
         );
     }
@@ -43,23 +43,23 @@ impl Cmov for u16 {
 
 impl Cmov for u32 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
         csel!(
             "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, EQ",
+            "csel {1:w}, {2:w}, {3:w}, NE",
             self,
-            value,
+            *value,
             condition
         );
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
         csel!(
             "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, NE",
+            "csel {1:w}, {2:w}, {3:w}, EQ",
             self,
-            value,
+            *value,
             condition
         );
     }
@@ -67,23 +67,23 @@ impl Cmov for u32 {
 
 impl Cmov for u64 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
         csel!(
             "cmp {0:x}, 0",
-            "csel {1:x}, {2:x}, {3:x}, EQ",
+            "csel {1:x}, {2:x}, {3:x}, NE",
             self,
-            value,
+            *value,
             condition
         );
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
         csel!(
             "cmp {0:x}, 0",
-            "csel {1:x}, {2:x}, {3:x}, NE",
+            "csel {1:x}, {2:x}, {3:x}, EQ",
             self,
-            value,
+            *value,
             condition
         );
     }

--- a/cmov/src/portable.rs
+++ b/cmov/src/portable.rs
@@ -10,47 +10,47 @@ use crate::{Cmov, Condition};
 
 impl Cmov for u16 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
-        tmp.cmovz(value as u64, condition);
+        tmp.cmovnz(&(*value as u64), condition);
         *self = tmp as u16;
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
-        tmp.cmovnz(value as u64, condition);
+        tmp.cmovz(&(*value as u64), condition);
         *self = tmp as u16;
     }
 }
 
 impl Cmov for u32 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
-        tmp.cmovz(value as u64, condition);
+        tmp.cmovnz(&(*value as u64), condition);
         *self = tmp as u32;
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
-        tmp.cmovnz(value as u64, condition);
+        tmp.cmovz(&(*value as u64), condition);
         *self = tmp as u32;
     }
 }
 
 impl Cmov for u64 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
-        let mask = (1 ^ is_non_zero(condition)).wrapping_sub(1);
-        *self = (*self & mask) | (value & !mask);
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
+        let mask = is_non_zero(condition).wrapping_sub(1);
+        *self = (*self & mask) | (*value & !mask);
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
-        let mask = is_non_zero(condition).wrapping_sub(1);
-        *self = (*self & mask) | (value & !mask);
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
+        let mask = (1 ^ is_non_zero(condition)).wrapping_sub(1);
+        *self = (*self & mask) | (*value & !mask);
     }
 }
 

--- a/cmov/src/x86.rs
+++ b/cmov/src/x86.rs
@@ -27,62 +27,62 @@ macro_rules! cmov {
 
 impl Cmov for u16 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
-        cmov!("cmovz {1:e}, {2:e}", self, value, condition);
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
+        cmov!("cmovnz {1:e}, {2:e}", self, *value, condition);
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
-        cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
+        cmov!("cmovz {1:e}, {2:e}", self, *value, condition);
     }
 }
 
 impl Cmov for u32 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
-        cmov!("cmovz {1:e}, {2:e}", self, value, condition);
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
+        cmov!("cmovnz {1:e}, {2:e}", self, *value, condition);
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
-        cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-impl Cmov for u64 {
-    #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
-        cmov!("cmovz {1:r}, {2:r}", self, value, condition);
-    }
-
-    #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
-        cmov!("cmovnz {1:r}, {2:r}", self, value, condition);
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
+        cmov!("cmovz {1:e}, {2:e}", self, *value, condition);
     }
 }
 
 #[cfg(target_arch = "x86")]
 impl Cmov for u64 {
     #[inline(always)]
-    fn cmovz(&mut self, value: Self, condition: Condition) {
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut lo = (*self & u32::MAX as u64) as u32;
         let mut hi = (*self >> 32) as u32;
 
-        lo.cmovz((value & u32::MAX as u64) as u32, condition);
-        hi.cmovz((value >> 32) as u32, condition);
+        lo.cmovnz(&((*value & u32::MAX as u64) as u32), condition);
+        hi.cmovnz(&((*value >> 32) as u32), condition);
 
         *self = (lo as u64) | (hi as u64) << 32;
     }
 
     #[inline(always)]
-    fn cmovnz(&mut self, value: Self, condition: Condition) {
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut lo = (*self & u32::MAX as u64) as u32;
         let mut hi = (*self >> 32) as u32;
 
-        lo.cmovnz((value & u32::MAX as u64) as u32, condition);
-        hi.cmovnz((value >> 32) as u32, condition);
+        lo.cmovz(&((*value & u32::MAX as u64) as u32), condition);
+        hi.cmovz(&((*value >> 32) as u32), condition);
 
         *self = (lo as u64) | (hi as u64) << 32;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Cmov for u64 {
+    #[inline(always)]
+    fn cmovnz(&mut self, value: &Self, condition: Condition) {
+        cmov!("cmovnz {1:r}, {2:r}", self, *value, condition);
+    }
+
+    #[inline(always)]
+    fn cmovz(&mut self, value: &Self, condition: Condition) {
+        cmov!("cmovz {1:r}, {2:r}", self, *value, condition);
     }
 }

--- a/cmov/tests/lib.rs
+++ b/cmov/tests/lib.rs
@@ -6,23 +6,23 @@ mod u8 {
         let mut n = 0x11u8;
 
         for cond in 1..0xFF {
-            n.cmovz(0x22, cond);
+            n.cmovz(&0x22, cond);
             assert_eq!(n, 0x11);
         }
 
-        n.cmovz(0x22, 0);
+        n.cmovz(&0x22, 0);
         assert_eq!(n, 0x22);
     }
 
     #[test]
     fn cmovnz_works() {
         let mut n = 0x11u8;
-        n.cmovnz(0x22, 0);
+        n.cmovnz(&0x22, 0);
         assert_eq!(n, 0x11);
 
         for cond in 1..0xFF {
             let mut n = 0x11u8;
-            n.cmovnz(0x22, cond);
+            n.cmovnz(&0x22, cond);
             assert_eq!(n, 0x22);
         }
     }
@@ -36,23 +36,23 @@ mod u16 {
         let mut n = 0x1111u16;
 
         for cond in 1..0xFF {
-            n.cmovz(0x2222, cond);
+            n.cmovz(&0x2222, cond);
             assert_eq!(n, 0x1111);
         }
 
-        n.cmovz(0x2222, 0);
+        n.cmovz(&0x2222, 0);
         assert_eq!(n, 0x2222);
     }
 
     #[test]
     fn cmovnz_works() {
         let mut n = 0x1111u16;
-        n.cmovnz(0x2222, 0);
+        n.cmovnz(&0x2222, 0);
         assert_eq!(n, 0x1111);
 
         for cond in 1..0xFF {
             let mut n = 0x1111u16;
-            n.cmovnz(0x2222, cond);
+            n.cmovnz(&0x2222, cond);
             assert_eq!(n, 0x2222);
         }
     }
@@ -66,23 +66,23 @@ mod u32 {
         let mut n = 0x11111111u32;
 
         for cond in 1..0xFF {
-            n.cmovz(0x22222222, cond);
+            n.cmovz(&0x22222222, cond);
             assert_eq!(n, 0x11111111);
         }
 
-        n.cmovz(0x22222222, 0);
+        n.cmovz(&0x22222222, 0);
         assert_eq!(n, 0x22222222);
     }
 
     #[test]
     fn cmovnz_works() {
         let mut n = 0x11111111u32;
-        n.cmovnz(0x22222222, 0);
+        n.cmovnz(&0x22222222, 0);
         assert_eq!(n, 0x11111111);
 
         for cond in 1..0xFF {
             let mut n = 0x11111111u32;
-            n.cmovnz(0x22222222, cond);
+            n.cmovnz(&0x22222222, cond);
             assert_eq!(n, 0x22222222);
         }
     }
@@ -96,23 +96,23 @@ mod u64 {
         let mut n = 0x1111_1111_1111_1111_u64;
 
         for cond in 1..0xFF {
-            n.cmovz(0x2222_2222_2222_2222, cond);
+            n.cmovz(&0x2222_2222_2222_2222, cond);
             assert_eq!(n, 0x1111_1111_1111_1111);
         }
 
-        n.cmovz(0x2222_2222_2222_2222, 0);
+        n.cmovz(&0x2222_2222_2222_2222, 0);
         assert_eq!(n, 0x2222_2222_2222_2222);
     }
 
     #[test]
     fn cmovnz_works() {
         let mut n = 0x1111_1111_1111_1111_u64;
-        n.cmovnz(0x2222_2222_2222_2222, 0);
+        n.cmovnz(&0x2222_2222_2222_2222, 0);
         assert_eq!(n, 0x1111_1111_1111_1111);
 
         for cond in 1..0xFF {
             let mut n = 0x1111_1111_1111_1111_u64;
-            n.cmovnz(0x2222_2222_2222_2222, cond);
+            n.cmovnz(&0x2222_2222_2222_2222, cond);
             assert_eq!(n, 0x2222_2222_2222_2222);
         }
     }
@@ -126,23 +126,23 @@ mod u128 {
         let mut n = 0x1111_1111_1111_1111_2222_2222_2222_2222_u128;
 
         for cond in 1..0xFF {
-            n.cmovz(0x2222_2222_2222_2222_3333_3333_3333_3333, cond);
+            n.cmovz(&0x2222_2222_2222_2222_3333_3333_3333_3333, cond);
             assert_eq!(n, 0x1111_1111_1111_1111_2222_2222_2222_2222);
         }
 
-        n.cmovz(0x2222_2222_2222_2222_3333_3333_3333_3333, 0);
+        n.cmovz(&0x2222_2222_2222_2222_3333_3333_3333_3333, 0);
         assert_eq!(n, 0x2222_2222_2222_2222_3333_3333_3333_3333);
     }
 
     #[test]
     fn cmovnz_works() {
         let mut n = 0x1111_1111_1111_1111_2222_2222_2222_2222_u128;
-        n.cmovnz(0x2222_2222_2222_2222_3333_3333_3333_3333, 0);
+        n.cmovnz(&0x2222_2222_2222_2222_3333_3333_3333_3333, 0);
         assert_eq!(n, 0x1111_1111_1111_1111_2222_2222_2222_2222);
 
         for cond in 1..0xFF {
             let mut n = 0x1111_1111_1111_1111_u128;
-            n.cmovnz(0x2222_2222_2222_2222_3333_3333_3333_3333, cond);
+            n.cmovnz(&0x2222_2222_2222_2222_3333_3333_3333_3333, cond);
             assert_eq!(n, 0x2222_2222_2222_2222_3333_3333_3333_3333);
         }
     }


### PR DESCRIPTION
This makes it easier to implement the `Cmov` trait for foreign types.

It additionally makes the `value` argument an `&Self` reference, which should make it easier to impl the trait for non-`Copy` types where it's desirable to avoid a move.

Note: breaking change