### PR TITLE
cmov: implement constant-time equality comparisons

### DIFF
--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -2,10 +2,10 @@ use crate::{Cmov, CmovEq, Condition};
 use core::arch::asm;
 
 macro_rules! csel {
-    ($cmp:expr, $csel:expr, $dst:expr, $src:expr, $condition:expr) => {
+    ($csel:expr, $dst:expr, $src:expr, $condition:expr) => {
         unsafe {
             asm! {
-                $cmp,
+                "cmp {0:w}, 0",
                 $csel,
                 in(reg) $condition,
                 inlateout(reg) *$dst,
@@ -42,24 +42,12 @@ macro_rules! csel_eq {
 impl Cmov for u16 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        csel!(
-            "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, NE",
-            self,
-            *value,
-            condition
-        );
+        csel!("csel {1:w}, {2:w}, {3:w}, NE", self, *value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        csel!(
-            "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, EQ",
-            self,
-            *value,
-            condition
-        );
+        csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, *value, condition);
     }
 }
 
@@ -76,24 +64,12 @@ impl CmovEq for u16 {
 impl Cmov for u32 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        csel!(
-            "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, NE",
-            self,
-            *value,
-            condition
-        );
+        csel!("csel {1:w}, {2:w}, {3:w}, NE", self, *value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        csel!(
-            "cmp {0:w}, 0",
-            "csel {1:w}, {2:w}, {3:w}, EQ",
-            self,
-            *value,
-            condition
-        );
+        csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, *value, condition);
     }
 }
 
@@ -110,24 +86,12 @@ impl CmovEq for u32 {
 impl Cmov for u64 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        csel!(
-            "cmp {0:x}, 0",
-            "csel {1:x}, {2:x}, {3:x}, NE",
-            self,
-            *value,
-            condition
-        );
+        csel!("csel {1:x}, {2:x}, {3:x}, NE", self, *value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        csel!(
-            "cmp {0:x}, 0",
-            "csel {1:x}, {2:x}, {3:x}, EQ",
-            self,
-            *value,
-            condition
-        );
+        csel!("csel {1:x}, {2:x}, {3:x}, EQ", self, *value, condition);
     }
 }
 

--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -52,10 +52,12 @@ impl Cmov for u16 {
 }
 
 impl CmovEq for u16 {
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
     }
 
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }
@@ -74,10 +76,12 @@ impl Cmov for u32 {
 }
 
 impl CmovEq for u32 {
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
     }
 
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }
@@ -96,10 +100,12 @@ impl Cmov for u64 {
 }
 
 impl CmovEq for u64 {
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
     }
 
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }

--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -9,7 +9,7 @@ macro_rules! csel {
                 $csel,
                 in(reg) $condition,
                 inlateout(reg) *$dst,
-                in(reg) $src,
+                in(reg) *$src,
                 in(reg) *$dst,
                 options(pure, nomem, nostack),
             };
@@ -42,12 +42,12 @@ macro_rules! csel_eq {
 impl Cmov for u16 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        csel!("csel {1:w}, {2:w}, {3:w}, NE", self, *value, condition);
+        csel!("csel {1:w}, {2:w}, {3:w}, NE", self, value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, *value, condition);
+        csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, value, condition);
     }
 }
 
@@ -64,12 +64,12 @@ impl CmovEq for u16 {
 impl Cmov for u32 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        csel!("csel {1:w}, {2:w}, {3:w}, NE", self, *value, condition);
+        csel!("csel {1:w}, {2:w}, {3:w}, NE", self, value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, *value, condition);
+        csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, value, condition);
     }
 }
 
@@ -86,12 +86,12 @@ impl CmovEq for u32 {
 impl Cmov for u64 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        csel!("csel {1:x}, {2:x}, {3:x}, NE", self, *value, condition);
+        csel!("csel {1:x}, {2:x}, {3:x}, NE", self, value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        csel!("csel {1:x}, {2:x}, {3:x}, EQ", self, *value, condition);
+        csel!("csel {1:x}, {2:x}, {3:x}, EQ", self, value, condition);
     }
 }
 

