### PR TITLE
cpufeatures: fix cfg for freestanding x86 targets

### DIFF
--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Fixed
+- `cfg` for freestanding x86 targets ([#1137])
+
+[#1137]: https://github.com/RustCrypto/utils/pull/1137
+
 ## 0.2.15 (2024-11-11)
 ### Fixed
 - Relax XSAVE checks ([#1130])

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -14,12 +14,12 @@ macro_rules! __unless_target_features {
     ($($tf:tt),+ => $body:expr ) => {{
         #[cfg(not(all($(target_feature=$tf,)*)))]
         {
-            #[cfg(not(any(target_env = "sgx", target_os = "", target_os = "uefi")))]
+            #[cfg(not(any(target_env = "sgx", target_os = "none", target_os = "uefi")))]
             $body
 
             // CPUID is not available on SGX. Freestanding and UEFI targets
             // do not support SIMD features with default compilation flags.
-            #[cfg(any(target_env = "sgx", target_os = "", target_os = "uefi"))]
+            #[cfg(any(target_env = "sgx", target_os = "none", target_os = "uefi"))]
             false
         }
 


### PR DESCRIPTION
Previously we were using an empty string for `target_os` to indicate freestanding targets which is incorrect. We should use `none` instead.

Closes #1136