### PR TITLE
zeroize_derive: Inject where clauses; skip unused

### DIFF
--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = {version = "2", features = ["full", "extra-traits"]}
+syn = {version = "2", features = ["full", "extra-traits", "visit"]}
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--document-private-items"]

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -351,3 +351,12 @@ fn derive_zeroize_with_marker() {
 
     trait Marker {}
 }
+
+#[test]
+// Issue #878
+fn derive_zeroize_used_param() {
+    #[derive(Zeroize)]
+    struct Z<T> {
+        used: T
+    }
+}

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -357,6 +357,6 @@ fn derive_zeroize_with_marker() {
 fn derive_zeroize_used_param() {
     #[derive(Zeroize)]
     struct Z<T> {
-        used: T
+        used: T,
     }
 }


### PR DESCRIPTION
The where clauses I was previously injecting *were* load bearing, but they needed to be filtered for skipped fields.

Fixes #878