--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -24,7 +24,7 @@ macro_rules! csel_eq {
             asm! {
                 "eor {0:w}, {1:w}, {2:w}",
                 "cmp {0:w}, 0",
-                "csel {3:w}, {4:w}, {5:w}, NE",
+                $instruction,
                 out(reg) _,
                 in(reg) *$lhs,
                 in(reg) *$rhs,
@@ -65,7 +65,11 @@ impl Cmov for u16 {
 
 impl CmovEq for u16 {
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        csel_eq!("csel {2:w}, {3:w}, {4:w}, NE", self, rhs, input, output);
+        csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
+    }
+
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }
 }
 
@@ -95,7 +99,11 @@ impl Cmov for u32 {
 
 impl CmovEq for u32 {
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        csel_eq!("csel {2:w}, {3:w}, {4:w}, NE", self, rhs, input, output);
+        csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
+    }
+
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }
 }
 
@@ -125,6 +133,10 @@ impl Cmov for u64 {
 
 impl CmovEq for u64 {
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        csel_eq!("csel {2:w}, {3:w}, {4:w}, NE", self, rhs, input, output);
+        csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
+    }
+
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }
 }

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -76,10 +76,12 @@ impl Cmov for u8 {
 }
 
 impl CmovEq for u8 {
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u16).cmoveq(&(*rhs as u16), input, output);
     }
 
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u16).cmovne(&(*rhs as u16), input, output);
     }

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -41,6 +41,25 @@ pub trait Cmov {
     }
 }
 
+///
+pub trait CmovEq {
+    /// Move if both inputs are equal.
+    ///
+    /// Uses a `xor` instruction to compare the two values, and
+    /// conditionally moves `input` to `output` when they are equal.
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        let mut tmp = 1u8;
+        self.cmovne(rhs, 0u8, &mut tmp);
+        tmp.cmovne(&0u8, input, output);
+    }
+
+    /// Move if both inputs are not equal.
+    ///
+    /// Uses a `xor` instruction to compare the two values, and
+    /// conditionally moves `input` to `output` when they are not equal.
+    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition);
+}
+
 impl Cmov for u8 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
@@ -54,6 +73,16 @@ impl Cmov for u8 {
         let mut tmp = *self as u16;
         tmp.cmovz(&(*value as u16), condition);
         *self = tmp as u8;
+    }
+}
+
+impl CmovEq for u8 {
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        (*self as u16).cmoveq(&(*rhs as u16), input, output);
+    }
+
+    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        (*self as u16).cmovne(&(*rhs as u16), input, output);
     }
 }
 
@@ -78,5 +107,29 @@ impl Cmov for u128 {
         hi.cmovz(&((*value >> 64) as u64), condition);
 
         *self = (lo as u128) | (hi as u128) << 64;
+    }
+}
+
+impl CmovEq for u128 {
+    #[inline(always)]
+    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        let lo = (*self & u64::MAX as u128) as u64;
+        let hi = (*self >> 64) as u64;
+
+        let mut tmp = 1u8;
+        lo.cmovne(&((*rhs & u64::MAX as u128) as u64), 0, &mut tmp);
+        hi.cmovne(&((*rhs >> 64) as u64), 0, &mut tmp);
+        tmp.cmoveq(&0, input, output);
+    }
+
+    #[inline(always)]
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        let lo = (*self & u64::MAX as u128) as u64;
+        let hi = (*self >> 64) as u64;
+
+        let mut tmp = 1u8;
+        lo.cmovne(&((*rhs & u64::MAX as u128) as u64), 0, &mut tmp);
+        hi.cmovne(&((*rhs >> 64) as u64), 0, &mut tmp);
+        tmp.cmoveq(&1, input, output);
     }
 }

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -22,7 +22,6 @@ mod x86;
 pub type Condition = u8;
 
 /// Conditional move
-// TODO(tarcieri): make one of `cmovz`/`cmovnz` a provided method which calls the other?
 pub trait Cmov {
     /// Move if non-zero.
     ///
@@ -41,7 +40,7 @@ pub trait Cmov {
     }
 }
 
-///
+/// Conditional move with equality comparison
 pub trait CmovEq {
     /// Move if both inputs are equal.
     ///

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -46,17 +46,17 @@ pub trait CmovEq {
     ///
     /// Uses a `xor` instruction to compare the two values, and
     /// conditionally moves `input` to `output` when they are equal.
-    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        let mut tmp = 1u8;
-        self.cmovne(rhs, 0u8, &mut tmp);
-        tmp.cmovne(&0u8, input, output);
-    }
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition);
 
     /// Move if both inputs are not equal.
     ///
     /// Uses a `xor` instruction to compare the two values, and
     /// conditionally moves `input` to `output` when they are not equal.
