### PR TITLE
fiat-constify: Fix implementation for fiat-crypto >= 0.0.21

### DIFF
--- a/fiat-constify/Cargo.toml
+++ b/fiat-constify/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
+prettyplease = "0.2.15"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["extra-traits", "full"] }

--- a/fiat-constify/src/main.rs
+++ b/fiat-constify/src/main.rs
@@ -5,17 +5,20 @@
 
 #![allow(clippy::single_match, clippy::new_without_default)]
 
-use proc_macro2::{Literal, Span};
-use quote::{quote, ToTokens};
+mod outputs;
+mod type_registry;
+
+use outputs::Outputs;
+use quote::quote;
 use std::{collections::BTreeMap as Map, env, fs, ops::Deref};
 use syn::{
+    parse_quote,
     punctuated::Punctuated,
-    token::{Brace, Bracket, Colon, Const, Eq, Let, Mut, Not, Paren, Pound, RArrow, Semi},
-    AttrStyle, Attribute, Block, Expr, ExprAssign, ExprCall, ExprLit, ExprPath, ExprReference,
-    ExprRepeat, ExprTuple, FnArg, Ident, Item, ItemFn, ItemType, Lit, LitInt, Local, LocalInit,
-    MacroDelimiter, Meta, MetaList, Pat, PatIdent, PatTuple, PatType, Path, PathArguments,
-    PathSegment, ReturnType, Stmt, Type, TypeArray, TypePath, TypeReference, TypeTuple, UnOp,
+    token::{Const, Eq, Let, Paren, Semi},
+    Expr, ExprCall, ExprPath, ExprReference, FnArg, Ident, Item, ItemFn, Local, LocalInit, Pat,
+    PatIdent, PatTuple, Path, Stmt, TypeReference,
 };
+use type_registry::TypeRegistry;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = env::args().collect::<Vec<_>>();
@@ -26,20 +29,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let code = fs::read_to_string(&args[1])?;
     let mut ast = syn::parse_file(&code)?;
-
-    // Add lint attributes
-    ast.attrs.push(build_attribute(
-        "allow",
-        &[
-            "clippy::identity_op",
-            "clippy::unnecessary_cast",
-            "dead_code",
-            "rustdoc::broken_intra_doc_links",
-            "unused_assignments",
-            "unused_mut",
-            "unused_variables",
-        ],
-    ));
+    ast.attrs.push(parse_quote! {
+        #![allow(
+            clippy::identity_op,
+            clippy::unnecessary_cast,
+            dead_code,
+            rustdoc::broken_intra_doc_links,
+            unused_assignments,
+            unused_mut,
+            unused_variables
+        )]
+    });
 
     let mut type_registry = TypeRegistry::new();
 
@@ -47,53 +47,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for item in &mut ast.items {
         match item {
             Item::Fn(func) => rewrite_fn_as_const(func, &type_registry),
-            Item::Type(ty) => type_registry.add(ty),
+            Item::Type(ty) => type_registry.add_type_alias(ty),
+            Item::Struct(ty) => type_registry.add_new_type(ty),
             _ => (),
         }
     }
 
     println!("#![doc = \" fiat-crypto output postprocessed by fiat-constify: <https://github.com/rustcrypto/utils>\"]");
-    println!("{}", ast.into_token_stream());
+    println!("{}", prettyplease::unparse(&ast));
     Ok(())
