### PR TITLE
hex-literal: release v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hex-literal"
-version = "0.5.0-pre"
+version = "1.0.0"
 
 [[package]]
 name = "hybrid-array"

--- a/hex-literal/CHANGELOG.md
+++ b/hex-literal/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.0 (2025-02-23)
+## 1.0.0 (2025-02-22)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
 - Relax MSRV policy and allow MSRV bumps in patch releases

--- a/hex-literal/CHANGELOG.md
+++ b/hex-literal/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (unreleased)
+## 1.0.0 (2025-02-23)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
+- Relax MSRV policy and allow MSRV bumps in patch releases
 
 [#1149]: https://github.com/RustCrypto/utils/pull/1149
 

--- a/hex-literal/Cargo.toml
+++ b/hex-literal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-literal"
-version = "0.5.0-pre"
+version = "1.0.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Macro for converting hexadecimal string to a byte array at compile time"


### PR DESCRIPTION
### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
- Relax MSRV policy and allow MSRV bumps in patch releases

[#1149]: https://github.com/RustCrypto/utils/pull/1149