### PR TITLE
Bump `hybrid-array` to v0.2.0-rc.10

### DIFF
--- a/.github/workflows/block-buffer.yml
+++ b/.github/workflows/block-buffer.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/block-padding.yml
+++ b/.github/workflows/block-padding.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dbl.yml
+++ b/.github/workflows/dbl.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/inout.yml
+++ b/.github/workflows/inout.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.72.0 # Pinned to prevent breakages
+          toolchain: 1.81.0 # Pinned to prevent breakages
           components: clippy
       - run: cargo clippy --all --all-features --exclude aarch64-dit -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
+checksum = "bae36f8710514b3e7aab028021733330de6e455e0352e19c6dd4513eecb7aa9a"
 dependencies = [
  "typenum",
 ]
@@ -114,9 +114,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "memchr"
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -164,18 +164,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -213,9 +213,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "wycheproof2blb"

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["block", "buffer"]
 categories = ["cryptography", "no-std"]
 edition = "2021"
 readme = "README.md"
-rust-version = "1.65"
+rust-version = "1.81"
 
 [dependencies]
 crypto-common = "0.2.0-rc.1"

--- a/block-padding/CHANGELOG.md
+++ b/block-padding/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Changed
+- Migrated from `generic-array` to `hybrid-array` ([#944])
+- MSRV is bumped to 1.81 ([#1116])
+
+[#944]: https://github.com/RustCrypto/utils/pull/944
+[#1116]: https://github.com/RustCrypto/utils/pull/1116
+
 ## 0.3.3 (2023-04-02)
 ### Added
 - `RawPadding` trait for padding blocks of arbitrary size ([#870])

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -5,7 +5,7 @@ description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.81"
 documentation = "https://docs.rs/block-padding"
 repository = "https://github.com/RustCrypto/utils"
 keywords = ["padding", "pkcs7", "ansix923", "iso7816"]
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 readme = "README.md"
 
 [dependencies]
-hybrid-array = "0.2.0-rc.9"
+hybrid-array = "0.2.0-rc.10"
 
 [features]
 std = []

--- a/dbl/CHANGELOG.md
+++ b/dbl/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## UNRELEASED
+### Changed
+- Migrated from `generic-array` to `hybrid-array` ([#944])
+- MSRV is bumped to 1.81 ([#1116])
+
+[#944]: https://github.com/RustCrypto/utils/pull/944
+[#1116]: https://github.com/RustCrypto/utils/pull/1116

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -8,9 +8,9 @@ documentation = "https://docs.rs/dbl"
 repository = "https://github.com/RustCrypto/utils"
 keywords = ["crypto", "dbl", "gf", "galois"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.81"
 readme = "README.md"
 
 [dependencies]
-hybrid-array = "0.2.0-rc.9"
+hybrid-array = "0.2.0-rc.10"
 

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -13,4 +13,3 @@ readme = "README.md"
 
 [dependencies]
 hybrid-array = "0.2.0-rc.10"
-

--- a/inout/CHANGELOG.md
+++ b/inout/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Changed
+- Migrated from `generic-array` to `hybrid-array` ([#944])
+- MSRV is bumped to 1.81 ([#1116])
+
+[#944]: https://github.com/RustCrypto/utils/pull/944
+[#1116]: https://github.com/RustCrypto/utils/pull/1116
+
 ## 0.1.3 (2022-03-31)
 ### Fixed
 - MIRI error in `From` impl for `InOutBuf` ([#755])

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -5,7 +5,7 @@ description = "Custom reference types for code generic over in-place and buffer-
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.81"
 documentation = "https://docs.rs/inout"
 repository = "https://github.com/RustCrypto/utils"
 keywords = ["custom-reference"]
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 block-padding = { version = "0.4.0-rc.0", path = "../block-padding", optional = true }
-hybrid-array = "0.2.0-rc.9"
+hybrid-array = "0.2.0-rc.10"
 
 [features]
 std = ["block-padding/std"]


### PR DESCRIPTION
This also bumps MSRV to 1.81 for `block-buffer`, `block-padding`, `dbl`, and `inout`, following the MSRV bump in `hybrid-array`.