### PR TITLE
hybrid-array: re-add `AsRef<[T; N]>`/`AsMut<[T; N]>` impls

### DIFF
--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -212,6 +212,17 @@ where
     }
 }
 
+impl<T, U, const N: usize> AsRef<[T; N]> for Array<T, U>
+where
+    Self: ArrayOps<T, N>,
+    U: ArraySize,
+{
+    #[inline]
+    fn as_ref(&self) -> &[T; N] {
+        self.as_core_array()
+    }
+}
+
 impl<T, U> AsMut<[T]> for Array<T, U>
 where
     U: ArraySize,
@@ -219,6 +230,17 @@ where
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self.0.as_mut()
+    }
+}
+
+impl<T, U, const N: usize> AsMut<[T; N]> for Array<T, U>
+where
+    Self: ArrayOps<T, N>,
+    U: ArraySize,
+{
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T; N] {
+        self.as_mut_core_array()
     }
 }
 


### PR DESCRIPTION
These were removed in #1026 for more consistency with core arrays and so inference would work by eliminating overlapping impls.

However, `generic-array` provides these impls, which makes removing them problematic when migrating `generic-array`-based code, so it's easier to keep them around, even if it breaks inference due to overlapping impls.