### PR TITLE
hybrid-array: add `FromIterator` impl

### DIFF
--- a/hybrid-array/src/lib.rs
+++ b/hybrid-array/src/lib.rs
@@ -419,6 +419,25 @@ where
     }
 }
 
+impl<T, U> FromIterator<T> for Array<T, U>
+where
+    U: ArraySize,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
+        let ret = Self::from_fn(|_| {
+            iter.next()
+                .expect("iterator should have enough items to fill array")
+        });
+
+        assert!(
+            iter.next().is_none(),
+            "too many items in iterator to fit in array"
+        );
+        ret
+    }
+}
+
 impl<T, U> Hash for Array<T, U>
 where
     T: Hash,

--- a/hybrid-array/tests/mod.rs
+++ b/hybrid-array/tests/mod.rs
@@ -1,5 +1,5 @@
 use hybrid_array::{Array, ArrayN};
-use typenum::{U0, U2, U3, U4, U6, U7};
+use typenum::{U0, U2, U3, U4, U5, U6, U7};
 
 const EXAMPLE_SLICE: &[u8] = &[1, 2, 3, 4, 5, 6];
 
@@ -71,4 +71,22 @@ fn split_ref_mut() {
 
     assert_eq!(prefix.as_slice(), &EXAMPLE_SLICE[..4]);
     assert_eq!(suffix.as_slice(), &EXAMPLE_SLICE[4..]);
+}
+
+#[test]
+fn from_iterator_correct_size() {
+    let array: Array<u8, U6> = EXAMPLE_SLICE.iter().copied().collect();
+    assert_eq!(array.as_slice(), EXAMPLE_SLICE);
+}
+
+#[test]
+#[should_panic]
+fn from_iterator_too_short() {
+    let _array: Array<u8, U7> = EXAMPLE_SLICE.iter().copied().collect();
+}
+
+#[test]
+#[should_panic]
+fn from_iterator_too_long() {
+    let _array: Array<u8, U5> = EXAMPLE_SLICE.iter().copied().collect();
 }


### PR DESCRIPTION
For feature parity with `GenericArray`.

It would be nice to have a fallible version of this which returns an error instead of panicking on length mismatch, but we'd first need to add `FromFn::try_from_fn` or thereabouts.

This is enough to cover the immediate use cases in the meantime.