### PR TITLE
Adding a zeroize function for flat types

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -795,7 +795,7 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
     }
 }
 
-/// Zeroizes a flat type/struct. Only zeroizes the values that it owns, and it does not work on 
+/// Zeroizes a flat type/struct. Only zeroizes the values that it owns, and it does not work on
 /// dynamically sized values or trait objects.
 #[inline(always)]
 pub fn zeroize_flat_type<T: Sized>(data: &mut T) {
@@ -805,9 +805,7 @@ pub fn zeroize_flat_type<T: Sized>(data: &mut T) {
     //
     // This is safe because `mem::size_of<T>()` returns the exact size of the object in memory, and
     // `data_ptr` points directly to the first byte of the data.
-    unsafe {
-        volatile_set(data_ptr, 0, size)
-    }
+    unsafe { volatile_set(data_ptr, 0, size) }
     atomic_fence()
 }
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -799,7 +799,7 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 /// dynamically sized values or trait objects. Do not use this function on a type that already
 /// implements `ZeroizeOnDrop`.
 ///
-/// # Safety:
+/// # Safety
 /// - The type must not contain references to outside data or dynamically sized data
 /// - This function can invalidate the type if it is used after this function is called on it. It is
 ///   advisable to call this method in `impl Drop`.

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -843,9 +843,9 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 ///         unsafe { zeroize_flat_type(self as *mut Self) }
 ///     }
 /// }
-/// impl ZeroizeOnDrop for DatatoZeroize {}
+/// impl ZeroizeOnDrop for DataToZeroize {}
 ///
-/// let mut data = DataToZerioze {
+/// let mut data = DataToZeroize {
 ///     flat_data_1: [3u8; 32],
 ///     flat_data_2: SomeMoreFlatData(123u64)
 /// };

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -796,9 +796,10 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 }
 
 /// Zeroizes a flat type/struct. Only zeroizes the values that it owns, and it does not work on
-/// dynamically sized values or trait objects.
+/// dynamically sized values or trait objects. Do not use this function on a type that already
+/// implements `ZeroizeOnDrop`.
 ///
-/// ## Safety:
+/// # Safety:
 /// - The type must not contain references to outside data or dynamically sized data
 /// - This function can invalidate the type if it is used after this function is called on it. It is
 ///   advisable to call this method in `impl Drop`.

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -805,10 +805,6 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 #[inline(always)]
 pub unsafe fn zeroize_flat_type<T: Sized>(data: *mut T) {
     let size = mem::size_of::<T>();
-    // Safety:
-    //
-    // This is safe because `mem::size_of<T>()` returns the exact size of the object in memory, and
-    // `data_ptr` points directly to the first byte of the data.
     volatile_set(data as *mut u8, 0, size);
     atomic_fence()
 }

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -797,11 +797,11 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 
 /// Zeroizes a flat type/struct. Only zeroizes the values that it owns, and it does not work on
 /// dynamically sized values or trait objects.
-/// 
+///
 /// ## Safety:
 /// - The type must not contain references to outside data or dynamically sized data
