### PR TITLE
zeroize: add `cross` tests to CI

### DIFF
--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -89,13 +89,11 @@ jobs:
             rust: 1.60.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
-
           # PPC32
           - target: powerpc-unknown-linux-gnu
             rust: 1.60.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -92,6 +92,27 @@ jobs:
       - run: cargo test --target ${{ matrix.target }}
       - run: cargo test --target ${{ matrix.target }} --all-features
 
+  # Cross-compiled tests
+  cross:
+    strategy:
+      matrix:
+        include:
+          # PPC32
+          - target: powerpc-unknown-linux-gnu
+            rust: 1.56.0 # MSRV
+          - target: powerpc-unknown-linux-gnu
+            rust: stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - uses: RustCrypto/actions/cross-install@master
+      - run: cross test --target ${{ matrix.target }}
+
   # Feature-gated ARM64 SIMD register support (MSRV 1.59)
   aarch64:
     strategy:


### PR DESCRIPTION
Adds PPC32, which should be useful for checking that any optional ASM-based features will still work on platforms where ASM has not yet been stabilized.