### PR TITLE
cmov: fix `size_of` warning on Rust 1.80

### DIFF
--- a/cmov/src/portable.rs
+++ b/cmov/src/portable.rs
@@ -7,6 +7,7 @@
 // TODO(tarcieri): more optimized implementation for small integers
 
 use crate::{Cmov, CmovEq, Condition};
+use core::mem::size_of;
 
 impl Cmov for u16 {
     #[inline]
@@ -97,7 +98,7 @@ impl CmovEq for u64 {
 /// - `condition` is non-zero: `1`
 #[inline]
 fn is_non_zero(condition: Condition) -> u64 {
-    const SHIFT_BITS: usize = core::mem::size_of::<u64>() - 1;
+    const SHIFT_BITS: usize = size_of::<u64>() - 1;
     let condition = condition as u64;
     ((condition | (!condition).wrapping_add(1)) >> SHIFT_BITS) & 1
 }


### PR DESCRIPTION
`size_of` is now in the prelude, so on older versions it needs to be imported explicitly.