### PR TITLE
cpufeatures: add support for `avx512vbmi(2)`

### DIFF
--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -142,6 +142,6 @@ __expand_check_macro! {
     ("sha", "xmm", 1, ebx, 29),
     ("avx512bw", "zmm", 1, ebx, 30),
     ("avx512vl", "zmm", 1, ebx, 31),
-    ("avx512vbmi", 1, ecx, 1),
-    ("avx512vbmi2", 1, ecx, 6),
+    ("avx512vbmi", "zmm", 1, ecx, 1),
+    ("avx512vbmi2", "zmm," 1, ecx, 6),
 }

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -142,4 +142,6 @@ __expand_check_macro! {
     ("sha", "xmm", 1, ebx, 29),
     ("avx512bw", "zmm", 1, ebx, 30),
     ("avx512vl", "zmm", 1, ebx, 31),
+    ("avx512vbmi", 1, ecx, 1),
+    ("avx512vbmi2", 1, ecx, 6)
 }

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -143,5 +143,5 @@ __expand_check_macro! {
     ("avx512bw", "zmm", 1, ebx, 30),
     ("avx512vl", "zmm", 1, ebx, 31),
     ("avx512vbmi", 1, ecx, 1),
-    ("avx512vbmi2", 1, ecx, 6)
+    ("avx512vbmi2", 1, ecx, 6),
 }

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -143,5 +143,5 @@ __expand_check_macro! {
     ("avx512bw", "zmm", 1, ebx, 30),
     ("avx512vl", "zmm", 1, ebx, 31),
     ("avx512vbmi", "zmm", 1, ecx, 1),
-    ("avx512vbmi2", "zmm," 1, ecx, 6),
+    ("avx512vbmi2", "zmm", 1, ecx, 6),
 }


### PR DESCRIPTION
This has only been tested on my machine (R7 7950X), but the values seem correct to me - I was following [this chart](https://en.wikichip.org/wiki/x86/avx-512#Detection) and a PR from the other month.