### PR TITLE
hybrid-array: use `assert_ne!` in `slice_as_chunks(_mut)`

### DIFF
--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -741,7 +741,7 @@ impl<T, const N: usize> FromFn<T> for [T; N] {
 /// Panics if `N` is 0.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn slice_as_chunks<T, N: ArraySize>(buf: &[T]) -> (&[Array<T, N>], &[T]) {
-    assert!(N::USIZE != 0, "chunk size must be non-zero");
+    assert_ne!(N::USIZE, 0, "chunk size must be non-zero");
     // Arithmetic safety: we have checked that `N::USIZE` is not zero, thus
     // division always returns correct result. `tail_pos` can not be bigger than `buf.len()`,
     // thus overflow on multiplication and underflow on substraction are impossible.
@@ -763,7 +763,7 @@ pub fn slice_as_chunks<T, N: ArraySize>(buf: &[T]) -> (&[Array<T, N>], &[T]) {
 /// Panics if `N` is 0.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn slice_as_chunks_mut<T, N: ArraySize>(buf: &mut [T]) -> (&mut [Array<T, N>], &mut [T]) {
-    assert!(N::USIZE != 0, "chunk size must be non-zero");
+    assert_ne!(N::USIZE, 0, "chunk size must be non-zero");
     // Arithmetic safety: we have checked that `N::USIZE` is not zero, thus
     // division always returns correct result. `tail_pos` can not be bigger than `buf.len()`,
     // thus overflow on multiplication and underflow on substraction are impossible.


### PR DESCRIPTION
Provides more effective debugging in the event the wrong size is used