### PR TITLE
digest-io: minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains various utility crates used in the RustCrypto project.
 | [`collectable`] | [![crates.io](https://img.shields.io/crates/v/collectable.svg)](https://crates.io/crates/collectable) | [![Documentation](https://docs.rs/collectable/badge.svg)](https://docs.rs/collectable) | Fallible, `no_std`-friendly collection traits |
 | [`cpufeatures`] | [![crates.io](https://img.shields.io/crates/v/cpufeatures.svg)](https://crates.io/crates/cpufeatures) | [![Documentation](https://docs.rs/cpufeatures/badge.svg)](https://docs.rs/cpufeatures) | Lightweight and efficient alternative to the `is_x86_feature_detected!` macro |
 | [`dbl`] | [![crates.io](https://img.shields.io/crates/v/dbl.svg)](https://crates.io/crates/dbl) | [![Documentation](https://docs.rs/dbl/badge.svg)](https://docs.rs/dbl) | Double operation in Galois Field (GF) |
+| [`digest-io`] | [![crates.io](https://img.shields.io/crates/v/digest-io.svg)](https://crates.io/crates/digest-io) | [![Documentation](https://docs.rs/digest-io/badge.svg)](https://docs.rs/digest-io) | `std::io`-compatibility wrappers for traits defined in the `digest` crate |
 | [`hex-literal`] | [![crates.io](https://img.shields.io/crates/v/hex-literal.svg)](https://crates.io/crates/hex-literal) | [![Documentation](https://docs.rs/hex-literal/badge.svg)](https://docs.rs/hex-literal) | A macro for converting hexadecimal strings to a byte array at compile time |
 | [`inout`] | [![crates.io](https://img.shields.io/crates/v/inout.svg)](https://crates.io/crates/inout) | [![Documentation](https://docs.rs/inout/badge.svg)](https://docs.rs/inout) | Custom reference types for code generic over in-place and buffer-to-buffer modes of operation. |
 | [`opaque-debug`] | [![crates.io](https://img.shields.io/crates/v/opaque-debug.svg)](https://crates.io/crates/opaque-debug) | [![Documentation](https://docs.rs/opaque-debug/badge.svg)](https://docs.rs/opaque-debug) | Macro for opaque `Debug` trait implementation |
@@ -53,6 +54,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [`collectable`]: ./collectable
 [`cpufeatures`]: ./cpufeatures
 [`dbl`]: ./dbl
+[`digest-io`]: ./digest-io
 [`hex-literal`]: ./hex-literal
 [`inout`]: ./inout
 [`opaque-debug`]: ./opaque-debug

--- a/digest-io/Cargo.toml
+++ b/digest-io/Cargo.toml
@@ -13,5 +13,7 @@ readme = "README.md"
 
 [dependencies]
 digest = "0.11.0-pre.10"
+
+[dev-dependencies]
 sha2 = "0.11.0-pre.5"
 sha3 = "0.11.0-pre.5"

--- a/digest-io/README.md
+++ b/digest-io/README.md
@@ -132,16 +132,16 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/inout.svg
-[crate-link]: https://crates.io/crates/inout
-[docs-image]: https://docs.rs/inout/badge.svg
-[docs-link]: https://docs.rs/inout/
+[crate-image]: https://img.shields.io/crates/v/digest-io.svg
+[crate-link]: https://crates.io/crates/digest-io
+[docs-image]: https://docs.rs/digest-io/badge.svg
+[docs-link]: https://docs.rs/digest-io/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260052-utils
-[build-image]: https://github.com/RustCrypto/utils/actions/workflows/inout.yml/badge.svg?branch=master
-[build-link]: https://github.com/RustCrypto/utils/actions/workflows/inout.yml?query=branch:master
+[build-image]: https://github.com/RustCrypto/utils/actions/workflows/digest-io.yml/badge.svg?branch=master
+[build-link]: https://github.com/RustCrypto/utils/actions/workflows/digest-io.yml?query=branch:master
 
 [//]: # (general links)
 


### PR DESCRIPTION
Fixes badges in the crate README and moves hash crates used in examples to dev dependencies.