### PR TITLE
zeroize: feature-gate AVX-512 under `simd`; MSRV 1.60

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -53,7 +53,7 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.72.0 # MSRV
+            rust: 1.60.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.72.0 # MSRV
+            rust: 1.60.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
@@ -71,7 +71,7 @@ jobs:
           # 64-bit macOS x86_64
           - target: x86_64-apple-darwin
             platform: macos-latest
-            rust: 1.72.0 # MSRV
+            rust: 1.60.0 # MSRV
           - target: x86_64-apple-darwin
             platform: macos-latest
             rust: stable
@@ -79,7 +79,7 @@ jobs:
           # 64-bit Windows
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
-            rust: 1.72.0 # MSRV
+            rust: 1.60.0 # MSRV
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
             rust: stable
@@ -93,16 +93,21 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }}
-      - run: cargo test --target ${{ matrix.target }} --all-features
 
   # Cross-compiled tests
   cross:
     strategy:
       matrix:
         include:
+          # AArch64
+          - target: aarch64-unknown-linux-gnu
+            rust: 1.60.0
+          - target: aarch64-unknown-linux-gnu
+            rust: stable
+
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.72.0 # MSRV
+            rust: 1.60.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest
@@ -115,25 +120,25 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cross-install@master
       - run: cross test --target ${{ matrix.target }}
+      - run: cross test --target ${{ matrix.target }} --all-features
 
-  # Feature-gated ARM64 SIMD register support (MSRV 1.59)
-  aarch64:
+  # Tests for x86-64 `simd` support (AVX-512 registers; MSRV 1.72)
+  x86:
     strategy:
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnu
             rust: 1.72.0
-          - target: aarch64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - run: ${{ matrix.deps }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cross-install@master
-      - run: cross test --target ${{ matrix.target }} --features aarch64
-      - run: cross test --target ${{ matrix.target }} --all-features
+      - run: cargo test --target ${{ matrix.target }} --features simd
+      - run: cargo test --target ${{ matrix.target }} --all-features

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 categories = ["cryptography", "memory-management", "no-std", "os"]
 keywords = ["memory", "memset", "secure", "volatile", "zero"]
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.60"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }
@@ -28,6 +28,7 @@ std = ["alloc"]
 
 aarch64 = [] # NOTE: vestigial no-op feature; AArch64 support is always enabled now
 derive = ["zeroize_derive"]
+simd = [] # NOTE: MSRV 1.72
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -36,7 +36,7 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 ## Minimum Supported Rust Version
 
-Rust **1.72** or newer.
+Rust **1.60** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -60,35 +60,21 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/zeroize.svg
-
 [crate-link]: https://crates.io/crates/zeroize
-
 [docs-image]: https://docs.rs/zeroize/badge.svg
-
 [docs-link]: https://docs.rs/zeroize/
-
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
-
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml/badge.svg
-
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/zeroize.yml
 
 [//]: # (general links)
 
 [RustCrypto]: https://github.com/RustCrypto
-
 [zeroize]: https://en.wikipedia.org/wiki/Zeroisation
-
 [`Zeroize` trait]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
-
 [Documentation]: https://docs.rs/zeroize/
-
 [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
-
 [core::ptr::write_volatile]: https://doc.rust-lang.org/core/ptr/fn.write_volatile.html
-
 [core::sync::atomic]: https://doc.rust-lang.org/stable/core/sync/atomic/index.html
-
 [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -22,6 +22,8 @@ macro_rules! impl_zeroize_for_simd_register {
     };
 }
 
-impl_zeroize_for_simd_register!(
-    __m128, __m128d, __m128i, __m256, __m256d, __m256i, __m512, __m512d, __m512i
-);
+impl_zeroize_for_simd_register!(__m128, __m128d, __m128i, __m256, __m256d, __m256i);
+
+// NOTE: MSRV 1.72
+#[cfg(feature = "simd")]
+impl_zeroize_for_simd_register!(__m512, __m512d, __m512i);


### PR DESCRIPTION
Restores MSRV 1.60 by feature-gating AVX-512 support on x86(_64) targets, which is the only thing which required the previous MSRV of 1.72.

Using a generic `simd` name (unlike the previous `aarch64` feature name) allows us to provide more feature-gated SIMD register support in the future without giving architecture-specific targets to each one, while also avoiding MSRV bumps in such cases.

When we bump overall MSRV, such support can be moved out from under the feature gate.