### PR TITLE
zeroize: use `doc_auto_cfg`

### DIFF
--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -1,7 +1,4 @@
 //! [`Zeroize`] impls for ARM64 SIMD registers.
-//!
-//! Gated behind the `aarch64` feature: MSRV 1.59
-//! (the overall crate is MSRV 1.60)
 
 use crate::{atomic_fence, volatile_write, Zeroize};
 
@@ -10,7 +7,6 @@ use core::arch::aarch64::*;
 macro_rules! impl_zeroize_for_simd_register {
     ($($type:ty),* $(,)?) => {
         $(
-            #[cfg_attr(docsrs, doc(cfg(target_arch = "aarch64")))]
             impl Zeroize for $type {
                 #[inline]
                 fn zeroize(&mut self) {

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
@@ -243,7 +243,6 @@ extern crate alloc;
 extern crate std;
 
 #[cfg(feature = "zeroize_derive")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize_derive")))]
 pub use zeroize_derive::{Zeroize, ZeroizeOnDrop};
 
 #[cfg(all(feature = "aarch64", target_arch = "aarch64"))]
@@ -541,7 +540,6 @@ impl_zeroize_tuple!(A, B, C, D, E, F, G, H, I);
 impl_zeroize_tuple!(A, B, C, D, E, F, G, H, I, J);
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<Z> Zeroize for Vec<Z>
 where
     Z: Zeroize,
@@ -563,11 +561,9 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<Z> ZeroizeOnDrop for Vec<Z> where Z: ZeroizeOnDrop {}
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<Z> Zeroize for Box<[Z]>
 where
     Z: Zeroize,
@@ -580,11 +576,9 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<Z> ZeroizeOnDrop for Box<[Z]> where Z: ZeroizeOnDrop {}
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Zeroize for Box<str> {
     fn zeroize(&mut self) {
         self.as_mut().zeroize();
@@ -592,7 +586,6 @@ impl Zeroize for Box<str> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Zeroize for String {
     fn zeroize(&mut self) {
         unsafe { self.as_mut_vec() }.zeroize();
@@ -600,7 +593,6 @@ impl Zeroize for String {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Zeroize for CString {
     fn zeroize(&mut self) {
         // mem::take uses replace internally to swap the pointer

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -11,7 +11,6 @@ use core::arch::x86_64::*;
 macro_rules! impl_zeroize_for_simd_register {
     ($($type:ty),* $(,)?) => {
         $(
-            #[cfg_attr(docsrs, doc(cfg(any(target_arch = "x86", target_arch = "x86_64"))))]
             impl Zeroize for $type {
                 #[inline]
                 fn zeroize(&mut self) {


### PR DESCRIPTION
Replaces manual `doc_cfg` annotations with automatic ones powered by `doc_auto_cfg`.