### PR TITLE
cpufeatures: relax XSAVE checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ version = "0.0.2"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.15 (2024-11-11)
+### Fixed
+- Relax XSAVE checks ([#1130])
+
+[#1130]: https://github.com/RustCrypto/utils/pull/1130
+
 ## 0.2.14 (2024-09-05)
 ### Added
 - Support for detecting Data Independent Timing (DIT) on AArch64 ([#1100], [#1101])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 description = """
 Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, 
 with no_std support and support for mobile targets including Android and iOS

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -112,20 +112,20 @@ macro_rules! __expand_check_macro {
 }
 
 __expand_check_macro! {
-    ("sse3", "xmm", 0, ecx, 0),
-    ("pclmulqdq", "xmm", 0, ecx, 1),
-    ("ssse3", "xmm", 0, ecx, 9),
-    ("fma", "xmm", 0, ecx, 12, 0, ecx, 28),
-    ("sse4.1", "xmm", 0, ecx, 19),
-    ("sse4.2", "xmm", 0, ecx, 20),
+    ("sse3", "", 0, ecx, 0),
+    ("pclmulqdq", "", 0, ecx, 1),
+    ("ssse3", "", 0, ecx, 9),
+    ("fma", "ymm", 0, ecx, 12, 0, ecx, 28),
+    ("sse4.1", "", 0, ecx, 19),
+    ("sse4.2", "", 0, ecx, 20),
     ("popcnt", "", 0, ecx, 23),
-    ("aes", "xmm", 0, ecx, 25),
+    ("aes", "", 0, ecx, 25),
     ("avx", "xmm", 0, ecx, 28),
     ("rdrand", "", 0, ecx, 30),
 
     ("mmx", "", 0, edx, 23),
-    ("sse", "xmm", 0, edx, 25),
-    ("sse2", "xmm", 0, edx, 26),
+    ("sse", "", 0, edx, 25),
+    ("sse2", "", 0, edx, 26),
 
     ("sgx", "", 1, ebx, 2),
     ("bmi1", "", 1, ebx, 3),
@@ -139,7 +139,7 @@ __expand_check_macro! {
     ("avx512pf", "zmm", 1, ebx, 26),
     ("avx512er", "zmm", 1, ebx, 27),
     ("avx512cd", "zmm", 1, ebx, 28),
-    ("sha", "xmm", 1, ebx, 29),
+    ("sha", "", 1, ebx, 29),
     ("avx512bw", "zmm", 1, ebx, 30),
     ("avx512vl", "zmm", 1, ebx, 31),
     ("avx512vbmi", "zmm", 1, ecx, 1),


### PR DESCRIPTION
The check was too conservative and caused false negatives on some targets. This change follows the `is_x86_feature_detected!` macro (see: https://docs.rs/crate/std_detect/latest/source/src/detect/os/x86.rs).

Closes #1129