### PR TITLE
block-padding+inout: remove `std` feature

### DIFF
--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -15,9 +15,6 @@ readme = "README.md"
 [dependencies]
 hybrid-array = "0.2.0-rc.10"
 
-[features]
-std = []
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -14,7 +14,3 @@ readme = "README.md"
 
 [dependencies]
 hybrid-array = "0.2.0-rc.10"
-
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/block-padding/src/lib.rs
+++ b/block-padding/src/lib.rs
@@ -8,11 +8,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms)]
-
-#[cfg(feature = "std")]
-extern crate std;
 
 pub use hybrid_array as array;
 
@@ -399,6 +395,4 @@ impl fmt::Display for UnpadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for UnpadError {}
+impl core::error::Error for UnpadError {}

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -14,7 +14,3 @@ readme = "README.md"
 [dependencies]
 block-padding = { version = "0.4.0-rc.0", path = "../block-padding", optional = true }
 hybrid-array = "0.2.0-rc.10"
-
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -15,9 +15,6 @@ readme = "README.md"
 block-padding = { version = "0.4.0-rc.0", path = "../block-padding", optional = true }
 hybrid-array = "0.2.0-rc.10"
 
-[features]
-std = ["block-padding/std"]
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/inout/src/errors.rs
+++ b/inout/src/errors.rs
@@ -10,9 +10,7 @@ impl fmt::Display for IntoArrayError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for IntoArrayError {}
+impl core::error::Error for IntoArrayError {}
 
 /// The error returned when input and output slices have different length
 /// and thus can not be converted to `InOutBuf`.
@@ -25,9 +23,7 @@ impl fmt::Display for NotEqualError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for NotEqualError {}
+impl core::error::Error for NotEqualError {}
 
 /// Padding error. Usually emitted when size of output buffer is insufficient.
 #[cfg(feature = "block-padding")]
@@ -43,9 +39,7 @@ impl fmt::Display for PadError {
 }
 
 #[cfg(feature = "block-padding")]
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for PadError {}
+impl core::error::Error for PadError {}
 
 /// Output buffer is smaller than input buffer.
 #[derive(Clone, Copy, Debug)]
@@ -57,6 +51,4 @@ impl fmt::Display for OutIsTooSmallError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for OutIsTooSmallError {}
+impl core::error::Error for OutIsTooSmallError {}

--- a/inout/src/lib.rs
+++ b/inout/src/lib.rs
@@ -10,9 +10,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 #[cfg(feature = "block-padding")]
 #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
 pub use block_padding;


### PR DESCRIPTION
Leverages the `error_in_core` feature stabilized in Rust 1.81 to allow `Error` trait impls in `no_std` contexts.

This was the only dependency on `std`, so this also removes the `std` feature, which is no longer necessary.