### PR TITLE
digest-io: initial implementation

### DIFF
--- a/.github/workflows/digest-io.yml
+++ b/.github/workflows/digest-io.yml
@@ -1,0 +1,43 @@
+name: digest-io
+
+on:
+  pull_request:
+      paths:
+        - "digest-io/**"
+        - "Cargo.*"
+  push:
+    branches: master
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: digest-io
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v4
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,11 +19,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a229bfd78e4827c91b9b95784f69492c1b77c1ab75a45a8a037b139215086f94"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.4.0-rc.3"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cmov"
@@ -34,6 +49,21 @@ name = "collectable"
 version = "0.1.0"
 
 [[package]]
+name = "const-oid"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb3c4a0d3776f7535c32793be81d6d5fec0d48ac70955d9834e643aa249a52f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0-pre"
 dependencies = [
@@ -41,10 +71,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "dbl"
 version = "0.4.0-rc.2"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c478574b20020306f98d61c8ca3322d762e1ff08117422ac6106438605ea516"
+dependencies = [
+ "block-buffer 0.11.0-rc.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "const-oid",
+ "crypto-common",
+]
+
+[[package]]
+name = "digest-io"
+version = "0.1.0"
+dependencies = [
+ "digest",
+ "sha2",
+ "sha3",
 ]
 
 [[package]]
@@ -95,6 +154,15 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "keccak"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
 
 [[package]]
 name = "libc"
@@ -176,6 +244,27 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b4241d1a56954dce82cecda5c8e9c794eef6f53abe5e5216bac0a0ea71ffa7"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bc997d7a5fa67cc1e352b2001124d28edb948b4e7a16567f9b3c1e51952524"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "cmov",
     "cpufeatures",
     "dbl",
+    "digest-io",
     "fiat-constify",
     "hex-literal",
     "inout",

--- a/digest-io/CHANGELOG.md
+++ b/digest-io/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 (UNRELEASED)
+- Initial release ([#1172])
+
+[#1172]: https://github.com/RustCrypto/utils/pull/1172

--- a/digest-io/Cargo.toml
+++ b/digest-io/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "digest-io"
+version = "0.1.0"
+description = "std::io-compatibility wrappers for traits defined in the digest crate"
+authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.85"
+documentation = "https://docs.rs/digest-io"
+repository = "https://github.com/RustCrypto/utils"
+categories = ["cryptography"]
+readme = "README.md"
+
+[dependencies]
+digest = "0.11.0-pre.10"
+sha2 = "0.11.0-pre.5"
+sha3 = "0.11.0-pre.5"

--- a/digest-io/LICENSE-APACHE
+++ b/digest-io/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/digest-io/LICENSE-MIT
+++ b/digest-io/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/digest-io/README.md
+++ b/digest-io/README.md
@@ -1,0 +1,148 @@
+# [RustCrypto]: `std::io`-compatibility wrappers for `digest`
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+
+Wrappers for compatibility between `std::io` and `digest` traits.
+
+## Examples
+
+Updating hash function by writing data into it:
+
+```rust
+use digest_io::IoWrapper;
+use sha2::{Digest, Sha256};
+use std::{fs::File, io};
+
+fn main() -> io::Result<()> {
+    // Wrap SHA-256 hash function
+    let mut hasher = IoWrapper(Sha256::new());
+
+    // Write contents of the file to the wrapped hasher
+    let mut f = File::open("Cargo.toml")?;
+    io::copy(&mut f, &mut hasher)?;
+
+    // Get the resulting hash of the file data
+    let hash = hasher.0.finalize();
+
+    println!("{hash:?}");
+    Ok(())
+}
+```
+
+Reading data from a XOF reader:
+
+```rust
+use digest_io::IoWrapper;
+use sha3::{Shake128, digest::ExtendableOutput};
+use std::{fs::File, io};
+
+fn read_array(r: &mut impl io::Read) -> io::Result<[u8; 64]> {
+    let mut buf = [0u8; 64];
+    r.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+fn main() -> io::Result<()> {
+    // Create XOF reader
+    let mut hasher = IoWrapper(Shake128::default());
+    let mut f = File::open("Cargo.toml")?;
+    io::copy(&mut f, &mut hasher)?;
+    let reader = hasher.0.finalize_xof();
+
+    // Wrap the reader and read data from it
+    let mut reader = IoWrapper(reader);
+    let buf = read_array(&mut reader)?;
+    println!("{buf:?}");
+
+    Ok(())
+}
+```
+
+Simultaneously reading and hashing file data:
+```rust
+use digest_io::HashReader;
+use sha2::Sha256;
+use std::{
+    fs::File,
+    io::{self, Read},
+};
+
+fn main() -> io::Result<()> {
+    // Create new hashing reader
+    let f = File::open("Cargo.toml")?;
+    let mut reader = HashReader::<Sha256, File>::new(f);
+
+    // Read all data from the file
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf)?;
+
+    // Get the resulting hash over read data
+    let hash = reader.finalize();
+    println!("Data: {buf:?}");
+    println!("Hash: {hash:?}");
+    Ok(())
+}
+```
+
+Simultaneously hashing data and writing it to file:
+```rust
+use digest_io::HashWriter;
+use sha2::{Digest, Sha256};
+use std::{
+    fs::File,
+    io::{self, Write},
+};
+
+fn main() -> io::Result<()> {
+    // Create new hashing reader
+    let f = File::create("out.txt")?;
+    let mut writer = HashWriter::<Sha256, File>::new(f);
+
+    // Write data to the file
+    let data = b"Hello world!";
+    writer.write_all(data)?;
+
+    // Get the resulting hash over written data
+    let hash = writer.finalize();
+    println!("{hash:?}");
+    assert_eq!(hash, Sha256::digest(data));
+    std::fs::remove_file("out.txt")?;
+    Ok(())
+}
+```
+
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/inout.svg
+[crate-link]: https://crates.io/crates/inout
+[docs-image]: https://docs.rs/inout/badge.svg
+[docs-link]: https://docs.rs/inout/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
+[build-image]: https://github.com/RustCrypto/utils/actions/workflows/inout.yml/badge.svg?branch=master
+[build-link]: https://github.com/RustCrypto/utils/actions/workflows/inout.yml?query=branch:master
+
+[//]: # (general links)
+
+[RustCrypto]: https://github.com/rustcrypto

--- a/digest-io/src/io_wrapper.rs
+++ b/digest-io/src/io_wrapper.rs
@@ -1,0 +1,28 @@
+use digest::{Update, XofReader};
+use std::io;
+
+/// Wrapper which allows to update state of an [`Update`] implementor by writing into it
+/// and to read data from a [`XofReader`] implementor.
+#[derive(Debug)]
+pub struct IoWrapper<T>(pub T);
+
+impl<T: Update> io::Write for IoWrapper<T> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Update::update(&mut self.0, buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<T: XofReader> io::Read for IoWrapper<T> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        XofReader::read(&mut self.0, buf);
+        Ok(buf.len())
+    }
+}

--- a/digest-io/src/lib.rs
+++ b/digest-io/src/lib.rs
@@ -1,0 +1,16 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![forbid(unsafe_code)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
+)]
+#![warn(missing_debug_implementations)]
+
+mod io_wrapper;
+mod reader;
+mod writer;
+
+pub use io_wrapper::IoWrapper;
+pub use reader::HashReader;
+pub use writer::HashWriter;

--- a/digest-io/src/reader.rs
+++ b/digest-io/src/reader.rs
@@ -1,0 +1,136 @@
+use digest::{Digest, FixedOutputReset, Output, Reset};
+use std::io;
+
+/// Abstraction over a reader which hashes the data being read
+#[derive(Debug)]
+pub struct HashReader<D: Digest, R: io::Read> {
+    reader: R,
+    hasher: D,
+}
+
+impl<D: Digest, R: io::Read> HashReader<D, R> {
+    /// Construct a new `HashReader` given an existing `reader` by value.
+    pub fn new(reader: R) -> Self {
+        Self::new_from_parts(D::new(), reader)
+    }
+
+    /// Construct a new `HashReader` given an existing `hasher` and `reader` by value.
+    pub fn new_from_parts(hasher: D, reader: R) -> Self {
+        HashReader { reader, hasher }
+    }
+
+    /// Replace the reader with another reader
+    pub fn replace_reader(&mut self, reader: R) {
+        self.reader = reader;
+    }
+
+    /// Gets a reference to the underlying hasher
+    pub fn get_hasher(&self) -> &D {
+        &self.hasher
+    }
+
+    /// Gets a reference to the underlying reader
+    pub fn get_reader(&self) -> &R {
+        &self.reader
+    }
+
+    /// Gets a mutable reference to the underlying hasher
+    pub fn get_hasher_mut(&mut self) -> &mut D {
+        &mut self.hasher
+    }
+
+    /// Gets a mutable reference to the underlying reader
+    /// Direct reads from the underlying reader are not hashed
+    pub fn get_reader_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    /// Consume the HashReader and return its hasher
+    pub fn into_hasher(self) -> D {
+        self.hasher
+    }
+
+    /// Consume the HashReader and return its internal reader
+    pub fn into_inner_reader(self) -> R {
+        self.reader
+    }
+
+    /// Consume the HashReader and return its hasher and internal reader
+    pub fn into_parts(self) -> (D, R) {
+        (self.hasher, self.reader)
+    }
+
+    /// Retrieve result and consume HashReader instance.
+    pub fn finalize(self) -> Output<D> {
+        self.hasher.finalize()
+    }
+
+    /// Write result into provided array and consume the HashReader instance.
+    pub fn finalize_into(self, out: &mut Output<D>) {
+        self.hasher.finalize_into(out)
+    }
+
+    /// Get output size of the hasher
+    pub fn output_size() -> usize {
+        <D as Digest>::output_size()
+    }
+}
+
+impl<D: Digest + Clone, R: io::Read + Clone> Clone for HashReader<D, R> {
+    fn clone(&self) -> HashReader<D, R> {
+        HashReader {
+            reader: self.reader.clone(),
+            hasher: self.hasher.clone(),
+        }
+    }
+}
+
+impl<D: Digest, R: io::Read> io::Read for HashReader<D, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let bytes = self.reader.read(buf)?;
+
+        if bytes > 0 {
+            self.hasher.update(&buf[0..bytes]);
+        }
+
+        Ok(bytes)
+    }
+}
+
+impl<D: Digest + FixedOutputReset, R: io::Read> HashReader<D, R> {
+    /// Retrieve result and reset hasher instance.
+    pub fn finalize_reset(&mut self) -> Output<D> {
+        Digest::finalize_reset(&mut self.hasher)
+    }
+
+    /// Rrite result into provided array and reset the hasher instance.
+    pub fn finalize_into_reset(&mut self, out: &mut Output<D>) {
+        Digest::finalize_into_reset(&mut self.hasher, out)
+    }
+}
+
+impl<D: Digest + Reset, R: io::Read> Reset for HashReader<D, R> {
+    fn reset(&mut self) {
+        Digest::reset(&mut self.hasher)
+    }
+}
+
+impl<D: Digest, R: io::BufRead> HashReader<D, R> {
+    /// Read and hash all bytes remaining in the reader, discarding the data
+    /// Based on implementation in b2sum crate, MIT License Copyright (c) 2017 John Downey
+    pub fn hash_to_end(&mut self) {
+        loop {
+            let count = {
+                let data = self.reader.fill_buf().unwrap();
+                if data.is_empty() {
+                    break;
+                }
+
+                self.hasher.update(data);
+                data.len()
+            };
+
+            self.reader.consume(count);
+        }
+    }
+}

--- a/digest-io/src/writer.rs
+++ b/digest-io/src/writer.rs
@@ -1,0 +1,121 @@
+use digest::{Digest, FixedOutputReset, Output, Reset};
+use std::io;
+
+/// Abstraction over a writer which hashes the data being written.
+#[derive(Debug)]
+pub struct HashWriter<D: Digest, W: io::Write> {
+    writer: W,
+    hasher: D,
+}
+
+impl<D: Digest, W: io::Write> HashWriter<D, W> {
+    /// Construct a new `HashWriter` given an existing `writer` by value.
+    pub fn new(writer: W) -> Self {
+        Self::new_from_parts(D::new(), writer)
+    }
+
+    /// Construct a new `HashWriter` given an existing `hasher` and `writer` by value.
+    pub fn new_from_parts(hasher: D, writer: W) -> Self {
+        HashWriter { writer, hasher }
+    }
+
+    /// Replace the writer with another writer
+    pub fn replace_writer(&mut self, writer: W) {
+        self.writer = writer;
+    }
+
+    /// Gets a reference to the underlying hasher
+    pub fn get_hasher(&self) -> &D {
+        &self.hasher
+    }
+
+    /// Gets a reference to the underlying writer
+    pub fn get_writer(&self) -> &W {
+        &self.writer
+    }
+
+    /// Gets a mutable reference to the underlying hasher
+    /// Updates to the digest are not written to the underlying writer
+    pub fn get_hasher_mut(&mut self) -> &mut D {
+        &mut self.hasher
+    }
+
+    /// Gets a mutable reference to the underlying writer
+    /// Direct writes to the underlying writer are not hashed
+    pub fn get_writer_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
+
+    /// Consume the HashWriter and return its hasher
+    pub fn into_hasher(self) -> D {
+        self.hasher
+    }
+
+    /// Consume the HashWriter and return its internal writer
+    pub fn into_inner_writer(self) -> W {
+        self.writer
+    }
+
+    /// Consume the HashWriter and return its hasher and internal writer
+    pub fn into_parts(self) -> (D, W) {
+        (self.hasher, self.writer)
+    }
+
+    /// Retrieve result and consume HashWriter instance.
+    pub fn finalize(self) -> Output<D> {
+        self.hasher.finalize()
+    }
+
+    /// Write result into provided array and consume the HashWriter instance.
+    pub fn finalize_into(self, out: &mut Output<D>) {
+        self.hasher.finalize_into(out)
+    }
+
+    /// Get output size of the hasher
+    pub fn output_size() -> usize {
+        <D as Digest>::output_size()
+    }
+}
+
+impl<D: Digest + Clone, W: io::Write + Clone> Clone for HashWriter<D, W> {
+    fn clone(&self) -> HashWriter<D, W> {
+        HashWriter {
+            writer: self.writer.clone(),
+            hasher: self.hasher.clone(),
+        }
+    }
+}
+
+impl<D: Digest, W: io::Write> io::Write for HashWriter<D, W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let bytes = self.writer.write(buf)?;
+
+        if bytes > 0 {
+            self.hasher.update(&buf[0..bytes]);
+        }
+
+        Ok(bytes)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+impl<D: Digest + FixedOutputReset, W: io::Write> HashWriter<D, W> {
+    /// Retrieve result and reset hasher instance.
+    pub fn finalize_reset(&mut self) -> Output<D> {
+        Digest::finalize_reset(&mut self.hasher)
+    }
+
+    /// Write result into provided array and reset the hasher instance.
+    pub fn finalize_into_reset(&mut self, out: &mut Output<D>) {
+        Digest::finalize_into_reset(&mut self.hasher, out)
+    }
+}
+
+impl<D: Digest + Reset, W: io::Write> Reset for HashWriter<D, W> {
+    fn reset(&mut self) {
+        Digest::reset(&mut self.hasher)
+    }
+}


### PR DESCRIPTION
This crate contains `std::io`-compatibility wrappers which are moved from the `digest` crate.