### PR TITLE
zeroize v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zeroize"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "serde",
  "zeroize_derive",

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.6.1 (2023-11-15)
+## 1.7.0 (2023-11-16)
+### Changed
+- Bump MSRV to 1.60 ([#900])
+
+## 1.6.1 (2023-11-15) [YANKED]
+
+NOTE: yanked because [#900] bumped MSRV to 1.60, which vioates our MSRV policy.
+
 ### Added
 - Impl `Zeroize` for `MaybeUninit` ([#900])
 

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroize"
-version = "1.6.1"
+version = "1.7.0"
 description = """
 Securely clear secrets from memory with a simple trait built on
 stable Rust primitives which guarantee memory is zeroed using an


### PR DESCRIPTION
### Changed
- Bump MSRV to 1.60 ([#900])

[#900]: https://github.com/RustCrypto/utils/pull/900