### PR TITLE
inout: use `core::ptr::eq`

### DIFF
--- a/inout/src/inout.rs
+++ b/inout/src/inout.rs
@@ -43,7 +43,7 @@ impl<'inp, 'out, T> InOut<'inp, 'out, T> {
     where
         T: Copy,
     {
-        if self.in_ptr != self.out_ptr {
+        if !core::ptr::eq(self.in_ptr, self.out_ptr) {
             unsafe {
                 ptr::copy(self.in_ptr, self.out_ptr, 1);
             }

--- a/inout/src/inout_buf.rs
+++ b/inout/src/inout_buf.rs
@@ -131,7 +131,7 @@ impl<'inp, 'out, T> InOutBuf<'inp, 'out, T> {
     where
         T: Copy,
     {
-        if self.in_ptr != self.out_ptr {
+        if !core::ptr::eq(self.in_ptr, self.out_ptr) {
             unsafe {
                 core::ptr::copy(self.in_ptr, self.out_ptr, self.len);
             }


### PR DESCRIPTION
Fixes the `clippy::ptr_eq` lint.