### PR TITLE
aarch64-dit: set docs.rs default-target

### DIFF
--- a/aarch64-dit/Cargo.toml
+++ b/aarch64-dit/Cargo.toml
@@ -16,3 +16,6 @@ rust-version = "1.61"
 
 [dev-dependencies]
 cpufeatures = { version = "0.2.14", path = "../cpufeatures" }
+
+[package.metadata.docs.rs]
+default-target = "aarch64-unknown-linux-gnu"


### PR DESCRIPTION
This hopefully allows the docs to generate on docs.rs.

Closes #1106