-}
-
-/// Build a toplevel attribute with the given name and comma-separated values.
-fn build_attribute(name: &str, values: &[&str]) -> Attribute {
-    let values = values
-        .iter()
-        .map(|value| build_path(value))
-        .collect::<Vec<_>>();
-    let path = build_path(name);
-    let tokens = quote! { #(#values),* };
-    let delimiter = MacroDelimiter::Paren(Paren::default());
-
-    Attribute {
-        pound_token: Pound::default(),
-        style: AttrStyle::Inner(Not::default()),
-        bracket_token: Bracket::default(),
-        meta: Meta::List(MetaList {
-            path,
-            delimiter,
-            tokens,
-        }),
-    }
-}
-
-/// Parse a path from a double-colon-delimited string.
-fn build_path(path: &str) -> Path {
-    let mut segments = Punctuated::new();
-
-    for segment in path.split("::") {
-        segments.push(PathSegment {
-            ident: Ident::new(segment, Span::call_site()),
-            arguments: PathArguments::None,
-        });
-    }
-
-    Path {
-        leading_colon: None,
-        segments,
-    }
 }
 
 /// Get an `Ident` from a `Pat::Ident`.
@@ -112,19 +74,35 @@ fn rewrite_fn_as_const(func: &mut ItemFn, type_registry: &TypeRegistry) {
 
     // Transform mutable arguments into return values.
     let mut inputs = Punctuated::new();
-    let mut outputs = Outputs::new();
+    let mut outputs = Outputs::new(type_registry);
+    let mut stmts = Vec::<Stmt>::new();
 
     for arg in &func.sig.inputs {
         // Transform mutable function arguments into return values
         if let FnArg::Typed(t) = arg {
             match &*t.ty {
-                Type::Reference(TypeReference {
+                syn::Type::Reference(TypeReference {
                     mutability: Some(_), // look for mutable references
                     elem,
                     ..
                 }) => {
                     outputs.add(get_ident_from_pat(&t.pat), elem.deref().clone());
                     continue;
+                }
+                syn::Type::Reference(TypeReference {
+                    mutability: None,
+                    elem,
+                    ..
+                }) if matches!(elem.deref(), syn::Type::Path(_)) => {
+                    // Generation of reborrows, LLVM should optimize this out, and it definitely
+                    // will if `#[repr(transparent)]` is used.
+                    let ty = type_registry::type_to_ident(elem).unwrap();
+                    let ident = get_ident_from_pat(&t.pat);
+                    if outputs.type_registry().is_new_type(ty) {
+                        stmts.push(parse_quote! {
+                            let #ident = &#ident.0;
+                        });
+                    }
                 }
                 _ => (),
             }
@@ -137,52 +115,88 @@ fn rewrite_fn_as_const(func: &mut ItemFn, type_registry: &TypeRegistry) {
     // Replace inputs with ones where the mutable references have been filtered out
     func.sig.inputs = inputs;
     func.sig.output = outputs.to_return_type();
-    func.block = Box::new(rewrite_fn_body(&func.block.stmts, &outputs, type_registry));
+    stmts.extend(rewrite_fn_body(&func.block.stmts, &outputs));
+    func.block.stmts = stmts;
 }
 
 /// Rewrite the function body, adding let bindings with `Default::default()`
 /// values for outputs, removing mutable references, and adding a return
 /// value/tuple.
-fn rewrite_fn_body(statements: &[Stmt], outputs: &Outputs, registry: &TypeRegistry) -> Block {
-    let mut stmts = Vec::new();
+fn rewrite_fn_body(stmts: &[Stmt], outputs: &Outputs) -> Vec<Stmt> {
+    let mut ident_assignments: Map<&Ident, Vec<&Expr>> = Map::new();
+    let mut rewritten = Vec::new();
 
-    stmts.extend(outputs.to_let_bindings(registry));
-
-    for stmt in statements {
-        let mut stmt = stmt.clone();
-        rewrite_fn_stmt(&mut stmt);
-        stmts.push(stmt.clone());
-    }
-
-    stmts.push(outputs.to_return_value());
-
-    Block {
-        brace_token: Brace::default(),
-        stmts,
-    }
-}
-
-/// Rewrite an expression in the function body, transforming mutable reference
-/// operations into value assignments.
-fn rewrite_fn_stmt(stmt: &mut Stmt) {
-    match stmt {
-        Stmt::Expr(expr, Some(_)) => match expr {
-            Expr::Assign(ExprAssign { left, .. }) => match *left.clone() {
-                Expr::Unary(unary) => {
-                    // Remove deref since we're removing mutable references
-                    if matches!(unary.op, UnOp::Deref(_)) {
-                        *left = unary.expr;
-                    }
+    for stmt in stmts {
+        if let Stmt::Expr(Expr::Assign(assignment), Some(_)) = stmt {
+            let lhs_path = match assignment.left.as_ref() {
+                Expr::Unary(lhs) => {
+                    let Expr::Path(exprpath) = lhs.expr.as_ref() else {
+                        unreachable!()
+                    };
+                    Some(exprpath)
                 }
-                _ => (),
-            },
-            Expr::Call(call) => {
-                *stmt = Stmt::Local(rewrite_fn_call(call.clone()));
+                Expr::Index(lhs) => {
+                    let Expr::Path(exprpath) = lhs.expr.as_ref() else {
+                        unreachable!()
+                    };
+                    Some(exprpath)
+                }
+                Expr::Call(expr) => {
+                    rewritten.push(Stmt::Local(rewrite_fn_call(expr.clone())));
+                    None
+                }
+                _ => None,
+            };
+            if let Some(lhs_path) = lhs_path {
+                ident_assignments
+                    .entry(Path::get_ident(&lhs_path.path).unwrap())
+                    .or_default()
+                    .push(&assignment.right);
             }
-            _ => (),
-        },
-        _ => (),
+        } else if let Stmt::Expr(Expr::Call(expr), Some(_)) = stmt {
+            rewritten.push(Stmt::Local(rewrite_fn_call(expr.clone())));
+        } else {
+            rewritten.push(stmt.clone());
+        }
     }
+
+    let mut asts = Vec::new();
+    for (ident, ty) in outputs.ident_type_pairs() {
+        let value = ident_assignments.get(ident).unwrap();
+        let type_prefix = if type_registry::type_to_ident(ty)
+            .is_some_and(|ident| outputs.type_registry().is_new_type(ident))
+        {
+            Some(ty)
+        } else {
+            None
+        };
+
+        let ast = match (type_prefix, value.len()) {
+            (None, 1) => {
+                let first = value.first().unwrap();
+                quote!(#first)
+            }
+            (Some(prefix), 1) => {
+                let first = value.first().unwrap();
+                quote!(#prefix(#first))
+            }
+
+            (None, _) => {
+                quote!([#(#value),*])
+            }
+            (Some(prefix), _) => {
+                quote!(#prefix([#(#value),*]))
+            }
+        };
+        asts.push(ast);
+    }
+
+    let expr: Expr = parse_quote! {
+        (#(#asts),*)
+    };
+
+    rewritten.push(Stmt::Expr(expr, None));
+    rewritten
 }
 
 /// Rewrite a function call, removing the mutable reference arguments and
@@ -242,189 +256,5 @@ fn rewrite_fn_call(mut call: ExprCall) -> Local {
             diverge: None,
         }),
         semi_token: Semi::default(),
-    }
-}
-
-/// Registry of types defined by the module being processed.
-pub struct TypeRegistry(Map<Ident, Type>);
-
-impl TypeRegistry {
-    /// Create a new type registry.
-    pub fn new() -> Self {
-        Self(Map::new())
-    }
-
-    /// Add a type to the type registry.
-    pub fn add(&mut self, item_type: &ItemType) {
-        if self
-            .0
-            .insert(item_type.ident.clone(), item_type.ty.deref().clone())
-            .is_some()
-        {
-            panic!("duplicate type name: {}", &item_type.ident);
-        }
-    }
-
-    /// Get a type from the registry by its ident.
-    pub fn get(&self, ident: &Ident) -> Option<&Type> {
-        self.0.get(ident)
-    }
-}
-
-/// Output values, which in regular `fiat-crypto` are passed as mutable references, e.g.:
-///
-/// ```
-/// out1: &mut ..., out2: &mut ...
-/// ```
-///
-/// This type stores the outputs and uses them to build the return type
-/// (i.e. `Signature::output`), `let mut` bindings in place of the mutable
-/// references, and a return value instead of using side effects to write to
-/// mutable references.
-#[derive(Debug)]
-pub struct Outputs(Map<Ident, Type>);
-
-impl Outputs {
-    /// Create new output storage.
-    pub fn new() -> Self {
-        Self(Map::new())
-    }
-
-    /// Add an output variable with the given name and type.
-    ///
-    /// Panics if the name is duplicated.
-    pub fn add(&mut self, name: Ident, ty: Type) {
-        if self.0.insert(name.clone(), ty).is_some() {
-            panic!("duplicate output name: {}", name);
-        }
-    }
-
-    /// Generate `let mut outN: Ty = <zero>` bindings at the start
-    /// of the function.
-    pub fn to_let_bindings(&self, registry: &TypeRegistry) -> Vec<Stmt> {
-        self.0
-            .iter()
-            .map(|(ident, ty)| {
-                Stmt::Local(Local {
-                    attrs: Vec::new(),
-                    let_token: Let::default(),
-                    pat: Pat::Type(PatType {
-                        attrs: Vec::new(),
-                        pat: Box::new(Pat::Ident(PatIdent {
-                            attrs: Vec::new(),
-                            by_ref: None,
-                            mutability: Some(Mut::default()),
-                            ident: ident.clone(),
-                            subpat: None,
-                        })),
-                        colon_token: Colon::default(),
-                        ty: Box::new(ty.clone()),
-                    }),
-                    init: Some(LocalInit {
-                        eq_token: Eq::default(),
-                        expr: Box::new(default_for(ty, registry)),
-                        diverge: None,
-                    }),
-                    semi_token: Semi::default(),
-                })
-            })
-            .collect()
-    }
-
-    /// Finish annotating outputs, updating the provided `Signature`.
-    pub fn to_return_type(&self) -> ReturnType {
-        let rarrow = RArrow::default();
-
-        let ret = match self.0.len() {
-            0 => panic!("expected at least one output"),
-            1 => self.0.values().next().unwrap().clone(),
-            _ => {
-                let mut elems = Punctuated::new();
-
-                for ty in self.0.values() {
-                    elems.push(ty.clone());
-                }
-
-                Type::Tuple(TypeTuple {
-                    paren_token: Paren::default(),
-                    elems,
-                })
-            }
-        };
-
-        ReturnType::Type(rarrow, Box::new(ret))
-    }
-
-    /// Generate the return value for the statement as a tuple of the outputs.
-    pub fn to_return_value(&self) -> Stmt {
-        let mut elems = self.0.keys().map(|ident| {
-            let mut segments = Punctuated::new();
-            segments.push(PathSegment {
-                ident: ident.clone(),
-                arguments: PathArguments::None,
-            });
-
-            let path = Path {
-                leading_colon: None,
-                segments,
-            };
-
-            Expr::Path(ExprPath {
-                attrs: Vec::new(),
-                qself: None,
-                path,
-            })
-        });
-
-        if elems.len() == 1 {
-            Stmt::Expr(elems.next().unwrap(), None)
-        } else {
-            Stmt::Expr(
-                Expr::Tuple(ExprTuple {
-                    attrs: Vec::new(),
-                    paren_token: Paren::default(),
-                    elems: elems.collect(),
-                }),
-                None,
-            )
-        }
-    }
-}
-
-/// Get a default value for the given type.
-fn default_for(ty: &Type, registry: &TypeRegistry) -> Expr {
-    let zero = Expr::Lit(ExprLit {
-        attrs: Vec::new(),
-        lit: Lit::Int(LitInt::from(Literal::u8_unsuffixed(0))),
-    });
-
-    match ty {
-        Type::Array(TypeArray { len, .. }) => Expr::Repeat(ExprRepeat {
-            attrs: Vec::new(),
-            bracket_token: Bracket::default(),
-            expr: Box::new(zero),
-            semi_token: Semi::default(),
-            len: Box::new(len.clone()),
-        }),
-        Type::Path(TypePath { path, .. }) => {
-            assert_eq!(
-                path.segments.len(),
-                1,
-                "wasn't expecting multiple segments in path"
-            );
-
-            let ident = path.segments.first().unwrap().ident.clone();
-
-            // Attempt to look up type in the registry
-            if let Some(registry_ty) = registry.get(&ident) {
-                // If we got a type from the registry, recurse
-                default_for(registry_ty, registry)
-            } else if matches!(ident.to_string().as_str(), "u8" | "u32" | "u64") {
-                zero
-            } else {
-                panic!("unsupported type: {:?}", ty)
-            }
-        }
-        _ => panic!("don't know how to build default value for {:?}", ty),
     }
 }

--- a/fiat-constify/src/main.rs
+++ b/fiat-constify/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("#![doc = \" fiat-crypto output postprocessed by fiat-constify: <https://github.com/rustcrypto/utils>\"]");
+    println!("//! fiat-crypto output postprocessed by fiat-constify: <https://github.com/rustcrypto/utils>");
     println!("{}", prettyplease::unparse(&ast));
     Ok(())
 }

--- a/fiat-constify/src/outputs.rs
+++ b/fiat-constify/src/outputs.rs
@@ -1,0 +1,77 @@
+use crate::type_registry::TypeRegistry;
+use syn::{
+    punctuated::Punctuated,
+    token::{Paren, RArrow},
+    Ident, ReturnType, Type, TypeTuple,
+};
+
+/// Output values, which in regular `fiat-crypto` are passed as mutable references, e.g.:
+///
+/// ```
+/// out1: &mut ..., out2: &mut ...
+/// ```
+///
+/// This type stores the outputs and uses them to build the return type
+/// (i.e. `Signature::output`), `let mut` bindings in place of the mutable
+/// references, and a return value instead of using side effects to write to
+/// mutable references.
+pub struct Outputs<'a> {
+    type_registry: &'a TypeRegistry,
+    outputs: Vec<(Ident, Type)>,
+}
+
+impl<'a> Outputs<'a> {
+    #[inline]
+    /// Create new output storage.
+    pub fn new(type_registry: &'a TypeRegistry) -> Self {
+        Self {
+            type_registry,
+            outputs: Vec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn type_registry(&self) -> &TypeRegistry {
+        self.type_registry
+    }
+
+    #[inline]
+    pub fn ident_type_pairs(&self) -> impl Iterator<Item = &(Ident, Type)> + ExactSizeIterator {
+        self.outputs.iter()
+    }
+
+    #[inline]
+    fn types(&self) -> impl Iterator<Item = &Type> + ExactSizeIterator {
+        self.outputs.iter().map(|(_, ty)| ty)
+    }
+
+    /// Add an output variable with the given name and type.
+    #[inline]
+    pub fn add(&mut self, name: Ident, ty: Type) {
+        self.outputs.push((name.clone(), ty));
+    }
+
+    /// Finish annotating outputs, updating the provided `Signature`.
+    pub fn to_return_type(&self) -> ReturnType {
+        let rarrow = RArrow::default();
+
+        let ret = match self.outputs.len() {
+            0 => panic!("expected at least one output"),
+            1 => self.types().next().unwrap().clone(),
+            _ => {
+                let mut elems = Punctuated::new();
+
+                for ty in self.types() {
+                    elems.push(ty.clone());
+                }
+
+                Type::Tuple(TypeTuple {
+                    paren_token: Paren::default(),
+                    elems,
+                })
+            }
+        };
+
+        ReturnType::Type(rarrow, Box::new(ret))
+    }
+}

--- a/fiat-constify/src/type_registry.rs
+++ b/fiat-constify/src/type_registry.rs
@@ -47,13 +47,9 @@ impl TypeRegistry {
         self.0.get(ident).copied()
     }
 
+    #[inline]
     pub fn is_new_type(&self, ident: &syn::Ident) -> bool {
-        let mut included = false;
-        if matches!(self.get(ident), Some(Type::NewType)) {
-            included = true;
-        }
-
-        included
+        matches!(self.get(ident), Some(Type::NewType))
     }
 }
 

--- a/fiat-constify/src/type_registry.rs
+++ b/fiat-constify/src/type_registry.rs
@@ -1,0 +1,67 @@
+//! Keeps track of which type is aliasing an existing type and which are new types.
+//!  This is useful because we only need to generate the return type prefixes for new types
+//!
+use std::collections::BTreeMap as Map;
+use syn::{Ident, ItemStruct, ItemType, Path};
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Type {
+    Alias,
+    NewType,
+}
+
+/// Registry of types defined by the module being processed.
+pub struct TypeRegistry(Map<Ident, Type>);
+
+impl TypeRegistry {
+    /// Create a new type registry.
+    pub fn new() -> Self {
+        Self(Map::new())
+    }
+
+    /// Add a type which is a new type to the type registry.
+    pub fn add_new_type(&mut self, item_struct: &ItemStruct) {
+        if self
+            .0
+            .insert(item_struct.ident.clone(), Type::NewType)
+            .is_some()
+        {
+            panic!("duplicate type name: {}", &item_struct.ident);
+        }
+    }
+
+    /// Add a type which is a type alias
+    pub fn add_type_alias(&mut self, item_type: &ItemType) {
+        if self
+            .0
+            .insert(item_type.ident.clone(), Type::Alias)
+            .is_some()
+        {
+            panic!("duplicate type name: {}", &item_type.ident);
+        }
+    }
+
+    /// Get the [`Type`] which the identifier is.
+    ///
+    /// Returns `None` whe ident can't be found.
+    pub fn get(&self, ident: &Ident) -> Option<Type> {
+        self.0.get(ident).copied()
+    }
+
+    pub fn is_new_type(&self, ident: &syn::Ident) -> bool {
+        let mut included = false;
+        if matches!(self.get(ident), Some(Type::NewType)) {
+            included = true;
+        }
+
+        included
+    }
+}
+
+#[inline]
+pub fn type_to_ident(ty: &syn::Type) -> Option<&Ident> {
+    if let syn::Type::Path(path) = ty {
+        return Path::get_ident(&path.path);
+    }
+
+    None
+}


### PR DESCRIPTION
fiat-crypto introduced new types instead of just type aliases, this causes the generated code to no longer compile. This is a breaking change since this will no longer compile code generated by fiat-crypto version < 0.0.21

Tests:
 * All `fiat-crypto` rust crate can be compiled using rustc

# Codegen
## Multiple output args
##### Before
```rust
#[inline]
pub fn fiat_p224_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) {
  // <snipped>
  *out1 = x112;
  out2[0] = x7;
  out2[1] = x8;
  out2[2] = x9;
  out2[3] = x10;
  out2[4] = x11;
  out3[0] = x114;
  out3[1] = x115;
  out3[2] = x116;
  out3[3] = x117;
  out3[4] = x118;
  out4[0] = x119;
  out4[1] = x120;
  out4[2] = x121;
  out4[3] = x122;
  out5[0] = x123;
  out5[1] = x124;
  out5[2] = x125;
  out5[3] = x126;
}
```

##### After
```rust
#[inline]
pub const fn fiat_p224_divstep(
    arg1: u64,
    arg2: &[u64; 5],
    arg3: &[u64; 5],
    arg4: &[u64; 4],
    arg5: &[u64; 4],
) -> (u64, [u64; 5], [u64; 5], [u64; 4], [u64; 4]) {
    // <snipped> 
    (
        x112,
        [x7, x8, x9, x10, x11],
        [x114, x115, x116, x117, x118],
        [x119, x120, x121, x122],
        [x123, x124, x125, x126],
    )
}
```

## Newtyped const output/input
##### Before
```rust
pub fn fiat_p521_relax(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) {
  let x1: u64 = (arg1[0]);
  let x2: u64 = (arg1[1]);
  let x3: u64 = (arg1[2]);
  let x4: u64 = (arg1[3]);
  let x5: u64 = (arg1[4]);
  let x6: u64 = (arg1[5]);
  let x7: u64 = (arg1[6]);
  let x8: u64 = (arg1[7]);
  let x9: u64 = (arg1[8]);
  out1[0] = x1;
  out1[1] = x2;
  out1[2] = x3;
  out1[3] = x4;
  out1[4] = x5;
  out1[5] = x6;
  out1[6] = x7;
  out1[7] = x8;
  out1[8] = x9;
}
```
##### After
```rust
pub const fn fiat_p521_relax(
    arg1: &fiat_p521_tight_field_element,
) -> fiat_p521_loose_field_element {
    let arg1 = &arg1.0;
    let x1: u64 = (arg1[0]);
    let x2: u64 = (arg1[1]);
    let x3: u64 = (arg1[2]);
    let x4: u64 = (arg1[3]);
    let x5: u64 = (arg1[4]);
    let x6: u64 = (arg1[5]);
    let x7: u64 = (arg1[6]);
    let x8: u64 = (arg1[7]);
    let x9: u64 = (arg1[8]);
    (fiat_p521_loose_field_element([x1, x2, x3, x4, x5, x6, x7, x8, x9]))
}
```