### PR TITLE
zeroize: Update comments on MSRV

### DIFF
--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -1,7 +1,7 @@
 //! [`Zeroize`] impls for ARM64 SIMD registers.
 //!
 //! Gated behind the `aarch64` feature: MSRV 1.59
-//! (the overall crate is MSRV 1.51)
+//! (the overall crate is MSRV 1.56)
 
 use crate::{atomic_fence, volatile_write, Zeroize};
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Requires Rust **1.51** or newer.
+//! Requires Rust **1.56** or newer.
 //!
 //! In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 //! for this crate's SemVer guarantees), however when we do it will be accompanied


### PR DESCRIPTION
If I understood it correctly the `zeroize` crate has now overall a MSRV of 1.56 since https://github.com/RustCrypto/utils/pull/869. There were just two places left where it was still stated that the MSRV is 1.51.