### PR TITLE
zeroize: bump `zeroize_derive` dep to v1.4

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }
-zeroize_derive = { version = "1.3", path = "../zeroize_derive", optional = true }
+zeroize_derive = { version = "1.4", path = "../zeroize_derive", optional = true }
 
 [features]
 default = ["alloc"]


### PR DESCRIPTION
This is useful for `-Z minimal-versions` to ensure derived code builds without warnings on recent Rust versions, which complain about the earlier custom derive:

```
error: non-local `impl` definition, `impl` blocks should be written at the same level as their item
```