### PR TITLE
Bump `crypto-common` and `hybrid-array`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 dependencies = [
  "crypto-common",
  "hex-literal 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-pre.3"
+version = "0.4.0-pre.4"
 dependencies = [
- "hybrid-array 0.2.0-pre.8",
+ "hybrid-array 0.2.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -42,18 +42,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
+checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
 dependencies = [
- "hybrid-array 0.2.0-pre.8",
+ "hybrid-array 0.2.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "dbl"
-version = "0.4.0-pre.3"
+version = "0.4.0-pre.4"
 dependencies = [
- "hybrid-array 0.2.0-pre.8",
+ "hybrid-array 0.2.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,15 +84,6 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "hybrid-array"
 version = "0.2.0-rc.0"
 dependencies = [
  "typenum",
@@ -100,11 +91,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "inout"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 dependencies = [
  "block-padding",
- "hybrid-array 0.2.0-pre.8",
+ "hybrid-array 0.2.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Buffer type for block processing of data"
@@ -13,7 +13,7 @@ readme = "README.md"
 rust-version = "1.65"
 
 [dependencies]
-crypto-common = "=0.2.0-pre.3"
+crypto-common = "=0.2.0-pre.4"
 zeroize = { version = "1.4", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.4.0-pre.3"
+version = "0.4.0-pre.4"
 description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 readme = "README.md"
 
 [dependencies]
-hybrid-array = "=0.2.0-pre.8"
+hybrid-array = "0.2.0-rc.0"
 
 [features]
 std = []

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl"
-version = "0.4.0-pre.3"
+version = "0.4.0-pre.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Double operation in Galois Field GF(2^128) as used by e.g. CMAC/PMAC"
@@ -12,5 +12,5 @@ rust-version = "1.65"
 readme = "README.md"
 
 [dependencies]
-hybrid-array = "=0.2.0-pre.8"
+hybrid-array = "0.2.0-rc.0"
 

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 description = "Custom reference types for code generic over in-place and buffer-to-buffer modes of operation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ keywords = ["custom-reference"]
 readme = "README.md"
 
 [dependencies]
-block-padding = { version = "=0.4.0-pre.3", path = "../block-padding", optional = true }
-hybrid-array = "=0.2.0-pre.8"
+block-padding = { version = "=0.4.0-pre.4", path = "../block-padding", optional = true }
+hybrid-array = "0.2.0-rc.0"
 
 [features]
 std = ["block-padding/std"]


### PR DESCRIPTION
Bumps the following dependencies:

- `crypto-common` => v0.2.0-pre.4
- `hybrid-array` => v0.2.0-rc.0

Also prepares the following releases:

- `block-buffer` v0.11.0-pre.4
- `block-padding` v0.4.0-pre.4
- `dbl` v0.4.0-pre.4
- `inout` v0.2.0-pre.4