### PR TITLE
zeroize 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ version = "0.11.0-pre.5"
 dependencies = [
  "crypto-common",
  "hex-literal 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.7.0",
 ]
 
 [[package]]
@@ -216,16 +216,16 @@ dependencies = [
 [[package]]
 name = "zeroize"
 version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zeroize"
+version = "1.8.0"
 dependencies = [
  "serde",
  "zeroize_derive",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zeroize_derive"

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.8.0 (2024-04-24)
+### Added
+- Unsafe `zeroize_flat_type` function ([#1045])
+- `Zeroize` impls for `__m512` types on `x86`/`x86_64` targets ([#1052])
+
+### Changed
+- Bump MSRV to 1.72 ([#1052])
+- Always enable AArch64 support ([#1064])
+
+### Fixed
+- Nightly warnings ([#1055])
+
+[#1045]: https://github.com/RustCrypto/utils/pull/1045
+[#1052]: https://github.com/RustCrypto/utils/pull/1052
+[#1055]: https://github.com/RustCrypto/utils/pull/1055
+[#1064]: https://github.com/RustCrypto/utils/pull/1064
+
 ## 1.7.0 (2023-11-16)
 ### Changed
 - Bump MSRV to 1.60 ([#900])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.0"
 description = """
 Securely clear secrets from memory with a simple trait built on
 stable Rust primitives which guarantee memory is zeroed using an

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -36,7 +36,7 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or newer.
+Rust **1.72** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -60,21 +60,35 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/zeroize.svg
+
 [crate-link]: https://crates.io/crates/zeroize
+
 [docs-image]: https://docs.rs/zeroize/badge.svg
+
 [docs-link]: https://docs.rs/zeroize/
+
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml/badge.svg
+
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml
 
 [//]: # (general links)
 
 [RustCrypto]: https://github.com/RustCrypto
+
 [zeroize]: https://en.wikipedia.org/wiki/Zeroisation
+
 [`Zeroize` trait]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
+
 [Documentation]: https://docs.rs/zeroize/
+
 [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+
 [core::ptr::write_volatile]: https://doc.rust-lang.org/core/ptr/fn.write_volatile.html
+
 [core::sync::atomic]: https://doc.rust-lang.org/stable/core/sync/atomic/index.html
+
 [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Requires Rust **1.60** or newer.
+//! Requires Rust **1.72** or newer.
 //!
 //! In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 //! for this crate's SemVer guarantees), however when we do it will be accompanied


### PR DESCRIPTION
### Added
- Unsafe `zeroize_flat_type` function ([#1045])
- `Zeroize` impls for `__m512` types on `x86`/`x86_64` targets ([#1052])

### Changed
- Bump MSRV to 1.72 ([#1052])
- Always enable AArch64 support ([#1064])

### Fixed
- Nightly warnings ([#1055])

[#1045]: https://github.com/RustCrypto/utils/pull/1045
[#1052]: https://github.com/RustCrypto/utils/pull/1052
[#1055]: https://github.com/RustCrypto/utils/pull/1055
[#1064]: https://github.com/RustCrypto/utils/pull/1064