### PR TITLE
dbl v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "dbl"
-version = "0.4.0-rc.2"
+version = "0.4.0"
 dependencies = [
  "hybrid-array",
 ]

--- a/dbl/CHANGELOG.md
+++ b/dbl/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (unreleased)
+## 0.4.0 (2025-08-06)
 ### Changed
 - Migrated from `generic-array` to `hybrid-array` ([#944])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl"
-version = "0.4.0-rc.2"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/dbl"

--- a/dbl/README.md
+++ b/dbl/README.md
@@ -26,7 +26,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/dbl.svg
+[crate-image]: https://img.shields.io/crates/v/dbl.svg?logo=rust
 [crate-link]: https://crates.io/crates/dbl
 [docs-image]: https://docs.rs/dbl/badge.svg
 [docs-link]: https://docs.rs/dbl/

--- a/dbl/README.md
+++ b/dbl/README.md
@@ -26,7 +26,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/dbl.svg?logo=rust
+[crate-image]: https://img.shields.io/crates/v/dbl.svg
 [crate-link]: https://crates.io/crates/dbl
 [docs-image]: https://docs.rs/dbl/badge.svg
 [docs-link]: https://docs.rs/dbl/


### PR DESCRIPTION
### Changed
- Migrated from `generic-array` to `hybrid-array` ([#944])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
- Seal the `Dbl` trait ([#1198])

Closes #1077 

[#944]: https://github.com/RustCrypto/utils/pull/944
[#1149]: https://github.com/RustCrypto/utils/pull/1149
[#1198]: https://github.com/RustCrypto/utils/pull/1198