### PR TITLE
cmov: use `#[inline]` instead of `#[inline(always)]`

### DIFF
--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -40,72 +40,72 @@ macro_rules! csel_eq {
 }
 
 impl Cmov for u16 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         csel!("csel {1:w}, {2:w}, {3:w}, NE", self, value, condition);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, value, condition);
     }
 }
 
 impl CmovEq for u16 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }
 }
 
 impl Cmov for u32 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         csel!("csel {1:w}, {2:w}, {3:w}, NE", self, value, condition);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         csel!("csel {1:w}, {2:w}, {3:w}, EQ", self, value, condition);
     }
 }
 
 impl CmovEq for u32 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }
 }
 
 impl Cmov for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         csel!("csel {1:x}, {2:x}, {3:x}, NE", self, value, condition);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         csel!("csel {1:x}, {2:x}, {3:x}, EQ", self, value, condition);
     }
 }
 
 impl CmovEq for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, NE", self, rhs, input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         csel_eq!("csel {3:w}, {4:w}, {5:w}, EQ", self, rhs, input, output);
     }

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -60,14 +60,14 @@ pub trait CmovEq {
 }
 
 impl Cmov for u8 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u16;
         tmp.cmovnz(&(*value as u16), condition);
         *self = tmp as u8;
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u16;
         tmp.cmovz(&(*value as u16), condition);
@@ -76,19 +76,19 @@ impl Cmov for u8 {
 }
 
 impl CmovEq for u8 {
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u16).cmoveq(&(*rhs as u16), input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u16).cmovne(&(*rhs as u16), input, output);
     }
 }
 
 impl Cmov for u128 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut lo = (*self & u64::MAX as u128) as u64;
         let mut hi = (*self >> 64) as u64;
@@ -99,7 +99,7 @@ impl Cmov for u128 {
         *self = (lo as u128) | (hi as u128) << 64;
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut lo = (*self & u64::MAX as u128) as u64;
         let mut hi = (*self >> 64) as u64;
@@ -112,7 +112,7 @@ impl Cmov for u128 {
 }
 
 impl CmovEq for u128 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         let lo = (*self & u64::MAX as u128) as u64;
         let hi = (*self >> 64) as u64;
@@ -123,7 +123,7 @@ impl CmovEq for u128 {
         tmp.cmoveq(&0, input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         let lo = (*self & u64::MAX as u128) as u64;
         let hi = (*self >> 64) as u64;

--- a/cmov/src/portable.rs
+++ b/cmov/src/portable.rs
@@ -9,14 +9,14 @@
 use crate::{Cmov, CmovEq, Condition};
 
 impl Cmov for u16 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
         tmp.cmovnz(&(*value as u64), condition);
         *self = tmp as u16;
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
         tmp.cmovz(&(*value as u64), condition);
@@ -25,26 +25,26 @@ impl Cmov for u16 {
 }
 
 impl CmovEq for u16 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmovne(&(*rhs as u64), input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmoveq(&(*rhs as u64), input, output);
     }
 }
 
 impl Cmov for u32 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
         tmp.cmovnz(&(*value as u64), condition);
         *self = tmp as u32;
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut tmp = *self as u64;
         tmp.cmovz(&(*value as u64), condition);
@@ -53,25 +53,25 @@ impl Cmov for u32 {
 }
 
 impl CmovEq for u32 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmovne(&(*rhs as u64), input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         (*self as u64).cmoveq(&(*rhs as u64), input, output);
     }
 }
 
 impl Cmov for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mask = is_non_zero(condition).wrapping_sub(1);
         *self = (*self & mask) | (*value & !mask);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mask = (1 ^ is_non_zero(condition)).wrapping_sub(1);
         *self = (*self & mask) | (*value & !mask);
@@ -79,12 +79,12 @@ impl Cmov for u64 {
 }
 
 impl CmovEq for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovnz(&input, (self ^ rhs) as u8);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovz(&input, (self ^ rhs) as u8);
     }
@@ -95,7 +95,7 @@ impl CmovEq for u64 {
 /// # Returns
 /// - `condition` is zero: `0`
 /// - `condition` is non-zero: `1`
-#[inline(always)]
+#[inline]
 fn is_non_zero(condition: Condition) -> u64 {
     const SHIFT_BITS: usize = core::mem::size_of::<u64>() - 1;
     let condition = condition as u64;

--- a/cmov/src/x86.rs
+++ b/cmov/src/x86.rs
@@ -26,48 +26,48 @@ macro_rules! cmov {
 }
 
 impl Cmov for u16 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         cmov!("cmovz {1:e}, {2:e}", self, value, condition);
     }
 }
 
 impl CmovEq for u16 {
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovz(&input, (self ^ rhs) as u8);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovnz(&input, (self ^ rhs) as u8);
     }
 }
 
 impl Cmov for u32 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         cmov!("cmovnz {1:e}, {2:e}", self, value, condition);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         cmov!("cmovz {1:e}, {2:e}", self, value, condition);
     }
 }
 
 impl CmovEq for u32 {
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovz(&input, (self ^ rhs) as u8);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovnz(&input, (self ^ rhs) as u8);
     }
@@ -75,7 +75,7 @@ impl CmovEq for u32 {
 
 #[cfg(target_arch = "x86")]
 impl Cmov for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         let mut lo = (*self & u32::MAX as u64) as u32;
         let mut hi = (*self >> 32) as u32;
@@ -86,7 +86,7 @@ impl Cmov for u64 {
         *self = (lo as u64) | (hi as u64) << 32;
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         let mut lo = (*self & u32::MAX as u64) as u32;
         let mut hi = (*self >> 32) as u32;
@@ -100,7 +100,7 @@ impl Cmov for u64 {
 
 #[cfg(target_arch = "x86")]
 impl CmovEq for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         let lo = (*self & u32::MAX as u64) as u32;
         let hi = (*self >> 32) as u32;
@@ -111,7 +111,7 @@ impl CmovEq for u64 {
         tmp.cmoveq(&0, input, output);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         let lo = (*self & u32::MAX as u64) as u32;
         let hi = (*self >> 32) as u32;
@@ -125,12 +125,12 @@ impl CmovEq for u64 {
 
 #[cfg(target_arch = "x86_64")]
 impl Cmov for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
         cmov!("cmovnz {1:r}, {2:r}", self, value, condition);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovz(&mut self, value: &Self, condition: Condition) {
         cmov!("cmovz {1:r}, {2:r}", self, value, condition);
     }
@@ -138,12 +138,12 @@ impl Cmov for u64 {
 
 #[cfg(target_arch = "x86_64")]
 impl CmovEq for u64 {
-    #[inline(always)]
+    #[inline]
     fn cmoveq(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovz(&input, (self ^ rhs) as u8);
     }
 
-    #[inline(always)]
+    #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {
         output.cmovnz(&input, (self ^ rhs) as u8);
     }


### PR DESCRIPTION
Related to [this comment](https://github.com/RustCrypto/utils/issues/920#issuecomment-1606146848), this PR changes all `[inline(always)]` to just `[inline]`.

I'm not sure what the scope of these changes should be as I imagine there's a lot of them, but it's a start.