### PR TITLE
cpufeatures: fix macOS build

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -117,6 +117,9 @@ macro_rules! check {
                 && $crate::aarch64::sysctlbyname(b"hw.optional.armv8_2_sha3\0")
         }
     };
+    ("sm4") => {
+        false
+    };
 }
 
 /// Apple helper function for calling `sysctlbyname`.


### PR DESCRIPTION
The "sm4" token wasn't being handled. To fix the bleeding, this adds it but hardcoded to disabled.

See build failure here: https://github.com/RustCrypto/utils/actions/runs/8818083683/job/24206057206?pr=1065

```
   Compiling cpufeatures v0.2.12 (/Users/runner/work/utils/utils/cpufeatures)
error: no rules expected the token `"sm4"`
   --> tests/aarch64.rs:5:51
    |
5   | cpufeatures::new!(armcaps, "aes", "sha2", "sha3", "sm4");
    |                                                   ^^^^^ no rules expected this token in macro call
    |
note: while trying to match `"aes"`
   --> /Users/runner/work/utils/utils/cpufeatures/src/aarch64.rs:107:6
    |
107 |     ("aes") => {
    |      ^^^^^
```