### PR TITLE
hybrid-array: Added serde impls for `Array`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "blobby"
 version = "0.3.1"
 dependencies = [
@@ -84,6 +93,9 @@ version = "0.4.1"
 name = "hybrid-array"
 version = "0.2.0-pre.5"
 dependencies = [
+ "bincode",
+ "serde",
+ "serde_json",
  "typenum",
 ]
 
@@ -166,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",

--- a/hybrid-array/CHANGELOG.md
+++ b/hybrid-array/CHANGELOG.md
@@ -5,5 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Pending
+
+- Added `serde` feature - implements `Serialize` and `Deserialize` for `Array`
+
 ## 0.1.0 (2022-05-07)
 - Initial release

--- a/hybrid-array/CHANGELOG.md
+++ b/hybrid-array/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Pending
 
 - Added `serde` feature - implements `Serialize` and `Deserialize` for `Array`
+- Added `ArrayExt::try_from_fn`
 
 ## 0.1.0 (2022-05-07)
 - Initial release

--- a/hybrid-array/Cargo.toml
+++ b/hybrid-array/Cargo.toml
@@ -18,3 +18,12 @@ rust-version = "1.65"
 
 [dependencies]
 typenum = "1.17"
+serde = { version = "1", optional = true }
+
+[dev-dependencies]
+bincode = "1.3"
+serde_json = "1"
+
+[features]
+default = []
+serde = ["dep:serde"]

--- a/hybrid-array/PERMISSIONS
+++ b/hybrid-array/PERMISSIONS
@@ -1,0 +1,23 @@
+generic-array
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Bartłomiej Kamiński
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hybrid-array/README.md
+++ b/hybrid-array/README.md
@@ -40,6 +40,10 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
+### Permissions
+
+Permissions and notices for code we use or modify can be found in [PERMISSIONS](PERMISSIONS).
+
 [//]: # (badges)
 
 [crate-image]: https://buildstats.info/crate/hybrid-array

--- a/hybrid-array/src/impl_serde.rs
+++ b/hybrid-array/src/impl_serde.rs
@@ -74,7 +74,9 @@ where
         // If there's a value allegedly remaining, and deserializing it doesn't fail, then that's a
         // length mismatch error
         if seq.size_hint() != Some(0) && seq.next_element::<Dummy>()?.is_some() {
-            Err(de::Error::invalid_length(N::USIZE + 1, &self))
+            // The addition only saturates if this array is the size of all addressable memory. Not
+            // going to happen. And if it did, the only effect is an off-by-one error message
+            Err(de::Error::invalid_length(N::USIZE.saturating_add(1), &self))
         } else {
             arr
         }

--- a/hybrid-array/src/impl_serde.rs
+++ b/hybrid-array/src/impl_serde.rs
@@ -2,10 +2,12 @@
 // https://github.com/fizyk20/generic-array/blob/0e2a03714b05bb7a737a677f8df77d6360d19c99/src/impl_serde.rs
 
 use crate::{Array, ArraySize};
-use core::fmt;
-use core::marker::PhantomData;
-use serde::de::{self, SeqAccess, Visitor};
-use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer};
+use core::{fmt, marker::PhantomData};
+use serde::{
+    de::{self, SeqAccess, Visitor},
+    ser::SerializeTuple,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 impl<T, N: ArraySize> Serialize for Array<T, N>
 where
@@ -25,7 +27,7 @@ where
     }
 }
 
-struct GAVisitor<T, N> {
+struct ArrayVisitor<T, N> {
     _t: PhantomData<T>,
     _n: PhantomData<N>,
 }
@@ -41,7 +43,7 @@ impl<'de> Deserialize<'de> for Dummy {
     }
 }
 
