### PR TITLE
zeroize: fix `homepage`/`repository` in Cargo.toml

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -10,7 +10,8 @@ even WASM!
 """
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/RustCrypto/utils/tree/master/zeroize"
+homepage = "https://github.com/RustCrypto/utils/tree/master/zeroize"
+repository = "https://github.com/RustCrypto/utils"
 readme = "README.md"
 categories = ["cryptography", "memory-management", "no-std", "os"]
 keywords = ["memory", "memset", "secure", "volatile", "zero"]

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -4,7 +4,8 @@ description = "Custom derive support for zeroize"
 version = "1.4.2"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"
+homepage = "https://github.com/RustCrypto/utils/tree/master/zeroize_derive"
+repository = "https://github.com/RustCrypto/utils"
 readme = "README.md"
 categories = ["cryptography", "memory-management", "no-std", "os"]
 keywords = ["memory", "memset", "secure", "volatile", "zero"]
@@ -17,7 +18,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = {version = "2", features = ["full", "extra-traits", "visit"]}
+syn = { version = "2", features = ["full", "extra-traits", "visit"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--document-private-items"]


### PR DESCRIPTION
Also fixes it for `zeroize_derive`.

Now:
- `repository` points to a valid git repository: the `utils` repo
- `homepage` points to the GitHub URL for the crate's subdirectory