### PR TITLE
block-buffer: improve safety comments, use `MaybeUninit` for internal buffer

### DIFF
--- a/block-buffer/src/sealed.rs
+++ b/block-buffer/src/sealed.rs
@@ -10,7 +10,7 @@ pub trait Sealed {
     #[cfg(feature = "zeroize")]
     type Pos: Default + Clone + zeroize::Zeroize;
 
-    const NAME: &str;
+    const NAME: &'static str;
 
     fn get_pos<N: ArraySize>(buf: &Block<N>, pos: &Self::Pos) -> usize;
 
@@ -26,7 +26,7 @@ pub trait Sealed {
 
 impl Sealed for super::Eager {
     type Pos = ();
-    const NAME: &str = "BlockBuffer<Eager>";
+    const NAME: &'static str = "BlockBuffer<Eager>";
 
     fn get_pos<N: ArraySize>(buf: &Block<N>, _pos: &Self::Pos) -> usize {
         // SAFETY: last byte in `buf` for eager hashes is always properly initialized
@@ -72,7 +72,7 @@ impl Sealed for super::Eager {
 
 impl Sealed for super::Lazy {
     type Pos = u8;
-    const NAME: &str = "BlockBuffer<Lazy>";
+    const NAME: &'static str = "BlockBuffer<Lazy>";
 
     fn get_pos<N: ArraySize>(_buf_val: &Block<N>, pos: &Self::Pos) -> usize {
         *pos as usize

--- a/block-buffer/src/sealed.rs
+++ b/block-buffer/src/sealed.rs
@@ -1,5 +1,7 @@
 use crate::array::{Array, ArraySize};
-use core::slice;
+use core::{mem::MaybeUninit, ptr, slice};
+
+type Block<N> = MaybeUninit<Array<u8, N>>;
 
 /// Sealed trait for buffer kinds.
 pub trait Sealed {
@@ -8,9 +10,11 @@ pub trait Sealed {
     #[cfg(feature = "zeroize")]
     type Pos: Default + Clone + zeroize::Zeroize;
 
-    fn get_pos(buf: &[u8], pos: &Self::Pos) -> usize;
+    const NAME: &str;
 
-    fn set_pos(buf_val: &mut [u8], pos: &mut Self::Pos, val: usize);
+    fn get_pos<N: ArraySize>(buf: &Block<N>, pos: &Self::Pos) -> usize;
+
+    fn set_pos<N: ArraySize>(buf: &mut Block<N>, pos: &mut Self::Pos, val: usize);
 
     /// Invariant guaranteed by a buffer kind, i.e. with correct
     /// buffer code this function always returns true.
@@ -22,14 +26,26 @@ pub trait Sealed {
 
 impl Sealed for super::Eager {
     type Pos = ();
+    const NAME: &str = "BlockBuffer<Eager>";
 
-    fn get_pos(buf: &[u8], _pos: &Self::Pos) -> usize {
-        buf[buf.len() - 1] as usize
+    fn get_pos<N: ArraySize>(buf: &Block<N>, _pos: &Self::Pos) -> usize {
+        // SAFETY: last byte in `buf` for eager hashes is always properly initialized
+        let pos = unsafe {
+            let buf_ptr = buf.as_ptr().cast::<u8>();
+            let last_byte_ptr = buf_ptr.add(N::USIZE - 1);
+            ptr::read(last_byte_ptr)
+        };
+        pos as usize
     }
 
-    fn set_pos(buf: &mut [u8], _pos: &mut Self::Pos, val: usize) {
+    fn set_pos<N: ArraySize>(buf: &mut Block<N>, _pos: &mut Self::Pos, val: usize) {
         debug_assert!(val <= u8::MAX as usize);
-        buf[buf.len() - 1] = val as u8;
+        // SAFETY: we write to the last byte of `buf` which is always safe
+        unsafe {
+            let buf_ptr = buf.as_mut_ptr().cast::<u8>();
+            let last_byte_ptr = buf_ptr.add(N::USIZE - 1);
+            ptr::write(last_byte_ptr, val as u8);
+        }
     }
 
     #[inline(always)]
@@ -42,8 +58,7 @@ impl Sealed for super::Eager {
         let nb = data.len() / N::USIZE;
         let blocks_len = nb * N::USIZE;
         let tail_len = data.len() - blocks_len;
-        // SAFETY: we guarantee that created slices do not point
-        // outside of `data`
+        // SAFETY: we guarantee that created slices do not point outside of `data`
         unsafe {
             let blocks_ptr = data.as_ptr() as *const Array<u8, N>;
             let tail_ptr = data.as_ptr().add(blocks_len);
@@ -57,12 +72,13 @@ impl Sealed for super::Eager {
 
 impl Sealed for super::Lazy {
     type Pos = u8;
+    const NAME: &str = "BlockBuffer<Lazy>";
 
-    fn get_pos(_buf_val: &[u8], pos: &Self::Pos) -> usize {
+    fn get_pos<N: ArraySize>(_buf_val: &Block<N>, pos: &Self::Pos) -> usize {
         *pos as usize
     }
 
-    fn set_pos(_buf_val: &mut [u8], pos: &mut Self::Pos, val: usize) {
+    fn set_pos<N: ArraySize>(_: &mut Block<N>, pos: &mut Self::Pos, val: usize) {
         debug_assert!(val <= u8::MAX as usize);
         *pos = val as u8;
     }
@@ -84,8 +100,7 @@ impl Sealed for super::Lazy {
             (nb, data.len() - nb * N::USIZE)
         };
         let blocks_len = nb * N::USIZE;
-        // SAFETY: we guarantee that created slices do not point
-        // outside of `data`
+        // SAFETY: we guarantee that created slices do not point outside of `data`
         unsafe {
             let blocks_ptr = data.as_ptr() as *const Array<u8, N>;
             let tail_ptr = data.as_ptr().add(blocks_len);

--- a/block-buffer/tests/mod.rs
+++ b/block-buffer/tests/mod.rs
@@ -109,7 +109,6 @@ fn test_read() {
 }
 
 #[test]
-#[rustfmt::skip]
 fn test_eager_paddings() {
     let mut buf_be = EagerBuffer::<U8>::new(&[0x42]);
     let mut buf_le = buf_be.clone();
@@ -119,8 +118,8 @@ fn test_eager_paddings() {
     buf_be.len64_padding_be(len, |block| out_be.extend(block));
     buf_le.len64_padding_le(len, |block| out_le.extend(block));
 
-    assert_eq!(out_be, hex!("42800000000000000001020304050607"));
-    assert_eq!(out_le, hex!("42800000000000000706050403020100"));
+    assert_eq!(out_be, hex!("4280000000000000 0001020304050607"));
+    assert_eq!(out_le, hex!("4280000000000000 0706050403020100"));
 
     let mut buf_be = EagerBuffer::<U10>::new(&[0x42]);
     let mut buf_le = buf_be.clone();
@@ -138,14 +137,20 @@ fn test_eager_paddings() {
     buf.len128_padding_be(len, |block| out.extend(block));
     assert_eq!(
         out,
-        hex!("42800000000000000000000000000000000102030405060708090a0b0c0d0e0f"),
+        hex!(
+            "42800000000000000000000000000000"
+            "000102030405060708090a0b0c0d0e0f"
+        ),
     );
 
     let mut buf = EagerBuffer::<U24>::new(&[0x42]);
     let mut out = Vec::<u8>::new();
     let len = 0x0001_0203_0405_0607_0809_0a0b_0c0d_0e0f;
     buf.len128_padding_be(len, |block| out.extend(block));
-    assert_eq!(out, hex!("4280000000000000000102030405060708090a0b0c0d0e0f"));
+    assert_eq!(
+        out,
+        hex!("4280000000000000 0001020304050607 08090a0b0c0d0e0f")
+    );
 
     let mut buf = EagerBuffer::<U4>::new(&[0x42]);
     let mut out = Vec::<u8>::new();


### PR DESCRIPTION
Marks private `unchecked` methods as `unsafe` and documents their safety requirements. Adds `SAFETY` comment for all `unsafe` uses. Use of `copy_nonoverlapping` ensures that compiler will not generate unreachable panic branches. Use of `MaybeUninit` removes unnecessary initialization and helps to test that we do not read bytes which were not written by us.

The code successfully passes MIRI tests, but I plan to test this implementation more thoroughly later.