### PR TITLE
inout: re-add `package.metadata.docs.rs` to Cargo.toml

### DIFF
--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -14,3 +14,6 @@ readme = "README.md"
 [dependencies]
 block-padding = { version = "0.4.0-rc.1", path = "../block-padding", optional = true }
 hybrid-array = "0.2.0-rc.10"
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
We need to instruct it to build with the `block-padding` feature to ensure that's properly documented.

This commit re-adds `all-features = true`