### PR TITLE
cpufeatures: remove `#[inline(never)]` workaround for CPUID intrinsics

### DIFF
--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -38,17 +38,10 @@ macro_rules! __detect_target_features {
         #[cfg(target_arch = "x86_64")]
         use core::arch::x86_64::{__cpuid, __cpuid_count, CpuidResult};
 
-        // These wrappers are workarounds around
-        // https://github.com/rust-lang/rust/issues/101346
-        //
-        // DO NOT remove it until MSRV is bumped to a version
-        // with the issue fix (at least 1.64).
-        #[inline(never)]
         unsafe fn cpuid(leaf: u32) -> CpuidResult {
             __cpuid(leaf)
         }
 
-        #[inline(never)]
         unsafe fn cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
             __cpuid_count(leaf, sub_leaf)
         }


### PR DESCRIPTION
The workaround is no longer needed since we have bumped MSRV to 1.85.