-/// - This function can invalidate the type if it is used after this function is called on it. It is 
-///   advisable to call this method in `drop()`.
+/// - This function can invalidate the type if it is used after this function is called on it. It is
+///   advisable to call this method in `impl Drop`.
 #[inline(always)]
 pub unsafe fn zeroize_flat_type<T: Sized>(data: *mut T) {
     let size = mem::size_of::<T>();

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -805,6 +805,10 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 #[inline(always)]
 pub unsafe fn zeroize_flat_type<T: Sized>(data: *mut T) {
     let size = mem::size_of::<T>();
+    // Safety:
+    //
+    // This is safe because `mem::size_of<T>()` returns the exact size of the object in memory, and
+    // `data_ptr` points directly to the first byte of the data.
     volatile_set(data as *mut u8, 0, size);
     atomic_fence()
 }

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -800,9 +800,93 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 /// implements `ZeroizeOnDrop`.
 ///
 /// # Safety
-/// - The type must not contain references to outside data or dynamically sized data
+/// - The type must not contain references to outside data or dynamically sized data, such as Vec<X>
+///   or String<X>.
 /// - This function can invalidate the type if it is used after this function is called on it. It is
-///   advisable to call this method in `impl Drop`.
+///   advisable to call this function in `impl Drop`.
+/// - The bit pattern of all zeroes must be valid for the data being zeroized. This may not be true for
+///   enums and pointers.
+///
+/// # Examples
+/// Safe usage for a simple struct:
+/// ```
+/// use zeroize::{ZeroizeOnDrop, zeroize_flat_type};
+///
+/// struct DataToZeroize(u64);
+///
+/// struct MoreDataToZeroize {
+///     flat_data_1: [u8; 32],
+///     flat_data_2: DataToZeroize,
+/// }
+///
+/// impl Drop for MoreDataToZeroize {
+///     fn drop(&mut self) {
+///         unsafe { zeroize_flat_type(self as *mut Self) }
+///     }
+/// }
+/// impl ZeroizeOnDrop for MoreDataToZeroize {}
+///
+/// let mut data = MoreDataToZeroize {
+///     flat_data_1: [3u8; 32],
+///     flat_data_2: DataToZeroize(123u64)
+/// };
+///
+/// // data gets zeroized when dropped
+/// ```
+/// ## Unsafe examples
+/// Below is an unsafe example. It is not comprehensive, but if the data you want to zeroize
+/// contains any of the following types, consider using `Zeroize` instead of `zeroize_flat_type`.
+/// ```
+/// use std::boxed::Box;
+/// use std::collections::HashMap;
+/// use std::sync::Arc;
+/// use std::vec::Vec;
+///
+/// struct UnsafeExample<'a> {
+///     // zeroizing pointers will create a null pointer, which could lead to dereferencing
+///     // null pointers
+///     ptr: *const u8,
+///     ptr_mut: *mut u8,
+///
+///     // references are non-nullable and should point to valid data
+///     reference: &'a u8,
+///     reference_mut: &'a mut u8,
+///
+///     // smart pointers are designed to manage ownership and deallocation of heap memory.
+///     // zeroizing them can mess up this management and result in memory leaks or double frees.
+///     smart_ptr_1: Vec<u8>,
+///     smart_ptr_2: Box<u8>,
+///     smart_ptr_3: Arc<u8>,
+///     hashmap: HashMap<u32, u32>,
+///     string: String
+/// }
+///
+/// // calling `zeroize_flat_type()` on this struct could be unsafe
+/// ```
+///
+/// The below example shows what happens when `zeroize_flat_type` is ran on a type containing a
+/// smart pointer.
+/// ```
+/// use zeroize::zeroize_flat_type;
+///
+/// struct UnsafeExample(String);
+///
+/// let mut data = UnsafeExample(String::from("take care when zeroizing with zeroize_flat_type()"));
+///
+/// // save the original pointer to determine if the data is still in memory after zeroizing
+/// let original_ptr = data.0.as_ptr();
+///
+/// unsafe { zeroize_flat_type(&mut data as *mut UnsafeExample) }
+///
+/// // the String's metadata was overwritten (such as the pointer to the heap, length, capacity)
+/// assert_eq!(data.0.as_ptr().is_null(), true);
+/// assert_eq!(data.0.len(), 0);
+/// assert_eq!(data.0.capacity(), 0);
+///
+/// // the original data still lives on the heap, possibly resulting in a little memory leak
+/// let memory_inspection = unsafe { core::slice::from_raw_parts(original_ptr, 49) };
+/// assert_eq!(memory_inspection, b"take care when zeroizing with zeroize_flat_type()");
+/// ```
 #[inline(always)]
 pub unsafe fn zeroize_flat_type<T: Sized>(data: *mut T) {
     let size = mem::size_of::<T>();

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -798,12 +798,13 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 /// Zeroizes a flat type/struct. Only zeroizes the values that it owns, and it does not work on 
 /// dynamically sized values or trait objects.
 #[inline(always)]
-pub fn zeroize_flat_type<T>(data: &mut T) {
+pub fn zeroize_flat_type<T: Sized>(data: &mut T) {
     let size = mem::size_of::<T>();
     let data_ptr = (data as *mut T).cast::<u8>();
     // Safety:
     //
-    // This is safe because `mem::size_of<T>()` returns the exact size of the object in memory.
+    // This is safe because `mem::size_of<T>()` returns the exact size of the object in memory, and
+    // `data_ptr` points directly to the first byte of the data.
     unsafe {
         volatile_set(data_ptr, 0, size)
     }

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -795,6 +795,21 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
     }
 }
 
+/// Zeroizes a flat type/struct. Only zeroizes the values that it owns, and it does not work on 
+/// dynamically sized values or trait objects.
+#[inline(always)]
+pub fn zeroize_flat_type<T>(data: &mut T) {
+    let size = mem::size_of::<T>();
+    let data_ptr = (data as *mut T).cast::<u8>();
+    // Safety:
+    //
+    // This is safe because `mem::size_of<T>()` returns the exact size of the object in memory.
+    unsafe {
+        volatile_set(data_ptr, 0, size)
+    }
+    atomic_fence()
+}
+
 /// Internal module used as support for `AssertZeroizeOnDrop`.
 #[doc(hidden)]
 pub mod __internal {

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -797,15 +797,19 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 
 /// Zeroizes a flat type/struct. Only zeroizes the values that it owns, and it does not work on
 /// dynamically sized values or trait objects.
+/// 
+/// ## Safety:
+/// - The type must not contain references to outside data or dynamically sized data
+/// - This function can invalidate the type if it is used after this function is called on it. It is 
+///   advisable to call this method in `drop()`.
 #[inline(always)]
-pub fn zeroize_flat_type<T: Sized>(data: &mut T) {
+pub unsafe fn zeroize_flat_type<T: Sized>(data: *mut T) {
     let size = mem::size_of::<T>();
-    let data_ptr = (data as *mut T).cast::<u8>();
     // Safety:
     //
     // This is safe because `mem::size_of<T>()` returns the exact size of the object in memory, and
     // `data_ptr` points directly to the first byte of the data.
-    unsafe { volatile_set(data_ptr, 0, size) }
+    volatile_set(data as *mut u8, 0, size);
     atomic_fence()
 }
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -866,7 +866,7 @@ unsafe fn volatile_set<T: Copy + Sized>(dst: *mut T, src: T, count: usize) {
 ///
 /// The below example shows what happens when `zeroize_flat_type` is ran on a type containing a
 /// smart pointer.
-/// ```
+/// ```no_run
 /// use zeroize::zeroize_flat_type;
 ///
 /// struct UnsafeExample(String);


### PR DESCRIPTION
For reducing zeroize code in chacha20, as per @newpavlov's [suggestion](https://github.com/RustCrypto/stream-ciphers/issues/336#issuecomment-1880346171)
I'm unsure of the name, documentation, and whether it should be a method instead of a function.