### PR TITLE
hex-literal: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ version = "0.11.0-pre"
 dependencies = [
  "crypto-common",
  "generic-array",
- "hex-literal 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]
@@ -85,12 +85,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hex-literal"
 version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+version = "0.4.0"
 
 [[package]]
 name = "hybrid-array"

--- a/hex-literal/CHANGELOG.md
+++ b/hex-literal/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## 0.4.0 (2023-04-02)
 ### Changed
 - Disallow comments inside hex strings ([#816])
 - Migrate to 2021 edition and bump MSRV to 1.57 ([#816])

--- a/hex-literal/Cargo.toml
+++ b/hex-literal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-literal"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Macro for converting hexadecimal string to a byte array at compile time"


### PR DESCRIPTION
### Changed
- Disallow comments inside hex strings ([#816])
- Migrate to 2021 edition and bump MSRV to 1.57 ([#816])
- Use CTFE instead of proc macro ([#816])

[#816]: https://github.com/RustCrypto/utils/pull/816