### PR TITLE
Migrate to `hybrid-array`; MSRV 1.65

### DIFF
--- a/.github/workflows/block-buffer.yml
+++ b/.github/workflows/block-buffer.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,21 +37,20 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo build --target ${{ matrix.target }}
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+  # TODO(tarcieri): re-enable after next `crypto-common` release
+  #minimal-versions:
+  #  uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+  #  with:
+  #      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +58,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo test
       - run: cargo test --all-features

--- a/.github/workflows/block-padding.yml
+++ b/.github/workflows/block-padding.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dbl.yml
+++ b/.github/workflows/dbl.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,8 +37,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo build --target ${{ matrix.target }}
 
   minimal-versions:
@@ -51,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -59,6 +57,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo test

--- a/.github/workflows/inout.yml
+++ b/.github/workflows/inout.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,16 +14,15 @@ name = "block-buffer"
 version = "0.11.0-pre"
 dependencies = [
  "crypto-common",
- "generic-array",
  "hex-literal 0.3.4",
  "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.0-pre"
 dependencies = [
- "generic-array",
+ "hybrid-array 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -44,18 +43,16 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6faaa83e7700e0832cbbf84854d4c356270526907d9b14fab927fc7a9b5befb8"
+source = "git+https://github.com/RustCrypto/traits#766c138c2671329bc7bd89a40981027659b016c9"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "dbl"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
- "generic-array",
+ "hybrid-array 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -65,16 +62,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -101,11 +88,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431615b6a66a159a76ac38f4b0bcbd5999433d08425d79e152438e3ab9f1013c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.2.0-pre"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -201,12 +197,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wycheproof2blb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+crypto-common = { git = "https://github.com/RustCrypto/traits" }

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 
 [dependencies]
 crypto-common = "0.2.0-pre"
-generic-array = "0.14"
 zeroize = { version = "1.4", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/block-buffer/README.md
+++ b/block-buffer/README.md
@@ -29,7 +29,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [docs-image]: https://docs.rs/block-buffer/badge.svg
 [docs-link]: https://docs.rs/block-buffer/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 [build-image]: https://github.com/RustCrypto/utils/workflows/block-buffer/badge.svg?branch=master&event=push

--- a/block-buffer/src/lib.rs
+++ b/block-buffer/src/lib.rs
@@ -6,15 +6,15 @@
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use generic_array;
+pub use crypto_common::{array, Block};
 
-use core::{fmt, ops::Add, slice};
-pub use crypto_common::Block;
-use crypto_common::{BlockSizeUser, BlockSizes};
-use generic_array::{
+use array::{
     typenum::{Add1, B1},
-    ArrayLength, GenericArray,
+    Array, ArraySize,
 };
+use core::{fmt, ops::Add, slice};
+use crypto_common::{BlockSizeUser, BlockSizes};
+
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -24,7 +24,7 @@ mod sealed;
 pub use read::ReadBuffer;
 
 /// Block with additional one byte
-type BlockP1<BlockSize> = GenericArray<u8, Add1<BlockSize>>;
+type BlockP1<BlockSize> = Array<u8, Add1<BlockSize>>;
 
 /// Trait for buffer kinds.
 pub trait BufferKind: sealed::Sealed {}
@@ -306,7 +306,7 @@ impl<BS: BlockSizes> BlockBuffer<BS, Lazy> {
     pub fn serialize(&self) -> BlockP1<BS>
     where
         BS: Add<B1>,
-        Add1<BS>: ArrayLength<u8>,
+        Add1<BS>: ArraySize,
     {
         let mut res = BlockP1::<BS>::default();
         res[0] = self.pos;
@@ -320,7 +320,7 @@ impl<BS: BlockSizes> BlockBuffer<BS, Lazy> {
     pub fn deserialize(buffer: &BlockP1<BS>) -> Result<Self, Error>
     where
         BS: Add<B1>,
-        Add1<BS>: ArrayLength<u8>,
+        Add1<BS>: ArraySize,
     {
         let pos = buffer[0];
         if !<Lazy as sealed::Sealed>::invariant(pos as usize, BS::USIZE) {
@@ -329,10 +329,8 @@ impl<BS: BlockSizes> BlockBuffer<BS, Lazy> {
         if buffer[1..][pos as usize..].iter().any(|&b| b != 0) {
             return Err(Error);
         }
-        Ok(Self {
-            buffer: GenericArray::clone_from_slice(&buffer[1..]),
-            pos,
-        })
+        let buffer = Array::clone_from_slice(&buffer[1..]);
+        Ok(Self { buffer, pos })
     }
 }
 

--- a/block-buffer/src/sealed.rs
+++ b/block-buffer/src/sealed.rs
@@ -1,5 +1,5 @@
+use crate::array::{Array, ArraySize};
 use core::slice;
-use generic_array::{ArrayLength, GenericArray};
 
 /// Sealed trait for buffer kinds.
 pub trait Sealed {
@@ -17,7 +17,7 @@ pub trait Sealed {
     fn invariant(pos: usize, block_size: usize) -> bool;
 
     /// Split input data into slice of blocks and tail.
-    fn split_blocks<N: ArrayLength<u8>>(data: &[u8]) -> (&[GenericArray<u8, N>], &[u8]);
+    fn split_blocks<N: ArraySize>(data: &[u8]) -> (&[Array<u8, N>], &[u8]);
 }
 
 impl Sealed for super::Eager {
@@ -38,14 +38,14 @@ impl Sealed for super::Eager {
     }
 
     #[inline(always)]
-    fn split_blocks<N: ArrayLength<u8>>(data: &[u8]) -> (&[GenericArray<u8, N>], &[u8]) {
+    fn split_blocks<N: ArraySize>(data: &[u8]) -> (&[Array<u8, N>], &[u8]) {
         let nb = data.len() / N::USIZE;
         let blocks_len = nb * N::USIZE;
         let tail_len = data.len() - blocks_len;
         // SAFETY: we guarantee that created slices do not point
         // outside of `data`
         unsafe {
-            let blocks_ptr = data.as_ptr() as *const GenericArray<u8, N>;
+            let blocks_ptr = data.as_ptr() as *const Array<u8, N>;
             let tail_ptr = data.as_ptr().add(blocks_len);
             (
                 slice::from_raw_parts(blocks_ptr, nb),
@@ -73,7 +73,7 @@ impl Sealed for super::Lazy {
     }
 
     #[inline(always)]
-    fn split_blocks<N: ArrayLength<u8>>(data: &[u8]) -> (&[GenericArray<u8, N>], &[u8]) {
+    fn split_blocks<N: ArraySize>(data: &[u8]) -> (&[Array<u8, N>], &[u8]) {
         if data.is_empty() {
             return (&[], &[]);
         }
@@ -87,7 +87,7 @@ impl Sealed for super::Lazy {
         // SAFETY: we guarantee that created slices do not point
         // outside of `data`
         unsafe {
-            let blocks_ptr = data.as_ptr() as *const GenericArray<u8, N>;
+            let blocks_ptr = data.as_ptr() as *const Array<u8, N>;
             let tail_ptr = data.as_ptr().add(blocks_len);
             (
                 slice::from_raw_parts(blocks_ptr, nb),

--- a/block-buffer/tests/mod.rs
+++ b/block-buffer/tests/mod.rs
@@ -1,7 +1,7 @@
 use block_buffer::{
-    generic_array::{
+    array::{
         typenum::{U10, U16, U24, U4, U8},
-        GenericArray,
+        Array,
     },
     Block, EagerBuffer, LazyBuffer, ReadBuffer,
 };
@@ -203,17 +203,17 @@ fn test_eager_serialize() {
     assert_eq!(buf3.serialize(), ser3);
 
     // Invalid position
-    let buf = GenericArray::from_slice(&[0, 0, 0, 4]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[0, 0, 0, 10]);
-    assert!(Buf::deserialize(buf).is_err());
+    let buf = Array([0, 0, 0, 4]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([0, 0, 0, 10]);
+    assert!(Buf::deserialize(&buf).is_err());
     // "Garbage" bytes are not zeroized
-    let buf = GenericArray::from_slice(&[1, 0, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[0, 1, 0, 1]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[0, 0, 1, 2]);
-    assert!(Buf::deserialize(buf).is_err());
+    let buf = Array([1, 0, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([0, 1, 0, 1]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([0, 0, 1, 2]);
+    assert!(Buf::deserialize(&buf).is_err());
 }
 
 #[test]
@@ -223,6 +223,7 @@ fn test_lazy_serialize() {
     let mut buf1 = Buf::default();
     let ser0 = buf1.serialize();
     assert_eq!(&ser0[..], &[0, 0, 0, 0, 0]);
+    Buf::deserialize(&ser0).unwrap();
     assert_eq!(Buf::deserialize(&ser0).unwrap().serialize(), ser0);
 
     buf1.digest_blocks(&[41, 42], |_| {});
@@ -262,19 +263,19 @@ fn test_lazy_serialize() {
     assert_eq!(buf3.serialize(), ser4);
 
     // Invalid position
-    let buf = GenericArray::from_slice(&[10, 0, 0, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[5, 0, 0, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
+    let buf = Array([10, 0, 0, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([5, 0, 0, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
     // "Garbage" bytes are not zeroized
-    let buf = GenericArray::from_slice(&[0, 1, 0, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[1, 0, 1, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[2, 0, 0, 1, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[3, 0, 0, 0, 1]);
-    assert!(Buf::deserialize(buf).is_err());
+    let buf = Array([0, 1, 0, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([1, 0, 1, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([2, 0, 0, 1, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([3, 0, 0, 0, 1]);
+    assert!(Buf::deserialize(&buf).is_err());
 }
 
 #[test]
@@ -332,17 +333,17 @@ fn test_read_serialize() {
     assert_eq!(&buf3.serialize()[..], &[1, 55, 56, 57]);
 
     // Invalid position
-    let buf = GenericArray::from_slice(&[0, 0, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[5, 0, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[10, 0, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
+    let buf = Array([0, 0, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([5, 0, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([10, 0, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
     // "Garbage" bytes are not zeroized
-    let buf = GenericArray::from_slice(&[2, 1, 0, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[3, 0, 1, 0]);
-    assert!(Buf::deserialize(buf).is_err());
-    let buf = GenericArray::from_slice(&[4, 0, 0, 1]);
-    assert!(Buf::deserialize(buf).is_err());
+    let buf = Array([2, 1, 0, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([3, 0, 1, 0]);
+    assert!(Buf::deserialize(&buf).is_err());
+    let buf = Array([4, 0, 0, 1]);
+    assert!(Buf::deserialize(&buf).is_err());
 }

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.0-pre"
 description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ keywords = ["padding", "pkcs7", "ansix923", "iso7816"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.14"
+hybrid-array = "=0.2.0-pre.5"
 
 [features]
 std = []

--- a/block-padding/src/lib.rs
+++ b/block-padding/src/lib.rs
@@ -14,9 +14,10 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+pub use hybrid_array as array;
+
 use core::fmt;
-pub use generic_array;
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::{Array, ArraySize};
 
 /// Padding types
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -49,10 +50,10 @@ pub trait RawPadding {
 }
 
 /// Block size.
-pub type Block<B> = GenericArray<u8, B>;
+pub type Block<B> = Array<u8, B>;
 
 /// Trait for padding messages divided into blocks
-pub trait Padding<BlockSize: ArrayLength<u8>> {
+pub trait Padding<BlockSize: ArraySize> {
     /// Padding type
     const TYPE: PadType;
 
@@ -92,7 +93,7 @@ pub trait Padding<BlockSize: ArrayLength<u8>> {
     }
 }
 
-impl<T, B: ArrayLength<u8>> Padding<B> for T
+impl<T, B: ArraySize> Padding<B> for T
 where
     T: RawPadding,
 {
@@ -113,11 +114,11 @@ where
 ///
 /// ```
 /// use block_padding::{ZeroPadding, Padding};
-/// use generic_array::{GenericArray, typenum::U8};
+/// use block_padding::array::{Array, typenum::U8};
 ///
 /// let msg = b"test";
 /// let pos = msg.len();
-/// let mut block: GenericArray::<u8, U8> = [0xff; 8].into();
+/// let mut block: Array::<u8, U8> = [0xff; 8].into();
 /// block[..pos].copy_from_slice(msg);
 /// ZeroPadding::pad(&mut block, pos);
 /// assert_eq!(&block[..], b"test\x00\x00\x00\x00");
@@ -158,11 +159,11 @@ impl RawPadding for ZeroPadding {
 ///
 /// ```
 /// use block_padding::{Pkcs7, Padding};
-/// use generic_array::{GenericArray, typenum::U8};
+/// use block_padding::array::{Array, typenum::U8};
 ///
 /// let msg = b"test";
 /// let pos = msg.len();
-/// let mut block: GenericArray::<u8, U8> = [0xff; 8].into();
+/// let mut block: Array::<u8, U8> = [0xff; 8].into();
 /// block[..pos].copy_from_slice(msg);
 /// Pkcs7::pad(&mut block, pos);
 /// assert_eq!(&block[..], b"test\x04\x04\x04\x04");
@@ -220,11 +221,11 @@ impl RawPadding for Pkcs7 {
 ///
 /// ```
 /// use block_padding::{Iso10126, Padding};
-/// use generic_array::{GenericArray, typenum::U8};
+/// use block_padding::array::{Array, typenum::U8};
 ///
 /// let msg = b"test";
 /// let pos = msg.len();
-/// let mut block: GenericArray::<u8, U8> = [0xff; 8].into();
+/// let mut block: Array::<u8, U8> = [0xff; 8].into();
 /// block[..pos].copy_from_slice(msg);
 /// Iso10126::pad(&mut block, pos);
 /// assert_eq!(&block[..], b"test\x04\x04\x04\x04");
@@ -255,11 +256,11 @@ impl RawPadding for Iso10126 {
 ///
 /// ```
 /// use block_padding::{AnsiX923, Padding};
-/// use generic_array::{GenericArray, typenum::U8};
+/// use block_padding::array::{Array, typenum::U8};
 ///
 /// let msg = b"test";
 /// let pos = msg.len();
-/// let mut block: GenericArray::<u8, U8> = [0xff; 8].into();
+/// let mut block: Array::<u8, U8> = [0xff; 8].into();
 /// block[..pos].copy_from_slice(msg);
 /// AnsiX923::pad(&mut block, pos);
 /// assert_eq!(&block[..], b"test\x00\x00\x00\x04");
@@ -309,11 +310,11 @@ impl RawPadding for AnsiX923 {
 ///
 /// ```
 /// use block_padding::{Iso7816, Padding};
-/// use generic_array::{GenericArray, typenum::U8};
+/// use block_padding::array::{Array, typenum::U8};
 ///
 /// let msg = b"test";
 /// let pos = msg.len();
-/// let mut block: GenericArray::<u8, U8> = [0xff; 8].into();
+/// let mut block: Array::<u8, U8> = [0xff; 8].into();
 /// block[..pos].copy_from_slice(msg);
 /// Iso7816::pad(&mut block, pos);
 /// assert_eq!(&block[..], b"test\x80\x00\x00\x00");
@@ -352,11 +353,11 @@ impl RawPadding for Iso7816 {
 ///
 /// ```
 /// use block_padding::{NoPadding, Padding};
-/// use generic_array::{GenericArray, typenum::U8};
+/// use block_padding::array::{Array, typenum::U8};
 ///
 /// let msg = b"test";
 /// let pos = msg.len();
-/// let mut block: GenericArray::<u8, U8> = [0xff; 8].into();
+/// let mut block: Array::<u8, U8> = [0xff; 8].into();
 /// block[..pos].copy_from_slice(msg);
 /// NoPadding::pad(&mut block, pos);
 /// assert_eq!(&block[..], b"test\xff\xff\xff\xff");

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "dbl"
-version = "0.3.2"
+version = "0.4.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Double operation in Galois Field (GF)"
 documentation = "https://docs.rs/dbl"
 repository = "https://github.com/RustCrypto/utils"
 keywords = ["crypto", "dbl", "gf", "galois"]
+edition = "2021"
+rust-version = "1.65"
 
 [dependencies]
-generic-array = "0.14"
+hybrid-array = "=0.2.0-pre.5"

--- a/dbl/src/lib.rs
+++ b/dbl/src/lib.rs
@@ -6,10 +6,8 @@
 )]
 #![forbid(unsafe_code)]
 
-extern crate generic_array;
-
-use generic_array::typenum::{U16, U32, U8};
-use generic_array::GenericArray;
+use hybrid_array::typenum::{U16, U32, U8};
+use hybrid_array::Array;
 
 use core::convert::TryInto;
 
@@ -39,7 +37,7 @@ pub trait Dbl {
     fn inv_dbl(self) -> Self;
 }
 
-impl Dbl for GenericArray<u8, U8> {
+impl Dbl for Array<u8, U8> {
     #[inline]
     fn dbl(self) -> Self {
         let mut val = u64::from_be_bytes(self.into());
@@ -63,7 +61,7 @@ impl Dbl for GenericArray<u8, U8> {
     }
 }
 
-impl Dbl for GenericArray<u8, U16> {
+impl Dbl for Array<u8, U16> {
     #[inline]
     fn dbl(self) -> Self {
         let mut val = [
@@ -108,7 +106,7 @@ impl Dbl for GenericArray<u8, U16> {
     }
 }
 
-impl Dbl for GenericArray<u8, U32> {
+impl Dbl for Array<u8, U32> {
     #[inline]
     fn dbl(self) -> Self {
         let mut val = [

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.1.3"
+version = "0.2.0-pre"
 description = "Custom reference types for code generic over in-place and buffer-to-buffer modes of operation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -11,8 +11,8 @@ repository = "https://github.com/RustCrypto/utils"
 keywords = ["custom-reference"]
 
 [dependencies]
-generic-array = "0.14"
-block-padding = { version = "0.3", path = "../block-padding", optional = true }
+block-padding = { version = "0.4.0-pre", path = "../block-padding", optional = true }
+hybrid-array = "=0.2.0-pre.5"
 
 [features]
 std = ["block-padding/std"]

--- a/inout/src/inout.rs
+++ b/inout/src/inout.rs
@@ -1,6 +1,6 @@
 use crate::InOutBuf;
 use core::{marker::PhantomData, ptr};
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::{Array, ArraySize};
 
 /// Custom pointer type which contains one immutable (input) and one mutable
 /// (output) pointer, which are either equal or non-overlapping.
@@ -98,7 +98,7 @@ impl<'inp, 'out, T> From<(&'inp T, &'out mut T)> for InOut<'inp, 'out, T> {
     }
 }
 
-impl<'inp, 'out, T, N: ArrayLength<T>> InOut<'inp, 'out, GenericArray<T, N>> {
+impl<'inp, 'out, T, N: ArraySize> InOut<'inp, 'out, Array<T, N>> {
     /// Returns `InOut` for the given position.
     ///
     /// # Panics
@@ -127,7 +127,7 @@ impl<'inp, 'out, T, N: ArrayLength<T>> InOut<'inp, 'out, GenericArray<T, N>> {
     }
 }
 
-impl<'inp, 'out, N: ArrayLength<u8>> InOut<'inp, 'out, GenericArray<u8, N>> {
+impl<'inp, 'out, N: ArraySize> InOut<'inp, 'out, Array<u8, N>> {
     /// XOR `data` with values behind the input slice and write
     /// result to the output slice.
     ///
@@ -135,10 +135,10 @@ impl<'inp, 'out, N: ArrayLength<u8>> InOut<'inp, 'out, GenericArray<u8, N>> {
     /// If `data` length is not equal to the buffer length.
     #[inline(always)]
     #[allow(clippy::needless_range_loop)]
-    pub fn xor_in2out(&mut self, data: &GenericArray<u8, N>) {
+    pub fn xor_in2out(&mut self, data: &Array<u8, N>) {
         unsafe {
             let input = ptr::read(self.in_ptr);
-            let mut temp = GenericArray::<u8, N>::default();
+            let mut temp = Array::<u8, N>::default();
             for i in 0..N::USIZE {
                 temp[i] = input[i] ^ data[i];
             }
@@ -147,10 +147,10 @@ impl<'inp, 'out, N: ArrayLength<u8>> InOut<'inp, 'out, GenericArray<u8, N>> {
     }
 }
 
-impl<'inp, 'out, N, M> InOut<'inp, 'out, GenericArray<GenericArray<u8, N>, M>>
+impl<'inp, 'out, N, M> InOut<'inp, 'out, Array<Array<u8, N>, M>>
 where
-    N: ArrayLength<u8>,
-    M: ArrayLength<GenericArray<u8, N>>,
+    N: ArraySize,
+    M: ArraySize,
 {
     /// XOR `data` with values behind the input slice and write
     /// result to the output slice.
@@ -159,10 +159,10 @@ where
     /// If `data` length is not equal to the buffer length.
     #[inline(always)]
     #[allow(clippy::needless_range_loop)]
-    pub fn xor_in2out(&mut self, data: &GenericArray<GenericArray<u8, N>, M>) {
+    pub fn xor_in2out(&mut self, data: &Array<Array<u8, N>, M>) {
         unsafe {
             let input = ptr::read(self.in_ptr);
-            let mut temp = GenericArray::<GenericArray<u8, N>, M>::default();
+            let mut temp = Array::<Array<u8, N>, M>::default();
             for i in 0..M::USIZE {
                 for j in 0..N::USIZE {
                     temp[i][j] = input[i][j] ^ data[i][j];


### PR DESCRIPTION
Builds on RustCrypto/traits#1319.

Migrates the following crates away from using `generic-array` to using `hybrid-array` instead:

- `block-buffer`
- `block-padding`
- `dbl`
- `inout`