### PR TITLE
hex-literal: enforce const evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hex-literal"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "hybrid-array"
@@ -115,9 +115,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "opaque-debug"
@@ -125,9 +125,9 @@ version = "0.3.0"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0dd4be24fcdcfeaa12a432d588dc59bbad6cad3510c67e74a2b6b2fc950564"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]

--- a/hex-literal/CHANGELOG.md
+++ b/hex-literal/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2023-04-05)
+### Changed
+- Enforce const evaluation ([#889])
+
+[#889]: https://github.com/RustCrypto/utils/pull/889
+
 ## 0.4.0 (2023-04-02)
 ### Changed
 - Disallow comments inside hex strings ([#816])

--- a/hex-literal/Cargo.toml
+++ b/hex-literal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-literal"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Macro for converting hexadecimal string to a byte array at compile time"

--- a/hex-literal/README.md
+++ b/hex-literal/README.md
@@ -31,22 +31,37 @@ let bytes1 = hex!("
     00010203 04050607
     08090a0b 0c0d0e0f
 ");
-assert_eq!(bytes1, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+assert_eq!(
+    bytes1,
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+);
 
-// It's possible to use several literals (results will be concatenated)
+// It's possible to use several literals
+// (results will be concatenated)
 let bytes2 = hex!(
     "00010203 04050607" // first half
-    "08090a0b" /* block comment */ "0c0d0e0f" // second half
+    "08090a0b 0c0d0e0f" // second half
 );
 assert_eq!(bytes1, bytes2);
 ```
 
 Using an unsupported character inside literals will result in a compilation error:
 ```rust,compile_fail
-# use hex_literal::hex;
-hex!("АА"); // Cyrillic "А"
-hex!("11　22"); // Japanese space
-hex!("0123 // Сomments inside literals are not supported");
+hex_literal::hex!("АА"); // Cyrillic "А"
+hex_literal::hex!("11　22"); // Japanese space
+```
+
+Сomments inside literals are not supported:
+```rust,compile_fail
+hex_literal::hex!("0123 // foo");
+```
+
+Each literal must contain an even number of hex characters:
+```rust,compile_fail
+hex_literal::hex!(
+    "01234"
+    "567"
+);
 ```
 
 ## Minimum Supported Rust Version

--- a/hex-literal/src/lib.rs
+++ b/hex-literal/src/lib.rs
@@ -81,6 +81,8 @@ pub const fn decode<const LEN: usize>(strings: &[&[u8]]) -> [u8; LEN] {
 macro_rules! hex {
     ($($s:literal)*) => {{
         const STRINGS: &[&'static [u8]] = &[$($s.as_bytes(),)*];
-        $crate::decode::<{ $crate::len(STRINGS) }>(STRINGS)
+        const LEN: usize = $crate::len(STRINGS);
+        const RES: [u8; LEN] = $crate::decode(STRINGS);
+        RES
     }};
 }


### PR DESCRIPTION
The previous version may not be const evaluated as [noticed](https://github.com/RustCrypto/utils/pull/816#discussion_r1157499048) by @Nugine.