### PR TITLE
zeroize: add support for `wasm`'s `v128` SIMD register

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -247,6 +247,8 @@ pub use zeroize_derive::{Zeroize, ZeroizeOnDrop};
 
 #[cfg(all(feature = "aarch64", target_arch = "aarch64"))]
 mod aarch64;
+#[cfg(all(target_arch = "wasm32", target_family = "wasm"))]
+mod wasm32;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
 

--- a/zeroize/src/wasm32.rs
+++ b/zeroize/src/wasm32.rs
@@ -1,0 +1,22 @@
+//! [`Zeroize`] impls for WASM SIMD registers.
+
+use crate::{atomic_fence, volatile_write, Zeroize};
+
+use core::arch::wasm32::v128;
+
+macro_rules! impl_zeroize_for_simd_register {
+    ($($type:ty),* $(,)?) => {
+        $(
+            #[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32", target_family = "wasm")))]
+            impl Zeroize for $type {
+                #[inline]
+                fn zeroize(&mut self) {
+                    volatile_write(self, unsafe { core::mem::zeroed() });
+                    atomic_fence();
+                }
+            }
+        )+
+    };
+}
+
+impl_zeroize_for_simd_register!(v128);


### PR DESCRIPTION
This PR adds support for zeroing `wasm`'s `v128` register. The module is named after the `core::arch` module, but it does require that `target_family = "wasm"` so I'm unsure of which naming scheme to stick with - I'm not too familiar with WASM as a whole to be honest.

I'll leave this as a draft until #967 is ready and merged, as the `support for zeroing SIMD registers for ...` notice will need updating.