### PR TITLE
Remove the hybrid-array dir

### DIFF
--- a/hybrid-array/README.md
+++ b/hybrid-array/README.md
@@ -1,6 +1,0 @@
-# MOVED!
-
-The new repository location is:
-
-https://github.com/RustCrypto/hybrid-array/
-


### PR DESCRIPTION
The crate was moved into a separate repository more than a year ago, so I think we can remove the notification directory.