### PR TITLE
hex-literal: add support for hex prefixes

### DIFF
--- a/hex-literal/CHANGELOG.md
+++ b/hex-literal/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Support for `0x` hex prefixes ([#923])
+
+[#923]: https://github.com/RustCrypto/utils/pull/923
+
 ## 0.4.1 (2023-04-05)
 ### Changed
 - Enforce const evaluation ([#889])

--- a/hex-literal/README.md
+++ b/hex-literal/README.md
@@ -10,15 +10,17 @@ This crate provides the `hex!` macro for converting hexadecimal string literals 
 
 It accepts the following characters in the input string:
 
+- `0x` — the hex prefix which is valid only at the start of a literal and will be ignored
 - `'0'...'9'`, `'a'...'f'`, `'A'...'F'` — hex characters which will be used in construction of the output byte array
 - `' '`, `'\r'`, `'\n'`, `'\t'` — formatting characters which will be ignored
 
 # Examples
+
 ```rust
 use hex_literal::hex;
 
 // The macro can be used in const contexts
-const DATA: [u8; 4] = hex!("01020304");
+const DATA: [u8; 4] = hex!("0x01020304");
 assert_eq!(DATA, [1, 2, 3, 4]);
 
 // Both upper and lower hex values are supported

--- a/hex-literal/src/lib.rs
+++ b/hex-literal/src/lib.rs
@@ -34,6 +34,18 @@ const fn next_byte(string: &[u8], pos: usize) -> Option<(u8, usize)> {
     Some(((half1 << 4) + half2, pos))
 }
 
+/// Strips the `0x` prefix from a hex string.
+///
+/// This function is an implementation detail and SHOULD NOT be called directly!
+#[doc(hidden)]
+pub const fn strip_hex_prefix(string: &[u8]) -> &[u8] {
+    if let [b'0', b'x' | b'X', rest @ ..] = string {
+        rest
+    } else {
+        string
+    }
+}
+
 /// Compute length of a byte array which will be decoded from the strings.
 ///
 /// This function is an implementation detail and SHOULD NOT be called directly!
@@ -80,7 +92,7 @@ pub const fn decode<const LEN: usize>(strings: &[&[u8]]) -> [u8; LEN] {
 #[macro_export]
 macro_rules! hex {
     ($($s:literal)*) => {{
-        const STRINGS: &[&'static [u8]] = &[$($s.as_bytes(),)*];
+        const STRINGS: &[&'static [u8]] = &[$( $crate::strip_hex_prefix($s.as_bytes()), )*];
         const LEN: usize = $crate::len(STRINGS);
         const RES: [u8; LEN] = $crate::decode(STRINGS);
         RES

--- a/hex-literal/tests/basic.rs
+++ b/hex-literal/tests/basic.rs
@@ -26,6 +26,12 @@ fn mixed_case() {
 }
 
 #[test]
+fn can_strip_prefix() {
+    assert_eq!(hex!("0x1a2b3c"), [0x1a, 0x2b, 0x3c]);
+    assert_eq!(hex!("0xa1" "0xb2" "0xc3"), [0xa1, 0xb2, 0xc3]);
+}
+
+#[test]
 fn multiple_literals() {
     assert_eq!(
         hex!(


### PR DESCRIPTION
Allows writing `hex!("0x1234")` by ignoring the initial `"0x"` prefix.
This only works by stripping the start of the literals, so something like `hex!("0x12 0x34")` or `hex!("   0x1234")` wouldn't work.
This would require a bit more effort to implement, so please let me know if you want this as well.