### PR TITLE
hybrid-array: remove `ByteArray` alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
 name = "fiat-constify"
 version = "0.0.0"
 dependencies = [
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
@@ -120,6 +121,16 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 [[package]]
 name = "opaque-debug"
 version = "0.3.0"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -514,9 +514,6 @@ fn check_slice_length<T, U: ArraySize>(slice: &[T]) -> Result<(), TryFromSliceEr
     Ok(())
 }
 
-/// Byte array type.
-pub type ByteArray<U> = Array<u8, U>;
-
 /// Array operations which are const generic over a given array size.
 pub trait ArrayOps<T, const N: usize>:
     AsRef<[T; N]>

--- a/hybrid-array/tests/mod.rs
+++ b/hybrid-array/tests/mod.rs
@@ -1,4 +1,4 @@
-use hybrid_array::{Array, ByteArray};
+use hybrid_array::Array;
 use typenum::{U0, U2, U3, U4, U6, U7};
 
 const EXAMPLE_SLICE: &[u8] = &[1, 2, 3, 4, 5, 6];
@@ -11,30 +11,30 @@ fn clone_from_slice() {
 
 #[test]
 fn tryfrom_slice_for_array() {
-    assert!(ByteArray::<U0>::try_from(EXAMPLE_SLICE).is_err());
-    assert!(ByteArray::<U3>::try_from(EXAMPLE_SLICE).is_err());
+    assert!(Array::<u8, U0>::try_from(EXAMPLE_SLICE).is_err());
+    assert!(Array::<u8, U3>::try_from(EXAMPLE_SLICE).is_err());
 
-    let array_ref = ByteArray::<U6>::try_from(EXAMPLE_SLICE).expect("slice contains 6 bytes");
+    let array_ref = Array::<u8, U6>::try_from(EXAMPLE_SLICE).expect("slice contains 6 bytes");
     assert_eq!(&*array_ref, EXAMPLE_SLICE);
 
-    assert!(ByteArray::<U7>::try_from(EXAMPLE_SLICE).is_err());
+    assert!(Array::<u8, U7>::try_from(EXAMPLE_SLICE).is_err());
 }
 
 #[test]
 fn tryfrom_slice_for_array_ref() {
-    assert!(<&ByteArray<U0>>::try_from(EXAMPLE_SLICE).is_err());
-    assert!(<&ByteArray::<U3>>::try_from(EXAMPLE_SLICE).is_err());
+    assert!(<&Array<u8, U0>>::try_from(EXAMPLE_SLICE).is_err());
+    assert!(<&Array::<u8, U3>>::try_from(EXAMPLE_SLICE).is_err());
 
-    let array_ref = <&ByteArray<U6>>::try_from(EXAMPLE_SLICE).expect("slice contains 6 bytes");
+    let array_ref = <&Array<u8, U6>>::try_from(EXAMPLE_SLICE).expect("slice contains 6 bytes");
     assert_eq!(array_ref.as_slice(), EXAMPLE_SLICE);
 
-    assert!(<&ByteArray::<U7>>::try_from(EXAMPLE_SLICE).is_err());
+    assert!(<&Array::<u8, U7>>::try_from(EXAMPLE_SLICE).is_err());
 }
 
 #[test]
 fn concat() {
-    let prefix = ByteArray::<U2>::clone_from_slice(&EXAMPLE_SLICE[..2]);
-    let suffix = ByteArray::<U4>::clone_from_slice(&EXAMPLE_SLICE[2..]);
+    let prefix = Array::<u8, U2>::clone_from_slice(&EXAMPLE_SLICE[..2]);
+    let suffix = Array::<u8, U4>::clone_from_slice(&EXAMPLE_SLICE[2..]);
 
     let array = prefix.concat(suffix);
     assert_eq!(array.as_slice(), EXAMPLE_SLICE);
@@ -42,7 +42,7 @@ fn concat() {
 
 #[test]
 fn split() {
-    let array = ByteArray::<U6>::clone_from_slice(EXAMPLE_SLICE);
+    let array = Array::<u8, U6>::clone_from_slice(EXAMPLE_SLICE);
 
     let (prefix, suffix) = array.split::<U2>();
 
@@ -52,7 +52,7 @@ fn split() {
 
 #[test]
 fn split_ref() {
-    let array = ByteArray::<U6>::clone_from_slice(EXAMPLE_SLICE);
+    let array = Array::<u8, U6>::clone_from_slice(EXAMPLE_SLICE);
 
     let (prefix, suffix) = array.split_ref::<U3>();
 
@@ -62,7 +62,7 @@ fn split_ref() {
 
 #[test]
 fn split_ref_mut() {
-    let array = &mut ByteArray::<U6>::clone_from_slice(EXAMPLE_SLICE);
+    let array = &mut Array::<u8, U6>::clone_from_slice(EXAMPLE_SLICE);
 
     let (prefix, suffix) = array.split_ref_mut::<U4>();
 


### PR DESCRIPTION
It's longer than `Array<u8, _>` and provides little value other than needless indirection.

Closes #987