### PR TITLE
Add Zeroize impls for __m512 types

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.71.0 # Pinned to prevent breakages
+          toolchain: 1.72.0 # Pinned to prevent breakages
           components: clippy
       - run: cargo clippy --all --all-features -- -D warnings
 

--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -53,7 +53,7 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.72.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.72.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
@@ -71,7 +71,7 @@ jobs:
           # 64-bit macOS x86_64
           - target: x86_64-apple-darwin
             platform: macos-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.72.0 # MSRV
           - target: x86_64-apple-darwin
             platform: macos-latest
             rust: stable
@@ -79,7 +79,7 @@ jobs:
           # 64-bit Windows
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.72.0 # MSRV
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
             rust: stable
@@ -102,7 +102,7 @@ jobs:
         include:
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.60.0 # MSRV
+            rust: 1.72.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest
@@ -122,7 +122,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            rust: 1.60.0
+            rust: 1.72.0
           - target: aarch64-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 categories = ["cryptography", "memory-management", "no-std", "os"]
 keywords = ["memory", "memset", "secure", "volatile", "zero"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.72"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -23,4 +23,6 @@ macro_rules! impl_zeroize_for_simd_register {
     };
 }
 
-impl_zeroize_for_simd_register!(__m128, __m128d, __m128i, __m256, __m256d, __m256i);
+impl_zeroize_for_simd_register!(
+    __m128, __m128d, __m128i, __m256, __m256d, __m256i, __m512, __m512d, __m512i
+);


### PR DESCRIPTION
This PR adds `Zeroize` impls for `__m512` types. It also bumps the MSRV to `1.72.0` since that was when these types were stabilized (according to godbolt).