### PR TITLE
aarch64-dit: initial crate

### DIFF
--- a/.github/workflows/aarch64-dit.yml
+++ b/.github/workflows/aarch64-dit.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.60.0 # MSRV
+          - 1.61.0 # MSRV
           - stable
     runs-on: macos-latest
     steps:

--- a/.github/workflows/aarch64-dit.yml
+++ b/.github/workflows/aarch64-dit.yml
@@ -1,0 +1,37 @@
+name: aarch64-dit
+
+on:
+  pull_request:
+    paths:
+      - "aarch64-dit/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: aarch64-dit
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  macos:
+    strategy:
+      matrix:
+        toolchain:
+          - 1.60.0 # MSRV
+          - stable
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: aarch64-apple-darwin
+      - run: cargo test

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           toolchain: 1.72.0 # Pinned to prevent breakages
           components: clippy
-      - run: cargo clippy --all --all-features -- -D warnings
+      - run: cargo clippy --all --all-features --exclude aarch64-dit -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 3
 
 [[package]]
+name = "aarch64-dit"
+version = "0.0.0"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "blobby"
 version = "0.3.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "aarch64-dit",
     "blobby",
     "block-buffer",
     "block-padding",

--- a/aarch64-dit/CHANGELOG.md
+++ b/aarch64-dit/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/aarch64-dit/Cargo.toml
+++ b/aarch64-dit/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "aarch64-dit"
+description = """
+Wrappers for enabling/disabling the Data Independent Timing (DIT) feature on AArch64 CPUs
+"""
+version = "0.0.0"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/RustCrypto/utils/tree/master/aarch64-dit"
+repository = "https://github.com/RustCrypto/utils"
+categories = ["cryptography", "hardware-support", "no-std"]
+keywords = ["crypto", "intrinsics"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.60"
+
+[dev-dependencies]
+# TODO: release `cpufeatures` with `dit` support
+cpufeatures = { path = "../cpufeatures" }

--- a/aarch64-dit/Cargo.toml
+++ b/aarch64-dit/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "hardware-support", "no-std"]
 keywords = ["crypto", "intrinsics"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [dev-dependencies]
 # TODO: release `cpufeatures` with `dit` support

--- a/aarch64-dit/LICENSE-APACHE
+++ b/aarch64-dit/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/aarch64-dit/LICENSE-MIT
+++ b/aarch64-dit/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/aarch64-dit/README.md
+++ b/aarch64-dit/README.md
@@ -1,0 +1,51 @@
+# [RustCrypto]: AArch64 Data-Independent Timing (DIT)
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache 2.0/MIT Licensed][license-image]
+![MSRV][msrv-image]
+
+Wrappers for enabling/disabling the [Data-Independent Timing] feature of modern AArch64 CPUs which
+can be used to help ensure that instructions take a constant amount of time regardless of input
+data, thus preventing potential information leaks via timing sidechannels.
+
+[Documentation][docs-link]
+
+## Minimum Supported Rust Version
+
+Rust **1.60** or newer.
+
+In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope for this crate's
+SemVer guarantees), however when we do it will be accompanied by a minor version bump.
+
+## License
+
+Licensed under either of:
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
+work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/aarch64-dit.svg
+[crate-link]: https://crates.io/crates/aarch64-dit
+[docs-image]: https://docs.rs/aarch64-dit/badge.svg
+[docs-link]: https://docs.rs/aarch64-dit/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[build-image]: https://github.com/RustCrypto/utils/actions/workflows/aarch64-dit.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/utils/actions/workflows/aarch64-dit.yml
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/RustCrypto
+[Data-Independent Timing]: https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/DIT--Data-Independent-Timing

--- a/aarch64-dit/README.md
+++ b/aarch64-dit/README.md
@@ -14,7 +14,7 @@ data, thus preventing potential information leaks via timing sidechannels.
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or newer.
+Rust **1.61** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope for this crate's
 SemVer guarantees), however when we do it will be accompanied by a minor version bump.
