### PR TITLE
cargo: point `repository` metadata to clonable URLs

### DIFF
--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -9,7 +9,8 @@ and CSEL on AArch64.
 version = "0.3.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/RustCrypto/utils/tree/master/cmov"
+homepage = "https://github.com/RustCrypto/utils/tree/master/cmov"
+repository = "https://github.com/RustCrypto/utils"
 categories = ["cryptography", "hardware-support", "no-std"]
 keywords = ["crypto", "intrinsics"]
 readme = "README.md"

--- a/fiat-constify/Cargo.toml
+++ b/fiat-constify/Cargo.toml
@@ -8,7 +8,8 @@ them as `const fn`
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/fiat-constify"
-repository = "https://github.com/RustCrypto/utils/tree/master/fiat-constify"
+homepage = "https://github.com/RustCrypto/utils/tree/master/fiat-constify"
+repository = "https://github.com/RustCrypto/utils"
 categories = ["cryptography"]
 keywords = ["fiat-crypto", "field"]
 readme = "README.md"


### PR DESCRIPTION
This tweaks the `repository` fields in Cargo metadata in order to use the correct (i.e. git clonable) URL. The existing GitHub webUI URLs for each package have been retained and moved to `homepage` fields.