-    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition);
+    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        let mut tmp = 1u8;
+        self.cmoveq(rhs, 0u8, &mut tmp);
+        tmp.cmoveq(&1u8, input, output);
+    }
 }
 
 impl Cmov for u8 {

--- a/cmov/src/portable.rs
+++ b/cmov/src/portable.rs
@@ -6,7 +6,7 @@
 
 // TODO(tarcieri): more optimized implementation for small integers
 
-use crate::{Cmov, Condition};
+use crate::{Cmov, CmovEq, Condition};
 
 impl Cmov for u16 {
     #[inline(always)]
@@ -21,6 +21,16 @@ impl Cmov for u16 {
         let mut tmp = *self as u64;
         tmp.cmovz(&(*value as u64), condition);
         *self = tmp as u16;
+    }
+}
+
+impl CmovEq for u16 {
+    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        (*self as u64).cmovne(&(*rhs as u64), input, output);
+    }
+
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        (*self as u64).cmoveq(&(*rhs as u64), input, output);
     }
 }
 
@@ -40,6 +50,16 @@ impl Cmov for u32 {
     }
 }
 
+impl CmovEq for u32 {
+    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        (*self as u64).cmovne(&(*rhs as u64), input, output);
+    }
+
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        (*self as u64).cmoveq(&(*rhs as u64), input, output);
+    }
+}
+
 impl Cmov for u64 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
@@ -51,6 +71,16 @@ impl Cmov for u64 {
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mask = (1 ^ is_non_zero(condition)).wrapping_sub(1);
         *self = (*self & mask) | (*value & !mask);
+    }
+}
+
+impl CmovEq for u64 {
+    fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        output.cmovnz(&input, (self ^ rhs) as u8);
+    }
+
+    fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
+        output.cmovz(&input, (self ^ rhs) as u8);
     }
 }
 

--- a/cmov/src/portable.rs
+++ b/cmov/src/portable.rs
@@ -25,10 +25,12 @@ impl Cmov for u16 {
 }
 
 impl CmovEq for u16 {
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmovne(&(*rhs as u64), input, output);
     }
 
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmoveq(&(*rhs as u64), input, output);
     }
@@ -51,10 +53,12 @@ impl Cmov for u32 {
 }
 
 impl CmovEq for u32 {
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmovne(&(*rhs as u64), input, output);
     }
 
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmoveq(&(*rhs as u64), input, output);
     }
@@ -75,10 +79,12 @@ impl Cmov for u64 {
 }
 
 impl CmovEq for u64 {
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovnz(&input, (self ^ rhs) as u8);
     }
 
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovz(&input, (self ^ rhs) as u8);
     }

--- a/cmov/src/x86.rs
+++ b/cmov/src/x86.rs
@@ -18,7 +18,7 @@ macro_rules! cmov {
                 $instruction,
                 in(reg_byte) $condition,
                 inlateout(reg) *$dst,
-                in(reg) $src,
+                in(reg) *$src,
                 options(pure, nomem, nostack),
             };
         }
@@ -32,8 +32,8 @@ macro_rules! cmov_eq {
             asm! {
                 "xor {0:e}, {1:e}",
                 $instruction,
-                in(reg) $lhs,
-                in(reg) $rhs,
+                in(reg) *$lhs,
+                in(reg) *$rhs,
                 inlateout(reg) tmp,
                 in(reg) $condition as u16,
                 options(pure, nomem, nostack),
@@ -46,44 +46,44 @@ macro_rules! cmov_eq {
 impl Cmov for u16 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        cmov!("cmovnz {1:e}, {2:e}", self, *value, condition);
+        cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        cmov!("cmovz {1:e}, {2:e}", self, *value, condition);
+        cmov!("cmovz {1:e}, {2:e}", self, value, condition);
     }
 }
 
 impl CmovEq for u16 {
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovz {2:e}, {3:e}", *self, *rhs, input, output);
+        cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
     }
 
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovnz {2:e}, {3:e}", *self, *rhs, input, output);
+        cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
     }
 }
 
 impl Cmov for u32 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        cmov!("cmovnz {1:e}, {2:e}", self, *value, condition);
