### PR TITLE
cmov v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "collectable"

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2023-10-14)
+### Added
+- `CmovEq` impl for slices ([#954])
+
+### Changed
+- Use `#[inline]` instead of `#[inline(always)]` ([#924])
+- `CmovEq` now invokes XOR within the ASM block ([#925])
+
+[#924]: https://github.com/RustCrypto/utils/pull/924
+[#925]: https://github.com/RustCrypto/utils/pull/925
+[#954]: https://github.com/RustCrypto/utils/pull/954
+
 ## 0.3.0 (2023-04-02)
 ### Added
 - `miri` support by forcing the `portable` backend ([#864])

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -6,7 +6,7 @@ constant-time and not be rewritten as branches by the compiler.
 Provides wrappers for the CMOV family of instructions on x86/x86_64
 and CSEL on AArch64.
 """
-version = "0.3.0"
+version = "0.3.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/cmov"


### PR DESCRIPTION
### Added
- `CmovEq` impl for slices ([#954])

### Changed
- Use `#[inline]` instead of `#[inline(always)]` ([#924])
- `CmovEq` now invokes XOR within the ASM block ([#925])

[#924]: https://github.com/RustCrypto/utils/pull/924
[#925]: https://github.com/RustCrypto/utils/pull/925
[#954]: https://github.com/RustCrypto/utils/pull/954