### PR TITLE
zeroize: always enable AArch64 support

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -23,10 +23,11 @@ zeroize_derive = { version = "1.3", path = "derive", optional = true }
 
 [features]
 default = ["alloc"]
-aarch64 = []
 alloc = []
-derive = ["zeroize_derive"]
 std = ["alloc"]
+
+aarch64 = [] # NOTE: vestigial no-op feature; AArch64 support is always enabled now
+derive = ["zeroize_derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -245,7 +245,7 @@ extern crate std;
 #[cfg(feature = "zeroize_derive")]
 pub use zeroize_derive::{Zeroize, ZeroizeOnDrop};
 
-#[cfg(all(feature = "aarch64", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 mod aarch64;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;


### PR DESCRIPTION
Now that our MSRV is high enough we don't need to feature-gate `aarch64` support anymore, and instead it can be always-on when compiling for `aarch64` targets.

The `aarch64` feature is retained as a noop since removing it would be a breaking change.