### PR TITLE
fiat-constify v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "fiat-constify"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/fiat-constify/Cargo.toml
+++ b/fiat-constify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiat-constify"
-version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.0"
 description = """
 Postprocessor for fiat-crypto generated field implementations which rewrites
 them as `const fn`
@@ -15,6 +15,7 @@ keywords = ["fiat-crypto", "field"]
 readme = "README.md"
 edition = "2024"
 rust-version = "1.85"
+publish = false
 
 [dependencies]
 prettyplease = "0.2.19"


### PR DESCRIPTION
Also adds `publish = "false"` as this tool is not intended for release (ideally we can eventually get rid of it), but the version bump denotes a major notable change to the codegen