### PR TITLE
inout: fix `InOutBufReserved::get_out_len`

### DIFF
--- a/inout/CHANGELOG.md
+++ b/inout/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4 (2025-02-21)
+### Fixed
+- Return output length from `InOutBufReserved::get_out_len` instead of input length ([#1150])
+
+[#1150]: https://github.com/RustCrypto/utils/pull/1150
+
 ## 0.1.3 (2022-03-31)
 ### Fixed
 - MIRI error in `From` impl for `InOutBuf` ([#755])

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.1.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.4" # Also update html_root_url in lib.rs when bumping this
 description = "Custom reference types for code generic over in-place and buffer-to-buffer modes of operation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/inout/src/lib.rs
+++ b/inout/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/inout/0.1.3"
+    html_root_url = "https://docs.rs/inout/0.1.4"
 )]
 #![allow(clippy::needless_lifetimes)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/inout/src/reserved.rs
+++ b/inout/src/reserved.rs
@@ -91,7 +91,7 @@ impl<'a, T> InOutBufReserved<'a, 'a, T> {
     /// Get output buffer length.
     #[inline(always)]
     pub fn get_out_len(&self) -> usize {
-        self.in_len
+        self.out_len
     }
 }
 


### PR DESCRIPTION
This PR is a backport of #1147 for inout v0.1.

Fixes #1146