### PR TITLE
feat(opaque-debug): support generics

### DIFF
--- a/opaque-debug/src/lib.rs
+++ b/opaque-debug/src/lib.rs
@@ -8,6 +8,17 @@
 #[doc(hidden)]
 pub extern crate core as __core;
 
+#[macro_export]
+#[doc(hidden)]
+macro_rules! format_params {
+    ($single:ident) => {
+        "{}"
+    };
+    ($first:ident, $($rest:ident),+) => {
+        concat!("{}", ", ", $crate::format_params!($($rest),+))
+    };
+}
+
 /// Macro for defining opaque `Debug` implementation.
 ///
 /// It will use the following format: "StructName { ... }". While it's
@@ -16,6 +27,20 @@ pub extern crate core as __core;
 /// uncareful logging.
 #[macro_export]
 macro_rules! implement {
+    ($struct:ident <$($params:ident),+>) => {
+        impl <$($params),+> $crate::__core::fmt::Debug for $struct <$($params),+> {
+            fn fmt(
+                &self,
+                f: &mut $crate::__core::fmt::Formatter,
+            ) -> Result<(), $crate::__core::fmt::Error> {
+                write!(
+                    f,
+                    concat!(stringify!($struct), "<", $crate::format_params!($($params),+), "> {{ ... }}"),
+                    $($crate::__core::any::type_name::<$params>()),+
+                )
+            }
+        }
+    };
     ($struct:ty) => {
         impl $crate::__core::fmt::Debug for $struct {
             fn fmt(

--- a/opaque-debug/tests/mod.rs
+++ b/opaque-debug/tests/mod.rs
@@ -6,8 +6,50 @@ struct Foo {
 
 opaque_debug::implement!(Foo);
 
+struct FooGeneric<T> {
+    secret: u64,
+    generic: T,
+}
+
+opaque_debug::implement!(FooGeneric<T>);
+
+struct FooManyGenerics<T, U, V> {
+    secret: u64,
+    generic1: T,
+    generic2: U,
+    generic3: V,
+}
+
+opaque_debug::implement!(FooManyGenerics<T, U, V>);
+
 #[test]
 fn debug_formatting() {
     let s = format!("{:?}", Foo { secret: 42 });
     assert_eq!(s, "Foo { ... }");
+}
+
+#[test]
+fn debug_formatting_generic() {
+    let s = format!(
+        "{:?}",
+        FooGeneric::<()> {
+            secret: 42,
+            generic: ()
+        }
+    );
+    assert_eq!(s, "FooGeneric<()> { ... }");
+}
+
+#[test]
+fn debug_formatting_many_generics() {
+    let s = format!(
+        "{:?}",
+        FooManyGenerics::<(), u8, &str> {
+            secret: 42,
+            generic1: (),
+            generic2: 0u8,
+            generic3: "hello",
+        }
+    );
+    assert_eq!(s, "FooManyGenerics<(), u8, &str> { ... }");
 }


### PR DESCRIPTION
This PR adds support for opaque debug impls on structs with generics. It does not support structs with trait bounds as working with them using macro_rules! is not possible as far as I can tell.

It also wasn't obvious how to avoid exporting the `format_params` macro which is required to build the format template without a trailing comma eg `Foo<T, U, V,> { ... }`.