### PR TITLE
cmov v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.3.0-pre"
+version = "0.3.0"
 
 [[package]]
 name = "collectable"

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2023-04-02)
+### Added
+- `miri` support by forcing the `portable` backend ([#864])
+- Constant-time equality comparisons ([#873])
+
+### Changed
+- Make `Cmov::cmovz` a provided method ([#871])
+
+### Fixed
+- Builds on `x86` (32-bit) targets ([#863])
+
+[#863]: https://github.com/RustCrypto/utils/pull/863
+[#864]: https://github.com/RustCrypto/utils/pull/864
+[#871]: https://github.com/RustCrypto/utils/pull/881
+[#873]: https://github.com/RustCrypto/utils/pull/883
+
 ## 0.2.0 (2023-02-26)
 ### Added
 - `Condition` alias for `u8` ([#830])

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -6,7 +6,7 @@ constant-time and not be rewritten as branches by the compiler.
 Provides wrappers for the CMOV family of instructions on x86/x86_64
 and CSEL on AArch64.
 """
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/cmov"


### PR DESCRIPTION
### Added
- `miri` support by forcing the `portable` backend ([#864])
- Constant-time equality comparisons ([#873])

### Changed
- Make `Cmov::cmovz` a provided method ([#871])

### Fixed
- Builds on `x86` (32-bit) targets ([#863])

[#863]: https://github.com/RustCrypto/utils/pull/863
[#864]: https://github.com/RustCrypto/utils/pull/864
[#871]: https://github.com/RustCrypto/utils/pull/881
[#873]: https://github.com/RustCrypto/utils/pull/883