### PR TITLE
cpufeatures: add DIT support for AArch64 Linux targets

### DIFF
--- a/cpufeatures/src/aarch64.rs
+++ b/cpufeatures/src/aarch64.rs
@@ -67,6 +67,7 @@ macro_rules! __expand_check_macro {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 __expand_check_macro! {
     ("aes",    AES),    // Enable AES support.
+    ("dit",    DIT),    // Enable DIT support.
     ("sha2",   SHA2),   // Enable SHA1 and SHA256 support.
     ("sha3",   SHA3),   // Enable SHA512 and SHA3 support.
     ("sm4",    SM4),    // Enable SM3 and SM4 support.
@@ -84,6 +85,7 @@ pub mod hwcaps {
     use libc::c_ulong;
 
     pub const AES: c_ulong = libc::HWCAP_AES | libc::HWCAP_PMULL;
+    pub const DIT: c_ulong = libc::HWCAP_DIT;
     pub const SHA2: c_ulong = libc::HWCAP_SHA2;
     pub const SHA3: c_ulong = libc::HWCAP_SHA3 | libc::HWCAP_SHA512;
     pub const SM4: c_ulong = libc::HWCAP_SM3 | libc::HWCAP_SM4;


### PR DESCRIPTION
On Linux, availability of FEAT_DIT can be detected via `HWCAP_DIT`.