### PR TITLE
cpufeatures: add support for DIT detection on Apple silicon

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -107,6 +107,12 @@ macro_rules! check {
     ("aes") => {
         true
     };
+    ("dit") => {
+        // https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Enable-DIT-for-constant-time-cryptographic-operations
+        unsafe {
+            $crate::aarch64::sysctlbyname(b"hw.optional.arm.FEAT_DIT\0")
+        }
+    };
     ("sha2") => {
         true
     };


### PR DESCRIPTION
Adds support for detecting Data Independent Timing (DIT) support which is available on Apple silicon (e.g. M1/M2/M3).

This uses the `hw.optional.arm.FEAT_DIT` sysctl for detection.

For more information, see:

https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Enable-DIT-for-constant-time-cryptographic-operations