### PR TITLE
cpufeatures: don't link `std` when linking `libc`

### DIFF
--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -15,13 +15,13 @@ edition = "2018"
 readme = "README.md"
 
 [target.'cfg(all(target_arch = "aarch64", target_vendor = "apple"))'.dependencies]
-libc = "0.2.155"
+libc = { version = "0.2.155", default-features = false }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-libc = "0.2.155"
+libc = { version = "0.2.155", default-features = false }
 
 [target.'cfg(all(target_arch = "loongarch64", target_os = "linux"))'.dependencies]
-libc = "0.2.155"
+libc = { version = "0.2.155", default-features = false }
 
 [target.aarch64-linux-android.dependencies]
-libc = "0.2.155"
+libc = { version = "0.2.155", default-features = false }


### PR DESCRIPTION
On AArch64, we link the `libc` crate to provide access to system call wrappers which can query available CPU features from the kernel, since those calls are protected on that CPU architecture.

We don't need `std` though, and it seems we're inadvertently linking it on Linux, Android, and macOS.