### PR TITLE
fiat-constify: remove MSRV

### DIFF
--- a/.github/workflows/fiat-constify.yml
+++ b/.github/workflows/fiat-constify.yml
@@ -22,17 +22,9 @@ env:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        toolchain:
-          - 1.56.0 # MSRV
-          - stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
-      - run: cargo test --all-features

--- a/fiat-constify/Cargo.toml
+++ b/fiat-constify/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["cryptography"]
 keywords = ["fiat-crypto", "field"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
 
 [dependencies]
 proc-macro2 = "1"

--- a/fiat-constify/README.md
+++ b/fiat-constify/README.md
@@ -5,7 +5,6 @@
 [![Build Status][build-image]][build-link]
 [![Safety Dance][safety-image]][safety-link]
 ![Apache2/MIT licensed][license-image]
-![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
 
 Postprocessor for [fiat-crypto] generated field implementations which rewrites
@@ -48,7 +47,6 @@ dual licensed as above, without any additional terms or conditions.
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
 


### PR DESCRIPTION
This is a simple command line utility intended for internal use only.

There's no need to have an MSRV policy around it, and having one was breaking the build of #984