+        cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        cmov!("cmovz {1:e}, {2:e}", self, *value, condition);
+        cmov!("cmovz {1:e}, {2:e}", self, value, condition);
     }
 }
 
 impl CmovEq for u32 {
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovz {2:e}, {3:e}", *self, *rhs, input, output);
+        cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
     }
 
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovnz {2:e}, {3:e}", *self, *rhs, input, output);
+        cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
     }
 }
 
@@ -141,22 +141,22 @@ impl CmovEq for u64 {
 impl Cmov for u64 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
-        cmov!("cmovnz {1:r}, {2:r}", self, *value, condition);
+        cmov!("cmovnz {1:r}, {2:r}", self, value, condition);
     }
 
     #[inline(always)]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
-        cmov!("cmovz {1:r}, {2:r}", self, *value, condition);
+        cmov!("cmovz {1:r}, {2:r}", self, value, condition);
     }
 }
 
 #[cfg(target_arch = "x86_64")]
 impl CmovEq for u64 {
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovz {2:e}, {3:e}", *self, *rhs, input, output);
+        cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
     }
 
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovnz {2:e}, {3:e}", *self, *rhs, input, output);
+        cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
     }
 }

--- a/cmov/src/x86.rs
+++ b/cmov/src/x86.rs
@@ -56,10 +56,12 @@ impl Cmov for u16 {
 }
 
 impl CmovEq for u16 {
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
     }
 
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
     }
@@ -78,10 +80,12 @@ impl Cmov for u32 {
 }
 
 impl CmovEq for u32 {
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
     }
 
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
     }
@@ -152,10 +156,12 @@ impl Cmov for u64 {
 
 #[cfg(target_arch = "x86_64")]
 impl CmovEq for u64 {
+    #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
     }
 
+    #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
     }

--- a/cmov/src/x86.rs
+++ b/cmov/src/x86.rs
@@ -25,24 +25,6 @@ macro_rules! cmov {
     };
 }
 
-macro_rules! cmov_eq {
-    ($instruction:expr, $lhs:expr, $rhs:expr, $condition:expr, $dst:expr) => {
-        let mut tmp = *$dst as u16;
-        unsafe {
-            asm! {
-                "xor {0:e}, {1:e}",
-                $instruction,
-                in(reg) *$lhs,
-                in(reg) *$rhs,
-                inlateout(reg) tmp,
-                in(reg) $condition as u16,
-                options(pure, nomem, nostack),
-            };
-        };
-        *$dst = tmp as u8;
-    };
-}
-
 impl Cmov for u16 {
     #[inline(always)]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
@@ -58,12 +40,12 @@ impl Cmov for u16 {
 impl CmovEq for u16 {
     #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
+        output.cmovz(&input, (self ^ rhs) as u8);
     }
 
     #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
+        output.cmovnz(&input, (self ^ rhs) as u8);
     }
 }
 
@@ -82,12 +64,12 @@ impl Cmov for u32 {
 impl CmovEq for u32 {
     #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
+        output.cmovz(&input, (self ^ rhs) as u8);
     }
 
     #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
+        output.cmovnz(&input, (self ^ rhs) as u8);
     }
 }
 
@@ -158,11 +140,11 @@ impl Cmov for u64 {
 impl CmovEq for u64 {
     #[inline(always)]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovz {2:e}, {3:e}", self, rhs, input, output);
+        output.cmovz(&input, (self ^ rhs) as u8);
     }
 
     #[inline(always)]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
-        cmov_eq!("cmovnz {2:e}, {3:e}", self, rhs, input, output);
+        output.cmovnz(&input, (self ^ rhs) as u8);
     }
 }

