### PR TITLE
zeroize_derive v1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.2 (2023-03-30)
+### Changed
+- Inject where clauses; skip unused ([#882])
+
+[#882]: https://github.com/RustCrypto/utils/pull/882
+
 ## 1.4.1 (2023-03-27)
 ### Changed
 - Do not automatically inject bounds ([#879])

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"


### PR DESCRIPTION
### Changed
- Inject where clauses; skip unused ([#882])

[#882]: https://github.com/RustCrypto/utils/pull/882