### PR TITLE
Set min version of serde to 1.0.184

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,18 +149,18 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/wycheproof2blb/CHANGELOG.md
+++ b/wycheproof2blb/CHANGELOG.md
@@ -4,12 +4,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
-### Changed
-- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#933])
-
-[#933]: https://github.com/RustCrypto/utils/pull/933
-[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
-
 ## 0.1.0 (2021-12-07)
 - Initial release

--- a/wycheproof2blb/Cargo.toml
+++ b/wycheproof2blb/Cargo.toml
@@ -12,6 +12,5 @@ edition = "2018"
 [dependencies]
 blobby = { version = "0.3.1", path = "../blobby" }
 hex = "0.4"
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.103, <1.0.172", features = ["derive"] }
+serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
In 1.0.184 `serde` was [un-blobbed](https://github.com/serde-rs/serde/releases/tag/v1.0.184). To prevent accidental pulling of the blobbed versions 1.0.184 will be used as a min version.

Relevant PR: #933 