### PR TITLE
Release *-pre.2 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 dependencies = [
  "crypto-common",
  "hex-literal 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-pre.1"
+version = "0.4.0-pre.2"
 dependencies = [
  "hybrid-array 0.2.0-pre.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "dbl"
-version = "0.4.0-pre.1"
+version = "0.4.0-pre.2"
 dependencies = [
  "hybrid-array 0.2.0-pre.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 dependencies = [
  "block-padding",
  "hybrid-array 0.2.0-pre.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Buffer type for block processing of data"

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.4.0-pre.1"
+version = "0.4.0-pre.2"
 description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl"
-version = "0.4.0-pre.1"
+version = "0.4.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Double operation in Galois Field GF(2^128) as used by e.g. CMAC/PMAC"

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 description = "Custom reference types for code generic over in-place and buffer-to-buffer modes of operation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ keywords = ["custom-reference"]
 readme = "README.md"
 
 [dependencies]
-block-padding = { version = "=0.4.0-pre.1", path = "../block-padding", optional = true }
+block-padding = { version = "=0.4.0-pre.2", path = "../block-padding", optional = true }
 hybrid-array = "=0.2.0-pre.7"
 
 [features]


### PR DESCRIPTION
Cuts the following prereleases, which include a bump to `hybrid-array` v0.2.0-pre.7:

- `block-buffer` v0.11.0-pre.2
- `block-padding` v0.4.0-pre.2
- `dbl` v0.4.0-pre.2
- `inout` v0.2.0-pre.2