### PR TITLE
zeroize: run clippy, clean up some docs and typos

### DIFF
--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -5,6 +5,7 @@
 
 use crate::{atomic_fence, volatile_write, Zeroize};
 
+#[allow(clippy::wildcard_imports)]
 use core::arch::aarch64::*;
 
 macro_rules! impl_zeroize_for_simd_register {

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -41,15 +41,13 @@
 //! ```
 //! use zeroize::Zeroize;
 //!
-//! fn main() {
-//!     // Protip: don't embed secrets in your source code.
-//!     // This is just an example.
-//!     let mut secret = b"Air shield password: 1,2,3,4,5".to_vec();
-//!     // [ ... ] open the air shield here
+//! // Protip: don't embed secrets in your source code.
+//! // This is just an example.
+//! let mut secret = b"Air shield password: 1,2,3,4,5".to_vec();
+//! // [ ... ] open the air shield here
 //!
-//!     // Now that we're done using the secret, zero it out.
-//!     secret.zeroize();
-//! }
+//! // Now that we're done using the secret, zero it out.
+//! secret.zeroize();
 //! ```
 //!
 //! The [`Zeroize`] trait is impl'd on all of Rust's core scalar types including
@@ -143,16 +141,14 @@
 //! ```
 //! use zeroize::Zeroizing;
 //!
-//! fn main() {
-//!     let mut secret = Zeroizing::new([0u8; 5]);
+//! let mut secret = Zeroizing::new([0u8; 5]);
 //!
-//!     // Set the air shield password
-//!     // Protip (again): don't embed secrets in your source code.
-//!     secret.copy_from_slice(&[1, 2, 3, 4, 5]);
-//!     assert_eq!(secret.as_ref(), &[1, 2, 3, 4, 5]);
+//! // Set the air shield password
+//! // Protip (again): don't embed secrets in your source code.
+//! secret.copy_from_slice(&[1, 2, 3, 4, 5]);
+//! assert_eq!(secret.as_ref(), &[1, 2, 3, 4, 5]);
 //!
-//!     // The contents of `secret` will be automatically zeroized on drop
-//! }
+//! // The contents of `secret` will be automatically zeroized on drop
 //! ```
 //!
 //! ## What guarantees does this crate provide?

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -26,6 +26,7 @@
 //! - No FFI or inline assembly! **WASM friendly** (and tested)!
 //! - `#![no_std]` i.e. **embedded-friendly**!
 //! - No functionality besides securely zeroing memory!
+//! - Support for zeroing SIMD registers on `x86`, `x86_64`, `aarch64` targets!
 //! - (Optional) Custom derive support for zeroing complex structures
 //!
 //! ## Minimum Supported Rust Version

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -232,6 +232,8 @@
 //! [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
 //! [`Ordering::SeqCst`]: core::sync::atomic::Ordering::SeqCst
 
+#![allow(clippy::inline_always)]
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -3,9 +3,11 @@
 use crate::{atomic_fence, volatile_write, Zeroize};
 
 #[cfg(target_arch = "x86")]
+#[allow(clippy::wildcard_imports)]
 use core::arch::x86::*;
 
 #[cfg(target_arch = "x86_64")]
+#[allow(clippy::wildcard_imports)]
 use core::arch::x86_64::*;
 
 macro_rules! impl_zeroize_for_simd_register {


### PR DESCRIPTION
This PR is rather self explanatory. I opted to allow `inline(always)` as in an application there's a good chance thst these will be pretty hot paths.

I also allowed wildcard imports within the `aarch64` and `x86` modules, as it'd just be a pain to keep track of all of the separate types.

Additionally, I chose to keep the notice about the lack of support for clearing registers. Inline-ASM is now a thing and end users are able to use it as they wish, but it's not specific to SIMD registers (which I failed to understand at first). We could maybe remove the part about the `rustc` support requirement/update it a little to make it more accurate for the current state of Rust, but I'm not really sure in that regard.