### PR TITLE
hybrid-array: add `ArrayN` type alias

### DIFF
--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -44,6 +44,9 @@ use typenum::{Diff, Sum, Unsigned};
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
+/// Type alias for [`Array`] which is const generic around a size `N`, ala `[T; N]`.
+pub type ArrayN<T, const N: usize> = Array<T, <[T; N] as AssociatedArraySize>::Size>;
+
 /// Hybrid typenum-based and const generic array type.
 ///
 /// Provides the flexibility of typenum-based expressions while also

--- a/hybrid-array/tests/mod.rs
+++ b/hybrid-array/tests/mod.rs
@@ -1,7 +1,10 @@
-use hybrid_array::Array;
+use hybrid_array::{Array, ArrayN};
 use typenum::{U0, U2, U3, U4, U6, U7};
 
 const EXAMPLE_SLICE: &[u8] = &[1, 2, 3, 4, 5, 6];
+
+/// Ensure `ArrayN` works as expected.
+const _FOO: ArrayN<u8, 4> = Array([1, 2, 3, 4]);
 
 #[test]
 fn clone_from_slice() {


### PR DESCRIPTION
Adds a type alias for `Array` which uses const generics instead of `typenum`.