### PR TITLE
Use minimal permissions for CI jobs

### DIFF
--- a/.github/workflows/blobby.yml
+++ b/.github/workflows/blobby.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: blobby

--- a/.github/workflows/block-buffer.yml
+++ b/.github/workflows/block-buffer.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: block-buffer

--- a/.github/workflows/block-padding.yml
+++ b/.github/workflows/block-padding.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: block-padding

--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: cmov

--- a/.github/workflows/cpufeatures.yml
+++ b/.github/workflows/cpufeatures.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: cpufeatures

--- a/.github/workflows/dbl.yml
+++ b/.github/workflows/dbl.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: dbl

--- a/.github/workflows/fiat-constify.yml
+++ b/.github/workflows/fiat-constify.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: fiat-constify

--- a/.github/workflows/hex-literal.yml
+++ b/.github/workflows/hex-literal.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: hex-literal

--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: hybrid-array

--- a/.github/workflows/inout.yml
+++ b/.github/workflows/inout.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: inout

--- a/.github/workflows/opaque-debug.yml
+++ b/.github/workflows/opaque-debug.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: opaque-debug

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,4 +1,5 @@
 name: Security Audit
+
 on:
   pull_request:
     paths: Cargo.lock

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - README.md
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: zeroize


### PR DESCRIPTION
For most jobs we only need to read the contents to run tests. But I am not sure which permissions should be used for the security audit job. I think it should be something like:
```yaml
permissions:
  contents: read
  checks: write
  issues: write
```
For now I will leave the default permissions.

Relevant issues: https://github.com/actions-rs/audit-check/issues/218, https://github.com/actions-rs/audit-check/issues/220