### PR TITLE
hybrid-array: use GATs for `ArraySize`

### DIFF
--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ version = "0.0.2"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "libc",
 ]
@@ -94,7 +94,7 @@ version = "0.4.1"
 
 [[package]]
 name = "hybrid-array"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "typenum",
 ]

--- a/hybrid-array/Cargo.toml
+++ b/hybrid-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0-pre"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability
@@ -14,7 +14,7 @@ categories = ["no-std", "data-structures"]
 keywords = ["generic-array"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 
 [dependencies]
 typenum = "1.16"

--- a/hybrid-array/README.md
+++ b/hybrid-array/README.md
@@ -51,7 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 


### PR DESCRIPTION
It's quite annoying to have to add a generic parameter to `ArraySize`, particularly when notating it in bounds.

GATs provide a solution to this problem, moving the type parameter to the associated type so bounds are simply `N: ArraySize`.