### PR TITLE
hybrid-array: simplify `From<Array<T, U>>` impl for `[T; N]`

### DIFF
--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -351,12 +351,11 @@ where
 impl<T, U, const N: usize> From<Array<T, U>> for [T; N]
 where
     Array<T, U>: ArrayOps<T, N>,
-    U: ArraySize,
+    U: ArraySize<ArrayType<T> = [T; N]>,
 {
     #[inline]
     fn from(arr: Array<T, U>) -> [T; N] {
-        let mut items = arr.0.into_iter();
-        core::array::from_fn(|_| items.next().expect("should always have item"))
+        arr.0
     }
 }
 


### PR DESCRIPTION
If the latter is named specifically as an associated type, then it can simply be moved out of the `Array` newtype.