### PR TITLE
cpufeatures: add support of armv8.2-a sm3, sm4 (#970)

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -69,6 +69,7 @@ __expand_check_macro! {
     ("aes",    AES),    // Enable AES support.
     ("sha2",   SHA2),   // Enable SHA1 and SHA256 support.
     ("sha3",   SHA3),   // Enable SHA512 and SHA3 support.
+    ("sm4",    SM4),    // Enable SM3 and SM4 support.
 }
 
 /// Linux hardware capabilities mapped to target features.
@@ -85,6 +86,7 @@ pub mod hwcaps {
     pub const AES: c_ulong = libc::HWCAP_AES | libc::HWCAP_PMULL;
     pub const SHA2: c_ulong = libc::HWCAP_SHA2;
     pub const SHA3: c_ulong = libc::HWCAP_SHA3 | libc::HWCAP_SHA512;
+    pub const SM4: c_ulong = libc::HWCAP_SM3 | libc::HWCAP_SM4;
 }
 
 // Apple OS (macOS, iOS, watchOS, and tvOS) `check!` macro.

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -18,6 +18,10 @@
 //! - `sha2`*
 //! - `sha3`*
 //!
+//! Linux only
+//!
+//! - `sm4`*
+//!
 //! ## `loongarch64`
 //!
 //! Linux only (LoongArch64 does not support OS-independent feature detection)

--- a/cpufeatures/tests/aarch64.rs
+++ b/cpufeatures/tests/aarch64.rs
@@ -2,7 +2,7 @@
 
 #![cfg(target_arch = "aarch64")]
 
-cpufeatures::new!(armcaps, "aes", "sha2", "sha3");
+cpufeatures::new!(armcaps, "aes", "sha2", "sha3", "sm4");
 
 #[test]
 fn init() {


### PR DESCRIPTION
Only supported on Linux platform with HWCAP_SM3 | HWCAP_SM4.

fix #970 .