### PR TITLE
cpufeatures: x86 support of sha512, sm3, sm4

### DIFF
--- a/cpufeatures/README.md
+++ b/cpufeatures/README.md
@@ -87,6 +87,9 @@ Target features:
 - `sse4.1`
 - `sse4.2`
 - `ssse3`
+- `sha512`
+- `sm3`
+- `sm4`
 
 If you would like detection support for a target feature which is not on
 this list, please [open a GitHub issue].

--- a/cpufeatures/README.md
+++ b/cpufeatures/README.md
@@ -87,9 +87,9 @@ Target features:
 - `sse4.1`
 - `sse4.2`
 - `ssse3`
-- `sha512`
-- `sm3`
-- `sm4`
+- `sha512`*
+- `sm3`*
+- `sm4`*
 
 If you would like detection support for a target feature which is not on
 this list, please [open a GitHub issue].

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -145,5 +145,5 @@ __expand_check_macro! {
 
     ("sha512", "ymm", 2, eax, 0),
     ("sm3", "xmm", 2, eax, 1),
-    ("sm4", "xmm", 2, eax, 2),
+    ("sm4", "ymm", 2, eax, 2),
 }

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -47,7 +47,7 @@ macro_rules! __detect_target_features {
         }
 
         let cr = unsafe {
-            [cpuid(1), cpuid_count(7, 0)]
+            [cpuid(1), cpuid_count(7, 0), cpuid_count(7, 1)]
         };
 
         $($crate::check!(cr, $tf) & )+ true
@@ -142,4 +142,8 @@ __expand_check_macro! {
     ("vpclmulqdq", "zmm", 1, ecx, 10),
     ("avx512bitalg", "zmm", 1, ecx, 12),
     ("avx512vpopcntdq", "zmm", 1, ecx, 14),
+
+    ("sha512", "ymm", 2, eax, 0),
+    ("sm3", "xmm", 2, eax, 1),
+    ("sm4", "xmm", 2, eax, 2),
 }


### PR DESCRIPTION
https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=1:_Extended_Features

Add supports of `sha512`, `sm3` and `sm4` in x86.

Rust support: https://github.com/rust-lang/rust/issues/126624