### PR TITLE
zeroize: remove explicit passing of the docsrs configuration flag

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -33,4 +33,3 @@ simd = [] # NOTE: MSRV 1.72
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
The flag is passed automatically by docs.rs.