### PR TITLE
zeroize: add `proxy_alloc_test`

### DIFF
--- a/zeroize/tests/alloc.rs
+++ b/zeroize/tests/alloc.rs
@@ -43,6 +43,8 @@ impl<S: Zeroize> Drop for SecretBox<S> {
 
 #[test]
 fn proxy_alloc_test() {
-    let _b1 = SecretBox::new([u128::MAX; 10]);
-    let _b2 = SecretBox::new([u8::MAX; 160]);
+    let b1 = SecretBox::new([u128::MAX; 10]);
+    core::hint::black_box(&b1);
+    let b2 = SecretBox::new([u8::MAX; 160]);
+    core::hint::black_box(&b2);
 }


### PR DESCRIPTION
The added test checks that zeroization happens using a custom global allocator. Replacing `self.0.as_mut().zeroize()` with `self.0 = Default::default()` results in test failure as expected. The test also passes Miri without issues.