### PR TITLE
algorithm-registry: initial commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "algorithm-registry"
+version = "0.1.0"
+dependencies = [
+ "const-oid",
+ "digest",
+ "sha1",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
 name = "blobby"
 version = "0.3.1"
 dependencies = [
@@ -11,9 +22,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.11.0-pre"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-pre",
  "hex-literal 0.3.4",
  "zeroize 1.6.0",
 ]
@@ -26,6 +46,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cmov"
 version = "0.3.1"
 
@@ -34,10 +60,35 @@ name = "collectable"
 version = "0.0.2"
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -56,12 +107,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
 name = "fiat-constify"
 version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -109,6 +181,15 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -176,6 +257,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +310,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wycheproof2blb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "algorithm-registry",
     "blobby",
     "block-buffer",
     "block-padding",
@@ -15,7 +16,7 @@ members = [
     "opaque-debug",
     "wycheproof2blb",
     "zeroize",
-    "zeroize/derive"
+    "zeroize/derive",
 ]
 
 [profile.dev]

--- a/algorithm-registry/Cargo.toml
+++ b/algorithm-registry/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "algorithm-registry"
+version = "0.1.0"
+description = """
+Utility to lookup algorithms from their OID
+"""
+authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+edition = "2018"
+documentation = "https://docs.rs/algorithm-db"
+repository = "https://github.com/RustCrypto/hashes"
+categories = ["cryptography"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+const-oid = { version = "0.9" }
+digest = "0.10.7"
+
+sha1 = { version = "0.10.6", features = ["oid"], optional = true }
+sha2 = { version = "0.10.8", features = ["oid"], optional = true }
+sha3 = { version = "0.10.8", features = ["oid"], optional = true }
+
+[features]
+default = ["sha1", "sha2", "sha3"]
+sha1 = ["dep:sha1"]
+sha2 = ["dep:sha2"]
+sha3 = ["dep:sha3"]

--- a/algorithm-registry/README.md
+++ b/algorithm-registry/README.md
@@ -1,0 +1,9 @@
+# [RustCrypto]: Algorithm Registry
+
+Registry allows a user to dynamically lookup an implementation of algorithm by OID.
+This is used for validation of certificates and other structures.
+
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/rustcrypto

--- a/algorithm-registry/src/digest.rs
+++ b/algorithm-registry/src/digest.rs
@@ -1,0 +1,36 @@
+use const_oid::{AssociatedOid, ObjectIdentifier};
+use digest::{Digest, DynDigest};
+
+/// [`get_digest`] would lookup the
+pub fn get_digest(identifier: ObjectIdentifier) -> Option<Box<dyn DynDigest>> {
+    macro_rules! check_match {
+        ($h:ty) => {
+            if (identifier == <$h as AssociatedOid>::OID) {
+                return Some(Box::new(<$h>::new()));
+            }
+        };
+    }
+
+    #[cfg(feature = "sha1")]
+    {
+        check_match!(sha1::Sha1);
+    }
+
+    #[cfg(feature = "sha2")]
+    {
+        check_match!(sha2::Sha224);
+        check_match!(sha2::Sha256);
+        check_match!(sha2::Sha384);
+        check_match!(sha2::Sha512);
+    }
+
+    #[cfg(feature = "sha3")]
+    {
+        check_match!(sha3::Sha3_224);
+        check_match!(sha3::Sha3_256);
+        check_match!(sha3::Sha3_384);
+        check_match!(sha3::Sha3_512);
+    }
+
+    None
+}

--- a/algorithm-registry/src/lib.rs
+++ b/algorithm-registry/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+pub mod digest;


### PR DESCRIPTION
This provides an helper for looking up an algorithm according to its OID.

I've found the same piece of code repeated in various ways all over in consumers of rust-crypto. This is an attempt at providing an implementation for rust-crypto users.