### PR TITLE
cpufeatures: add missing target features to readme

### DIFF
--- a/cpufeatures/README.md
+++ b/cpufeatures/README.md
@@ -49,6 +49,8 @@ Target features:
 - `avx512ifma`*
 - `avx512pf`*
 - `avx512vl`*
+- `avx512vbmi`*
+- `avx512vbmi2`*
 - `bmi1`
 - `bmi2`
 - `fma`,


### PR DESCRIPTION
Support for `avx512vbmi` and `avx512vbmi2` was added in #926, but the README was not updated appropriately.