### PR TITLE
Cut new release candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "hex-literal 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hybrid-array",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.2"
 dependencies = [
  "hybrid-array",
 ]
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "dbl"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "hybrid-array",
 ]
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 dependencies = [
  "block-padding",
  "hybrid-array",

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Buffer type for block processing of data"

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.2"
 description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Double operation in Galois Field GF(2^128) as used by e.g. CMAC/PMAC"

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 description = "Custom reference types for code generic over in-place and buffer-to-buffer modes of operation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ keywords = ["custom-reference"]
 readme = "README.md"
 
 [dependencies]
-block-padding = { version = "0.4.0-rc.1", path = "../block-padding", optional = true }
+block-padding = { version = "0.4.0-rc.2", path = "../block-padding", optional = true }
 hybrid-array = "0.2"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Cuts new `-rc.*` releases of the following:

- `block-buffer` v0.11.0-rc.3
- `block-padding` v0.4.0-rc.2
- `dbl` v0.4.0-rc.1
- `inout` v0.2.0-rc.2

These all depend on `hybrid-array` v0.2 (final)