@@ -41,7 +41,7 @@ additional terms or conditions.
 [docs-image]: https://docs.rs/aarch64-dit/badge.svg
 [docs-link]: https://docs.rs/aarch64-dit/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[msrv-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.61+-blue.svg
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/aarch64-dit.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/aarch64-dit.yml
 

--- a/aarch64-dit/src/lib.rs
+++ b/aarch64-dit/src/lib.rs
@@ -1,0 +1,64 @@
+#![no_std]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[cfg(not(target_arch = "aarch64"))]
+compile_error!("This crate only builds on `aarch64` targets");
+
+use core::arch::asm;
+
+/// Detect if DIT is enabled for the current thread by checking the processor state register.
+#[target_feature(enable = "dit")]
+pub unsafe fn get_dit_enabled() -> bool {
+    let mut dit: u64;
+    asm!("mrs {dit}, DIT", dit = out(reg) dit);
+    (dit >> 24) & 1 != 0
+}
+
+/// Enable DIT for the current thread.
+#[target_feature(enable = "dit")]
+pub unsafe fn set_dit_enabled() {
+    asm!("msr DIT, #1");
+}
+
+/// Restore DIT state depending on the enabled bit.
+#[target_feature(enable = "dit")]
+pub unsafe fn restore_dit(enabled: bool) {
+    if !enabled {
+        // Disable DIT
+        asm!("msr DIT, #0");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_dit_enabled, restore_dit, set_dit_enabled};
+    cpufeatures::new!(dit_supported, "dit");
+
+    #[test]
+    fn get() {
+        let dit_token = dit_supported::init();
+        if !dit_token.get() {
+            panic!("DIT is not available on this CPU");
+        }
+
+        let dit_enabled = unsafe { get_dit_enabled() };
+        assert!(!dit_enabled);
+
+        unsafe { set_dit_enabled() };
+        let dit_enabled = unsafe { get_dit_enabled() };
+        assert!(dit_enabled);
+
+        unsafe { restore_dit(true) };
+        let dit_enabled = unsafe { get_dit_enabled() };
+        assert!(dit_enabled);
+
+        unsafe { restore_dit(false) };
+        let dit_enabled = unsafe { get_dit_enabled() };
+        assert!(!dit_enabled);
+    }
+}

--- a/aarch64-dit/src/lib.rs
+++ b/aarch64-dit/src/lib.rs
@@ -15,14 +15,18 @@ use core::arch::asm;
 #[target_feature(enable = "dit")]
 pub unsafe fn get_dit_enabled() -> bool {
     let mut dit: u64;
-    asm!("mrs {dit}, DIT", dit = out(reg) dit);
+    asm!(
+        "mrs {dit}, DIT",
+        dit = out(reg) dit,
+        options(nomem, nostack, preserves_flags)
+    );
     (dit >> 24) & 1 != 0
 }
 
 /// Enable DIT for the current thread.
 #[target_feature(enable = "dit")]
 pub unsafe fn set_dit_enabled() {
-    asm!("msr DIT, #1");
+    asm!("msr DIT, #1", options(nomem, nostack, preserves_flags));
 }
 
 /// Restore DIT state depending on the enabled bit.
@@ -30,7 +34,7 @@ pub unsafe fn set_dit_enabled() {
 pub unsafe fn restore_dit(enabled: bool) {
     if !enabled {
         // Disable DIT
-        asm!("msr DIT, #0");
+        asm!("msr DIT, #0", options(nomem, nostack, preserves_flags));
     }
 }
 


### PR DESCRIPTION
Adds a crate with wrappers for the Data-Independent Timing (DIT) feature of AArch64 CPUs.

The implementation is largely a translation of Apple's guide of how to write wrappers for enabling/disabling DIT: https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Enable-DIT-for-constant-time-cryptographic-operations

It would be nice to wrap that all up into an RAII guard which can first use `cpufeatures` to check for `FEAT_DIT` and, if available, enable it for the current thread, while also first querying the processor status register and restoring the previous state on `Drop`, which is necessary for proper nested usage of DIT.

But for now, this just wraps the barebones functionality in an `unsafe` API.