### PR TITLE
zeroize: wasm `v128`, more aarch64 registers, `const Zeroizing::new()`

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.61.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -53,7 +53,7 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.61.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.61.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
@@ -71,7 +71,7 @@ jobs:
           # 64-bit macOS x86_64
           - target: x86_64-apple-darwin
             platform: macos-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.61.0 # MSRV
           - target: x86_64-apple-darwin
             platform: macos-latest
             rust: stable
@@ -79,7 +79,7 @@ jobs:
           # 64-bit Windows
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.61.0 # MSRV
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
             rust: stable
@@ -102,7 +102,7 @@ jobs:
         include:
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.60.0 # MSRV
+            rust: 1.61.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest
@@ -116,13 +116,12 @@ jobs:
       - uses: RustCrypto/actions/cross-install@master
       - run: cross test --target ${{ matrix.target }}
 
-  # Feature-gated ARM64 SIMD register support (MSRV 1.59)
   aarch64:
     strategy:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            rust: 1.60.0
+            rust: 1.61.0
           - target: aarch64-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest
@@ -135,5 +134,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cross-install@master
-      - run: cross test --target ${{ matrix.target }} --features aarch64
       - run: cross test --target ${{ matrix.target }} --all-features

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains various utility crates used in the RustCrypto project.
 | [`inout`] | [![crates.io](https://img.shields.io/crates/v/inout.svg)](https://crates.io/crates/inout) | [![Documentation](https://docs.rs/inout/badge.svg)](https://docs.rs/inout) | ![MSRV 1.56][msrv-1.56] | Custom reference types for code generic over in-place and buffer-to-buffer modes of operation. |
 | [`opaque-debug`] | [![crates.io](https://img.shields.io/crates/v/opaque-debug.svg)](https://crates.io/crates/opaque-debug) | [![Documentation](https://docs.rs/opaque-debug/badge.svg)](https://docs.rs/opaque-debug) | ![MSRV 1.41][msrv-1.41] | Macro for opaque `Debug` trait implementation |
 | [`wycheproof2blb`] |  |  | | Utility for converting [Wycheproof] test vectors to the blobby format |
-| [`zeroize`] | [![crates.io](https://img.shields.io/crates/v/zeroize.svg)](https://crates.io/crates/zeroize) | [![Documentation](https://docs.rs/zeroize/badge.svg)](https://docs.rs/zeroize) | ![MSRV 1.60][msrv-1.60] | Securely zero memory while avoiding compiler optimizations |
+| [`zeroize`] | [![crates.io](https://img.shields.io/crates/v/zeroize.svg)](https://crates.io/crates/zeroize) | [![Documentation](https://docs.rs/zeroize/badge.svg)](https://docs.rs/zeroize) | ![MSRV 1.61][msrv-1.61] | Securely zero memory while avoiding compiler optimizations |
 
 ## License
 
@@ -53,6 +53,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [msrv-1.57]: https://img.shields.io/badge/rustc-1.57.0+-blue.svg
 [msrv-1.59]: https://img.shields.io/badge/rustc-1.59.0+-blue.svg
 [msrv-1.60]: https://img.shields.io/badge/rustc-1.60.0+-blue.svg
+[msrv-1.61]: https://img.shields.io/badge/rustc-1.61.0+-blue.svg
 
 [//]: # (crates)
 

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 categories = ["cryptography", "memory-management", "no-std", "os"]
 keywords = ["memory", "memset", "secure", "volatile", "zero"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -23,7 +23,6 @@ zeroize_derive = { version = "1.3", path = "derive", optional = true }
 
 [features]
 default = ["alloc"]
-aarch64 = []
 alloc = []
 derive = ["zeroize_derive"]
 std = ["alloc"]

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -36,7 +36,7 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or newer.
+Rust **1.61** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -64,7 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/zeroize/badge.svg
 [docs-link]: https://docs.rs/zeroize/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.61+-blue.svg
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml
 

--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -22,7 +22,6 @@ macro_rules! impl_zeroize_for_simd_register {
     };
 }
 
-// TODO(tarcieri): other NEON register types?
 impl_zeroize_for_simd_register! {
     uint8x8_t,
     uint8x16_t,
@@ -32,4 +31,22 @@ impl_zeroize_for_simd_register! {
     uint32x4_t,
     uint64x1_t,
     uint64x2_t,
+    int8x8_t,
+    int8x16_t,
+    int16x4_t,
+    int16x8_t,
+    int32x2_t,
+    int32x4_t,
+    int64x1_t,
+    int64x2_t,
+    float32x2_t,
+    float32x4_t,
+    float64x1_t,
+    float64x2_t,
+    poly8x8_t,
+    poly8x16_t,
+    poly16x4_t,
+    poly16x8_t,
+    poly64x1_t,
+    poly64x2_t,
 }

--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -2,6 +2,7 @@
 
 use crate::{atomic_fence, volatile_write, Zeroize};
 
+#[allow(clippy::wildcard_imports)]
 use core::arch::aarch64::*;
 
 macro_rules! impl_zeroize_for_simd_register {

--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -1,7 +1,4 @@
 //! [`Zeroize`] impls for ARM64 SIMD registers.
-//!
-//! Gated behind the `aarch64` feature: MSRV 1.59
-//! (the overall crate is MSRV 1.60)
 
 use crate::{atomic_fence, volatile_write, Zeroize};
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -227,6 +227,8 @@
 //! [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
 //! [`Ordering::SeqCst`]: core::sync::atomic::Ordering::SeqCst
 
+#![allow(clippy::inline_always)]
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -41,15 +41,13 @@
 //! ```
 //! use zeroize::Zeroize;
 //!
-//! fn main() {
-//!     // Protip: don't embed secrets in your source code.
-//!     // This is just an example.
-//!     let mut secret = b"Air shield password: 1,2,3,4,5".to_vec();
-//!     // [ ... ] open the air shield here
+//! // Protip: don't embed secrets in your source code.
+//! // This is just an example.
+//! let mut secret = b"Air shield password: 1,2,3,4,5".to_vec();
+//! // [ ... ] open the air shield here
 //!
-//!     // Now that we're done using the secret, zero it out.
-//!     secret.zeroize();
-//! }
+//! // Now that we're done using the secret, zero it out.
+//! secret.zeroize();
 //! ```
 //!
 //! The [`Zeroize`] trait is impl'd on all of Rust's core scalar types including
@@ -143,16 +141,14 @@
 //! ```
 //! use zeroize::Zeroizing;
 //!
-//! fn main() {
-//!     let mut secret = Zeroizing::new([0u8; 5]);
+//! let mut secret = Zeroizing::new([0u8; 5]);
 //!
-//!     // Set the air shield password
-//!     // Protip (again): don't embed secrets in your source code.
-//!     secret.copy_from_slice(&[1, 2, 3, 4, 5]);
-//!     assert_eq!(secret.as_ref(), &[1, 2, 3, 4, 5]);
+//! // Set the air shield password
+//! // Protip (again): don't embed secrets in your source code.
+//! secret.copy_from_slice(&[1, 2, 3, 4, 5]);
+//! assert_eq!(secret.as_ref(), &[1, 2, 3, 4, 5]);
 //!
-//!     // The contents of `secret` will be automatically zeroized on drop
-//! }
+//! // The contents of `secret` will be automatically zeroized on drop
 //! ```
 //!
 //! ## What guarantees does this crate provide?

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -34,7 +34,7 @@
 //! Requires Rust **1.60** or newer.
 //!
 //! In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
-//! for this crate's SemVer guarantees), however when we do it will be accompanied
+//! for this crate's `SemVer` guarantees), however when we do it will be accompanied
 //! by a minor version bump.
 //!
 //! ## Usage
@@ -312,10 +312,10 @@ impl_zeroize_with_default! {
     u8, u16, u32, u64, u128, usize
 }
 
-/// `PhantomPinned` is zero sized so provide a ZeroizeOnDrop implementation.
+/// [`PhantomPinned`] is zero sized so provide a [`ZeroizeOnDrop`] implementation.
 impl ZeroizeOnDrop for PhantomPinned {}
 
-/// `()` is zero sized so provide a ZeroizeOnDrop implementation.
+/// `()` is zero sized so provide a [`ZeroizeOnDrop`] implementation.
 impl ZeroizeOnDrop for () {}
 
 macro_rules! impl_zeroize_for_non_zero {
@@ -393,7 +393,7 @@ where
 
             // Ensures self is None and that the value was dropped. Without the take, the drop
             // of the (zeroized) value isn't called, which might lead to a leak or other
-            // unexpected behavior. For example, if this were Option<Vec<T>>, the above call to
+            // unexpected behavior. For example, if this were `Option<Vec<T>>`, the above call to
             // zeroize would not free the allocated memory, but the the `take` call will.
             self.take();
         }
@@ -434,7 +434,7 @@ impl<Z> Zeroize for MaybeUninit<Z> {
     fn zeroize(&mut self) {
         // Safety:
         // `MaybeUninit` is valid for any byte pattern, including zeros.
-        unsafe { ptr::write_volatile(self, MaybeUninit::zeroed()) }
+        unsafe { ptr::write_volatile(self, Self::zeroed()) }
         atomic_fence();
     }
 }
@@ -452,12 +452,12 @@ impl<Z> Zeroize for [MaybeUninit<Z>] {
     fn zeroize(&mut self) {
         let ptr = self.as_mut_ptr().cast::<MaybeUninit<u8>>();
         let size = self.len().checked_mul(mem::size_of::<Z>()).unwrap();
-        assert!(size <= isize::MAX as usize);
+        assert!(isize::try_from(size).is_ok());
 
         // Safety:
         //
         // This is safe, because every valid pointer is well aligned for u8
-        // and it is backed by a single allocated object for at least `self.len() * size_pf::<Z>()` bytes.
+        // and it is backed by a single allocated object for at least `self.len() * size_of::<Z>()` bytes.
         // and 0 is a valid value for `MaybeUninit<Z>`
         // The memory of the slice should not wrap around the address space.
         unsafe { volatile_set(ptr, MaybeUninit::zeroed(), size) }
@@ -478,7 +478,7 @@ where
     Z: DefaultIsZeroes,
 {
     fn zeroize(&mut self) {
-        assert!(self.len() <= isize::MAX as usize);
+        assert!(isize::try_from(self.len()).is_ok());
 
         // Safety:
         //
@@ -504,7 +504,7 @@ impl<Z> Zeroize for PhantomData<Z> {
     fn zeroize(&mut self) {}
 }
 
-/// [`PhantomData` is always zero sized so provide a ZeroizeOnDrop implementation.
+/// [`PhantomData`] is always zero sized so provide a [`ZeroizeOnDrop`] implementation.
 impl<Z> ZeroizeOnDrop for PhantomData<Z> {}
 
 macro_rules! impl_zeroize_tuple {
@@ -616,8 +616,8 @@ impl Zeroize for CString {
     }
 }
 
-/// `Zeroizing` is a a wrapper for any `Z: Zeroize` type which implements a
-/// `Drop` handler which zeroizes dropped values.
+/// [`Zeroizing`] is a a wrapper for any `Z: Zeroize` type which implements a
+/// [`Drop`] handler which zeroizes dropped values.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Zeroizing<Z: Zeroize>(Z);
 
@@ -625,10 +625,10 @@ impl<Z> Zeroizing<Z>
 where
     Z: Zeroize,
 {
-    /// Move value inside a `Zeroizing` wrapper which ensures it will be
+    /// Move value inside a [`Zeroizing`] wrapper which ensures it will be
     /// zeroized when it's dropped.
     #[inline(always)]
-    pub fn new(value: Z) -> Self {
+    pub const fn new(value: Z) -> Self {
         Self(value)
     }
 }
@@ -651,8 +651,8 @@ where
     Z: Zeroize,
 {
     #[inline(always)]
-    fn from(value: Z) -> Zeroizing<Z> {
-        Zeroizing(value)
+    fn from(value: Z) -> Self {
+        Self(value)
     }
 }
 
@@ -716,7 +716,7 @@ where
     Z: Zeroize,
 {
     fn drop(&mut self) {
-        self.0.zeroize()
+        self.0.zeroize();
     }
 }
 
@@ -792,7 +792,7 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 /// Internal module used as support for `AssertZeroizeOnDrop`.
 #[doc(hidden)]
 pub mod __internal {
-    use super::*;
+    use super::{Zeroize, ZeroizeOnDrop};
 
     /// Auto-deref workaround for deriving `ZeroizeOnDrop`.
     pub trait AssertZeroizeOnDrop {
@@ -810,7 +810,7 @@ pub mod __internal {
 
     impl<T: Zeroize + ?Sized> AssertZeroize for T {
         fn zeroize_or_on_drop(&mut self) {
-            self.zeroize()
+            self.zeroize();
         }
     }
 }

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -243,6 +243,8 @@ pub use zeroize_derive::{Zeroize, ZeroizeOnDrop};
 
 #[cfg(all(feature = "aarch64", target_arch = "aarch64"))]
 mod aarch64;
+#[cfg(all(target_arch = "wasm32", target_family = "wasm"))]
+mod wasm32;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -26,6 +26,7 @@
 //! - No FFI or inline assembly! **WASM friendly** (and tested)!
 //! - `#![no_std]` i.e. **embedded-friendly**!
 //! - No functionality besides securely zeroing memory!
+//! - Support for zeroing SIMD registers on `x86`, `x86_64`, `aarch64` and `wasm` targets!
 //! - (Optional) Custom derive support for zeroing complex structures
 //!
 //! ## Minimum Supported Rust Version
@@ -204,15 +205,10 @@
 //!
 //! <https://crates.io/crates/secrecy>
 //!
-//! ## What about: clearing registers, mlock, mprotect, etc?
+//! ## What about: mlock, mprotect, etc?
 //!
 //! This crate is focused on providing simple, unobtrusive support for reliably
 //! zeroing memory using the best approach possible on stable Rust.
-//!
-//! Clearing registers is a difficult problem that can't easily be solved by
-//! something like a crate, and requires either inline ASM or rustc support.
-//! See <https://github.com/rust-lang/rust/issues/17046> for background on
-//! this particular problem.
 //!
 //! Other memory protection mechanisms are interesting and useful, but often
 //! overkill (e.g. defending against RAM scraping or attackers with swap access).
@@ -241,7 +237,7 @@ extern crate std;
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize_derive")))]
 pub use zeroize_derive::{Zeroize, ZeroizeOnDrop};
 
-#[cfg(all(feature = "aarch64", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 mod aarch64;
 #[cfg(all(target_arch = "wasm32", target_family = "wasm"))]
 mod wasm32;

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Requires Rust **1.60** or newer.
+//! Requires Rust **1.61** or newer.
 //!
 //! In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 //! for this crate's `SemVer` guarantees), however when we do it will be accompanied

--- a/zeroize/src/wasm32.rs
+++ b/zeroize/src/wasm32.rs
@@ -1,0 +1,22 @@
+//! [`Zeroize`] impls for WASM SIMD registers.
+
+use crate::{atomic_fence, volatile_write, Zeroize};
+
+use core::arch::wasm32::v128;
+
+macro_rules! impl_zeroize_for_simd_register {
+    ($($type:ty),* $(,)?) => {
+        $(
+            #[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32", target_family = "wasm")))]
+            impl Zeroize for $type {
+                #[inline]
+                fn zeroize(&mut self) {
+                    volatile_write(self, unsafe { core::mem::zeroed() });
+                    atomic_fence();
+                }
+            }
+        )+
+    };
+}
+
+impl_zeroize_for_simd_register!(v128);

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -3,9 +3,11 @@
 use crate::{atomic_fence, volatile_write, Zeroize};
 
 #[cfg(target_arch = "x86")]
+#[allow(clippy::wildcard_imports)]
 use core::arch::x86::*;
 
 #[cfg(target_arch = "x86_64")]
+#[allow(clippy::wildcard_imports)]
 use core::arch::x86_64::*;
 
 macro_rules! impl_zeroize_for_simd_register {


### PR DESCRIPTION
This includes:

- Support for `wasm`'s `v128` SIMD register
- Support for `Aarch64` `int*`, `float*` and `poly*` registers
- Removes the `aarch64` feature (and the corresponding docs) as the MSRV was above that required by `core::arch::aarch64` (**breaking change**)
- Ran clippy on the entire crate and added `#[allow(...)]`s where appropriate (wildcard imports and inline always)
- `Zeroizing::new()` is now `const` (required MSRV bump to 1.61 - **breaking change**)
- Cleaned up the docs in general, fixed a typo and removed some irrelevant documentation regarding the lack of support for clearing registers (very outdated)

I attempted to add feature-gated support for `__m512*` registers but it was only stabilized in 1.73.0, and even with some `#[cfg]`s, I couldn't get anything working on my 7950x (which has more than enough AVX512 support). It would've been a nice touch considering the rest of the breaking changes.

I could attempt to implement the changes brought up in #841 ~~but maybe by XORing the value with itself within an ASM block or something similar?~~ not really viable due to the generic-ness of the implementation.

I can always revert the two breaking changes - they're not super important but `const Zeroizing::new()` is quite nice, at not a great cost.