-impl<'de, T, N: ArraySize> Visitor<'de> for GAVisitor<T, N>
+impl<'de, T, N: ArraySize> Visitor<'de> for ArrayVisitor<T, N>
 where
     T: Deserialize<'de>,
 {
@@ -87,7 +89,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        let visitor = GAVisitor {
+        let visitor = ArrayVisitor {
             _t: PhantomData,
             _n: PhantomData,
         };

--- a/hybrid-array/src/impl_serde.rs
+++ b/hybrid-array/src/impl_serde.rs
@@ -1,0 +1,135 @@
+// This file was modified from
+// https://github.com/fizyk20/generic-array/blob/0e2a03714b05bb7a737a677f8df77d6360d19c99/src/impl_serde.rs
+
+use crate::{Array, ArraySize};
+use core::fmt;
+use core::marker::PhantomData;
+use serde::de::{self, SeqAccess, Visitor};
+use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer};
+
+impl<T, N: ArraySize> Serialize for Array<T, N>
+where
+    T: Serialize,
+{
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tup = serializer.serialize_tuple(N::USIZE)?;
+        for el in self {
+            tup.serialize_element(el)?;
+        }
+
+        tup.end()
+    }
+}
+
+struct GAVisitor<T, N> {
+    _t: PhantomData<T>,
+    _n: PhantomData<N>,
+}
+
+// to avoid extra computation when testing for extra elements in the sequence
+struct Dummy;
+impl<'de> Deserialize<'de> for Dummy {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Dummy)
+    }
+}
+
+impl<'de, T, N: ArraySize> Visitor<'de> for GAVisitor<T, N>
+where
+    T: Deserialize<'de>,
+{
+    type Value = Array<T, N>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "struct Array<T, U{}>", N::USIZE)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Array<T, N>, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        // Check the length in advance
+        match seq.size_hint() {
+            Some(n) if n != N::USIZE => {
+                return Err(de::Error::invalid_length(n, &self));
+            }
+            _ => {}
+        }
+
+        // Deserialize the array
+        let arr = Array::try_from_fn(|idx| {
+            let next_elem_opt = seq.next_element()?;
+            next_elem_opt.ok_or(de::Error::invalid_length(idx, &self))
+        });
+
+        // If there's a value allegedly remaining, and deserializing it doesn't fail, then that's a
+        // length mismatch error
+        if seq.size_hint() != Some(0) && seq.next_element::<Dummy>()?.is_some() {
+            Err(de::Error::invalid_length(N::USIZE + 1, &self))
+        } else {
+            arr
+        }
+    }
+}
+
+impl<'de, T, N: ArraySize> Deserialize<'de> for Array<T, N>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Array<T, N>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let visitor = GAVisitor {
+            _t: PhantomData,
+            _n: PhantomData,
+        };
+        deserializer.deserialize_tuple(N::USIZE, visitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let array = Array::<u8, typenum::U2>::default();
+        let serialized = bincode::serialize(&array);
+        assert!(serialized.is_ok());
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let mut array = Array::<u8, typenum::U2>::default();
+        array[0] = 1;
+        array[1] = 2;
+        let serialized = bincode::serialize(&array).unwrap();
+        let deserialized = bincode::deserialize::<Array<u8, typenum::U2>>(&serialized);
+        assert!(deserialized.is_ok());
+        let array = deserialized.unwrap();
+        assert_eq!(array[0], 1);
+        assert_eq!(array[1], 2);
+    }
+
+    #[test]
+    fn test_serialized_size() {
+        let array = Array::<u8, typenum::U1>::default();
+        let size = bincode::serialized_size(&array).unwrap();
+        assert_eq!(size, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_too_many() {
+        let serialized = "[1, 2, 3, 4, 5]";
+        let _ = serde_json::from_str::<Array<u8, typenum::U4>>(serialized).unwrap();
+    }
+}

--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -583,12 +583,13 @@ pub trait ArrayExt<T>: Sized {
         F: FnMut(usize) -> Result<T, E>;
 
     /// Create array using the given callback function for each element.
+    #[allow(clippy::unwrap_used)]
     fn from_fn<F>(mut cb: F) -> Self
     where
         F: FnMut(usize) -> T,
     {
         // Turn the ordinary callback into a Result callback that always returns Ok
-        let wrapped_cb = |x| Result::<T, ::core::convert::Infallible>::Ok(cb(x));
+        let wrapped_cb = |idx| Result::<_, ::core::convert::Infallible>::Ok(cb(idx));
         // Now use the try_from version of this method
         Self::try_from_fn(wrapped_cb).unwrap()
     }

--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -583,13 +583,13 @@ pub trait ArrayExt<T>: Sized {
         F: FnMut(usize) -> Result<T, E>;
 
     /// Create array using the given callback function for each element.
-    #[allow(clippy::unwrap_used)]
+    #[allow(clippy::unwrap_used, unused_qualifications)]
     fn from_fn<F>(mut cb: F) -> Self
     where
         F: FnMut(usize) -> T,
     {
         // Turn the ordinary callback into a Result callback that always returns Ok
-        let wrapped_cb = |idx| Result::<_, ::core::convert::Infallible>::Ok(cb(idx));
+        let wrapped_cb = |idx| Result::<T, ::core::convert::Infallible>::Ok(cb(idx));
         // Now use the try_from version of this method
         Self::try_from_fn(wrapped_cb).unwrap()
     }


### PR DESCRIPTION
I'd love to switch `hpke` over to `hybrid-array`, since it's becoming pretty hard to manually audit `generic-array`, and we expose it so it's not like we can get away with leaving it old forever.

One of the really convenient things that `generic-array` provides, though, is `Serialize`/`Deserialize` impls for `GenericArray`. We use this in our [Xyber impl](https://github.com/rozbb/rust-hpke/blob/6d3ec43f8b014a7d65faafc3b51d687b04087ce3/src/kem/xyber768d00.rs#L148). The only other option for autoderiving these traits is `serde-bigarray` (upstream support is [not](https://github.com/serde-rs/serde/pull/1860#pullrequestreview-735520420) coming any time soon), and I'd rather not bring it in.

This PR should bring `hybrid-array` a little closer to feature-parity with `generic-array`. I don't love the `unsafe` stuff here, but it's pretty minimal and well-documented, and also has a clear roadmap for removing it once certain functions stabilize.