### PR TITLE
cpufeatures: release v0.2.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ version = "0.0.2"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "libc",
 ]

--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.17 (2025-01-24)
+### Fixed
+- Don't link `std` when linking `libc` ([#1142])
+
+[#1142]: https://github.com/RustCrypto/utils/pull/1142
+
 ## 0.2.16 (2024-11-22)
 ### Fixed
 - `cfg` for freestanding x86 targets ([#1137])

--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 description = """
 Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, 
 with no_std support and support for mobile targets including Android and iOS

--- a/cpufeatures/LICENSE-MIT
+++ b/cpufeatures/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 The RustCrypto Project Developers
+Copyright (c) 2020-2025 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/cpufeatures/README.md
+++ b/cpufeatures/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Lightweight and efficient runtime CPU feature detection for `aarch64`, `loongarch64`, and
 `x86`/`x86_64` targets.
@@ -108,7 +108,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/cpufeatures.svg
+[crate-image]: https://img.shields.io/crates/v/cpufeatures.svg?logo=rust
 [crate-link]: https://crates.io/crates/cpufeatures
 [docs-image]: https://docs.rs/cpufeatures/badge.svg
 [docs-link]: https://docs.rs/cpufeatures/
@@ -116,7 +116,7 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
-[build-image]: https://github.com/RustCrypto/utils/workflows/cpufeatures/badge.svg?branch=master&event=push
+[build-image]: https://github.com/RustCrypto/utils/actions/workflows/cpufeatures.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/cpufeatures.yml
 
 [//]: # (general links)


### PR DESCRIPTION
### Fixed
- Don't link `std` when linking `libc` ([#1142])

[#1142]: https://github.com/RustCrypto/utils/pull/1142