### PR TITLE
Fix cmovnz documentation

### DIFF
--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -27,7 +27,7 @@ pub trait Cmov {
     ///
     /// Uses a `test` instruction to check if the given `condition` value is
     /// equal to zero, conditionally moves `value` to `self` when `condition` is
-    /// equal to zero.
+    /// not equal to zero.
     fn cmovnz(&mut self, value: &Self, condition: Condition);
 
     /// Move if zero.


### PR DESCRIPTION
cmovnz moves when condition is **not** 0. Basically just a typo.