### PR TITLE
zeroize_derive v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.0-pre"
+version = "1.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.56"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }
-zeroize_derive = { version = "=1.4.0-pre", path = "derive", optional = true }
+zeroize_derive = { version = "1.3", path = "derive", optional = true }
 
 [features]
 default = ["alloc"]

--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 (2023-03-26)
+### Changed
+- 2021 edition upgrade; MSRV 1.56 ([#869])
+- Bump `syn` to v2 ([#858])
+
+### Removed
+- `synstructure` dependency ([#858])
+
+[#858]: https://github.com/RustCrypto/utils/pull/858
+[#869]: https://github.com/RustCrypto/utils/pull/869
+
 ## 1.3.3 (2022-11-30)
 ### Fixed
 - Deriving `ZeroizeOnDrop` on items with generics ([#787])

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.4.0-pre"
+version = "1.4.0"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"

--- a/zeroize/derive/LICENSE-MIT
+++ b/zeroize/derive/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2021 The RustCrypto Project Developers
+Copyright (c) 2019-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Changed
- 2021 edition upgrade; MSRV 1.56 ([#869])
- Bump `syn` to v2 ([#858])

### Removed
- `synstructure` dependency ([#858])

[#858]: https://github.com/RustCrypto/utils/pull/858
[#869]: https://github.com/RustCrypto/utils/pull/869