--- a/cmov/tests/lib.rs
+++ b/cmov/tests/lib.rs
@@ -1,149 +1,334 @@
 mod u8 {
-    use cmov::Cmov;
+    use cmov::{Cmov, CmovEq};
+
+    pub const U8_A: u8 = 0x11;
+    pub const U8_B: u8 = 0x22;
 
     #[test]
     fn cmovz_works() {
-        let mut n = 0x11u8;
+        let mut n = U8_A;
 
         for cond in 1..0xFF {
-            n.cmovz(&0x22, cond);
-            assert_eq!(n, 0x11);
+            n.cmovz(&U8_B, cond);
+            assert_eq!(n, U8_A);
         }
 
-        n.cmovz(&0x22, 0);
-        assert_eq!(n, 0x22);
+        n.cmovz(&U8_B, 0);
+        assert_eq!(n, U8_B);
     }
 
     #[test]
     fn cmovnz_works() {
-        let mut n = 0x11u8;
-        n.cmovnz(&0x22, 0);
-        assert_eq!(n, 0x11);
+        let mut n = U8_A;
+        n.cmovnz(&U8_B, 0);
+        assert_eq!(n, U8_A);
 
         for cond in 1..0xFF {
-            let mut n = 0x11u8;
-            n.cmovnz(&0x22, cond);
-            assert_eq!(n, 0x22);
+            let mut n = U8_A;
+            n.cmovnz(&U8_B, cond);
+            assert_eq!(n, U8_B);
         }
+    }
+
+    #[test]
+    fn cmoveq_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu8 {
+            cond.cmoveq(&cond, cond, &mut o);
+            assert_eq!(o, cond);
+            cond.cmoveq(&0, 0, &mut o);
+            assert_eq!(o, cond);
+        }
+
+        U8_A.cmoveq(&U8_A, 43u8, &mut o);
+        assert_eq!(o, 43u8);
+        U8_A.cmoveq(&U8_B, 55u8, &mut o);
+        assert_eq!(o, 43u8);
+    }
+
+    #[test]
+    fn cmovne_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu8 {
+            cond.cmovne(&0, cond, &mut o);
+            assert_eq!(o, cond);
+            cond.cmovne(&cond, 0, &mut o);
+            assert_eq!(o, cond);
+        }
+
+        U8_A.cmovne(&U8_B, 55u8, &mut o);
+        assert_eq!(o, 55u8);
+        U8_A.cmovne(&U8_A, 12u8, &mut o);
+        assert_eq!(o, 55u8);
     }
 }
 
 mod u16 {
-    use cmov::Cmov;
+    use cmov::{Cmov, CmovEq};
+
+    pub const U16_A: u16 = 0x1111;
+    pub const U16_B: u16 = 0x2222;
 
     #[test]
     fn cmovz_works() {
-        let mut n = 0x1111u16;
+        let mut n = U16_A;
 
         for cond in 1..0xFF {
-            n.cmovz(&0x2222, cond);
-            assert_eq!(n, 0x1111);
+            n.cmovz(&U16_B, cond);
+            assert_eq!(n, U16_A);
         }
 
-        n.cmovz(&0x2222, 0);
-        assert_eq!(n, 0x2222);
+        n.cmovz(&U16_B, 0);
+        assert_eq!(n, U16_B);
     }
 
     #[test]
     fn cmovnz_works() {
-        let mut n = 0x1111u16;
-        n.cmovnz(&0x2222, 0);
-        assert_eq!(n, 0x1111);
+        let mut n = U16_A;
+        n.cmovnz(&U16_B, 0);
+        assert_eq!(n, U16_A);
 
         for cond in 1..0xFF {
-            let mut n = 0x1111u16;
-            n.cmovnz(&0x2222, cond);
-            assert_eq!(n, 0x2222);
+            let mut n = U16_A;
+            n.cmovnz(&U16_B, cond);
+            assert_eq!(n, U16_B);
         }
+    }
+
+    #[test]
+    fn cmoveq_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu16 {
+            cond.cmoveq(&cond, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmoveq(&0, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U16_A.cmoveq(&U16_A, 43u8, &mut o);
+        assert_eq!(o, 43u8);
+        U16_A.cmoveq(&U16_B, 55u8, &mut o);
+        assert_eq!(o, 43u8);
+    }
+
+    #[test]
+    fn cmovne_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu16 {
+            cond.cmovne(&0, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmovne(&cond, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U16_A.cmovne(&U16_B, 55u8, &mut o);
+        assert_eq!(o, 55u8);
+        U16_A.cmovne(&U16_A, 12u8, &mut o);
+        assert_eq!(o, 55u8);
     }
 }
 
 mod u32 {
-    use cmov::Cmov;
+    use cmov::{Cmov, CmovEq};
+
+    pub const U32_A: u32 = 0x11111111;
+    pub const U32_B: u32 = 0x22222222;
 
     #[test]
     fn cmovz_works() {
-        let mut n = 0x11111111u32;
+        let mut n = U32_A;
 
         for cond in 1..0xFF {
-            n.cmovz(&0x22222222, cond);
-            assert_eq!(n, 0x11111111);
+            n.cmovz(&U32_B, cond);
+            assert_eq!(n, U32_A);
         }
 
-        n.cmovz(&0x22222222, 0);
-        assert_eq!(n, 0x22222222);
+        n.cmovz(&U32_B, 0);
+        assert_eq!(n, U32_B);
     }
 
     #[test]
     fn cmovnz_works() {
-        let mut n = 0x11111111u32;
-        n.cmovnz(&0x22222222, 0);
-        assert_eq!(n, 0x11111111);
+        let mut n = U32_A;
+        n.cmovnz(&U32_B, 0);
+        assert_eq!(n, U32_A);
 
         for cond in 1..0xFF {
-            let mut n = 0x11111111u32;
-            n.cmovnz(&0x22222222, cond);
-            assert_eq!(n, 0x22222222);
+            let mut n = U32_A;
+            n.cmovnz(&U32_B, cond);
+            assert_eq!(n, U32_B);
         }
+    }
+
+    #[test]
+    fn cmoveq_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu32 {
+            cond.cmoveq(&cond, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmoveq(&0, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U32_A.cmoveq(&U32_A, 43u8, &mut o);
+        assert_eq!(o, 43u8);
+        U32_A.cmoveq(&U32_B, 55u8, &mut o);
+        assert_eq!(o, 43u8);
+    }
+
+    #[test]
+    fn cmovne_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu32 {
+            cond.cmovne(&0, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmovne(&cond, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U32_A.cmovne(&U32_B, 55u8, &mut o);
+        assert_eq!(o, 55u8);
+        U32_A.cmovne(&U32_A, 12u8, &mut o);
+        assert_eq!(o, 55u8);
     }
 }
 
 mod u64 {
-    use cmov::Cmov;
+    use cmov::{Cmov, CmovEq};
+
+    pub const U64_A: u64 = 0x1111_1111_1111_1111;
+    pub const U64_B: u64 = 0x2222_2222_2222_2222;
 
     #[test]
     fn cmovz_works() {
-        let mut n = 0x1111_1111_1111_1111_u64;
+        let mut n = U64_A;
 
         for cond in 1..0xFF {
-            n.cmovz(&0x2222_2222_2222_2222, cond);
-            assert_eq!(n, 0x1111_1111_1111_1111);
+            n.cmovz(&U64_B, cond);
+            assert_eq!(n, U64_A);
         }
 
-        n.cmovz(&0x2222_2222_2222_2222, 0);
-        assert_eq!(n, 0x2222_2222_2222_2222);
+        n.cmovz(&U64_B, 0);
+        assert_eq!(n, U64_B);
     }
 
     #[test]
     fn cmovnz_works() {
-        let mut n = 0x1111_1111_1111_1111_u64;
-        n.cmovnz(&0x2222_2222_2222_2222, 0);
-        assert_eq!(n, 0x1111_1111_1111_1111);
+        let mut n = U64_A;
+        n.cmovnz(&U64_B, 0);
+        assert_eq!(n, U64_A);
 
         for cond in 1..0xFF {
-            let mut n = 0x1111_1111_1111_1111_u64;
-            n.cmovnz(&0x2222_2222_2222_2222, cond);
-            assert_eq!(n, 0x2222_2222_2222_2222);
+            let mut n = U64_A;
+            n.cmovnz(&U64_B, cond);
+            assert_eq!(n, U64_B);
         }
+    }
+
+    #[test]
+    fn cmoveq_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu64 {
+            cond.cmoveq(&cond, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmoveq(&0, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U64_A.cmoveq(&U64_A, 43u8, &mut o);
+        assert_eq!(o, 43u8);
+        U64_A.cmoveq(&U64_B, 55u8, &mut o);
+        assert_eq!(o, 43u8);
+    }
+
+    #[test]
+    fn cmovne_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu64 {
+            cond.cmovne(&0, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmovne(&cond, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U64_A.cmovne(&U64_B, 55u8, &mut o);
+        assert_eq!(o, 55u8);
+        U64_A.cmovne(&U64_A, 12u8, &mut o);
+        assert_eq!(o, 55u8);
     }
 }
 
 mod u128 {
-    use cmov::Cmov;
+    use cmov::{Cmov, CmovEq};
+
+    pub const U128_A: u128 = 0x1111_1111_1111_1111_2222_2222_2222_2222;
+    pub const U128_B: u128 = 0x2222_2222_2222_2222_3333_3333_3333_3333;
 
     #[test]
     fn cmovz_works() {
-        let mut n = 0x1111_1111_1111_1111_2222_2222_2222_2222_u128;
+        let mut n = U128_A;
 
         for cond in 1..0xFF {
-            n.cmovz(&0x2222_2222_2222_2222_3333_3333_3333_3333, cond);
-            assert_eq!(n, 0x1111_1111_1111_1111_2222_2222_2222_2222);
+            n.cmovz(&U128_B, cond);
+            assert_eq!(n, U128_A);
         }
 
-        n.cmovz(&0x2222_2222_2222_2222_3333_3333_3333_3333, 0);
-        assert_eq!(n, 0x2222_2222_2222_2222_3333_3333_3333_3333);
+        n.cmovz(&U128_B, 0);
+        assert_eq!(n, U128_B);
     }
 
     #[test]
     fn cmovnz_works() {
-        let mut n = 0x1111_1111_1111_1111_2222_2222_2222_2222_u128;
-        n.cmovnz(&0x2222_2222_2222_2222_3333_3333_3333_3333, 0);
-        assert_eq!(n, 0x1111_1111_1111_1111_2222_2222_2222_2222);
+        let mut n = U128_A;
+        n.cmovnz(&U128_B, 0);
+        assert_eq!(n, U128_A);
 
         for cond in 1..0xFF {
-            let mut n = 0x1111_1111_1111_1111_u128;
-            n.cmovnz(&0x2222_2222_2222_2222_3333_3333_3333_3333, cond);
-            assert_eq!(n, 0x2222_2222_2222_2222_3333_3333_3333_3333);
+            let mut n = U128_A;
+            n.cmovnz(&U128_B, cond);
+            assert_eq!(n, U128_B);
         }
+    }
+
+    #[test]
+    fn cmoveq_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu128 {
+            cond.cmoveq(&cond, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmoveq(&0, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U128_A.cmoveq(&U128_A, 43u8, &mut o);
+        assert_eq!(o, 43u8);
+        U128_A.cmoveq(&U128_B, 55u8, &mut o);
+        assert_eq!(o, 43u8);
+    }
+
+    #[test]
+    fn cmovne_works() {
+        let mut o = 0u8;
+
+        for cond in 1..0xFFu128 {
+            cond.cmovne(&0, cond as u8, &mut o);
+            assert_eq!(o, cond as u8);
+            cond.cmovne(&cond, 0, &mut o);
+            assert_eq!(o, cond as u8);
+        }
+
+        U128_A.cmovne(&U128_B, 55u8, &mut o);
+        assert_eq!(o, 55u8);
+        U128_A.cmovne(&U128_A, 12u8, &mut o);
+        assert_eq!(o, 55u8);
     }
 }

--- a/cmov/tests/lib.rs
+++ b/cmov/tests/lib.rs
@@ -135,8 +135,8 @@ mod u16 {
 mod u32 {
     use cmov::{Cmov, CmovEq};
 
-    pub const U32_A: u32 = 0x11111111;
-    pub const U32_B: u32 = 0x22222222;
+    pub const U32_A: u32 = 0x1111_1111;
+    pub const U32_B: u32 = 0x2222_2222;
 
     #[test]
     fn cmovz_works() {


### PR DESCRIPTION
Following on from #872, this is heavily a WIP, and a lot of the implementation is sub-par.

I cleaned the macro usage up, although it seemed intentionally designed that way so I can revert those changes if needs be.

I'm not 100% sure on the portable implementation, nor am I sure that `EOR` is the most suitable instruction for Aarch64 (but it works).

Additionally, I think we should note that direct usage won't provide the most ideal outcomes - I believe the compiler will still attempt to optimise in some places, although I'm not 100% sure on that. Using this crate within `subtle` (or similar) sounds the most suitable to me.

Adding benches via `dudect_bencher` could be very handy, just as a sanity-check (but I'd be happy to hear any ideas regarding that).

Edit: in hindsight, I'm not sure that dereferencing within the macros is the best approach either (implementation-wise).

Feel free to rip this work to shreds - it's best that we get it right and make no mistakes 🙏