### PR TITLE
inout: use `doc_auto_cfg`

### DIFF
--- a/inout/src/errors.rs
+++ b/inout/src/errors.rs
@@ -27,7 +27,6 @@ impl core::error::Error for NotEqualError {}
 
 /// Padding error. Usually emitted when size of output buffer is insufficient.
 #[cfg(feature = "block-padding")]
-#[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
 #[derive(Clone, Copy, Debug)]
 pub struct PadError;
 

--- a/inout/src/lib.rs
+++ b/inout/src/lib.rs
@@ -6,12 +6,11 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::needless_lifetimes)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "block-padding")]
-#[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
 pub use block_padding;
 
 mod errors;

--- a/inout/src/reserved.rs
+++ b/inout/src/reserved.rs
@@ -129,7 +129,6 @@ impl<'inp, 'out, T> InOutBufReserved<'inp, 'out, T> {
 impl<'inp, 'out> InOutBufReserved<'inp, 'out, u8> {
     /// Transform buffer into [`PaddedInOutBuf`] using padding algorithm `P`.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline(always)]
     pub fn into_padded_blocks<P, BS>(self) -> Result<PaddedInOutBuf<'inp, 'out, BS>, PadError>
     where
@@ -183,7 +182,6 @@ impl<'inp, 'out> InOutBufReserved<'inp, 'out, u8> {
 
 /// Variant of [`InOutBuf`] with optional padded tail block.
 #[cfg(feature = "block-padding")]
-#[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
 pub struct PaddedInOutBuf<'inp, 'out, BS: ArraySize> {
     blocks: InOutBuf<'inp, 'out, Array<u8, BS>>,
     tail_in: Array<u8, BS>,


### PR DESCRIPTION
Removes manual rustdoc feature annotations and performs them automatically