### PR TITLE
wycheproof2blb: secp224r1 support

### DIFF
--- a/wycheproof2blb/src/ecdsa.rs
+++ b/wycheproof2blb/src/ecdsa.rs
@@ -55,7 +55,7 @@ pub fn generator(data: &[u8], algorithm: &str, _key_size: u32) -> Vec<TestInfo> 
     let mut infos = vec![];
     for g in &suite.test_groups {
         assert_eq!(g.key.curve, algorithm);
-        assert!(matches!(g.sha.as_str(), "SHA-256" | "SHA-384"));
+        assert!(matches!(g.sha.as_str(), "SHA-224" | "SHA-256" | "SHA-384"));
         for tc in &g.tests {
             if tc.case.result == crate::wycheproof::CaseResult::Acceptable {
                 // TODO: figure out what to do with test cases that pass but which have weak params

--- a/wycheproof2blb/src/main.rs
+++ b/wycheproof2blb/src/main.rs
@@ -112,6 +112,10 @@ fn main() {
             file: "eddsa_test.json",
             generator: ed25519::generator,
         },
+        "secp224r1" => Algorithm {
+            file: "ecdsa_secp224r1_sha224_test.json",
+            generator: ecdsa::generator,
+        },
         "secp256r1" => Algorithm {
             file: "ecdsa_secp256r1_sha256_test.json",
             generator: ecdsa::generator,


### PR DESCRIPTION
Adds support for extracting secp224r1 test vectors from Wycheproof, in order to test the `p224` crate.