### PR TITLE
zeroize v1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zeroize"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "serde",
  "zeroize_derive",

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.8.1 (2024-05-25)
+### Changed
+- Feature-gate AVX-512 support under `simd`; restores MSRV 1.60 ([#1073])
+
+[#1073]: https://github.com/RustCrypto/utils/pull/1073
+
 ## 1.8.0 (2024-04-24) [YANKED]
 
 NOTE: yanked due concerns over the MSRV bump. See [#1067].

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroize"
-version = "1.8.0"
+version = "1.8.1"
 description = """
 Securely clear secrets from memory with a simple trait built on
 stable Rust primitives which guarantee memory is zeroed using an


### PR DESCRIPTION
### Changed
- Feature-gate AVX-512 support under `simd`; restores MSRV 1.60 ([#1073])

[#1073]: https://github.com/RustCrypto/utils/pull/1073