### PR TITLE
Temporary remove `resolver.incompatible-rust-versions`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,5 @@ members = [
 ]
 exclude = ["aarch64-dit"]
 
-[resolver]
-incompatible-rust-versions = "allow"
-
 [profile.dev]
 opt-level = 2


### PR DESCRIPTION
Cargo does not respect this setting in Cargo.toml, instead it has to be provided in config.toml. I [requested](https://internals.rust-lang.org/t/22439) for this to change, so until the situation is clarified the setting is removed.