### PR TITLE
cpufeatures: use cfg() to detect aarch64 android instead of [target.aarch64-linux-android]

### DIFF
--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -24,5 +24,5 @@ libc = { version = "0.2.155", default-features = false }
 [target.'cfg(all(target_arch = "loongarch64", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.155", default-features = false }
 
-[target.aarch64-linux-android.dependencies]
+[target.'cfg(all(target_arch = "aarch64", target_os = "android"))'.dependencies]
 libc = { version = "0.2.155", default-features = false }


### PR DESCRIPTION
I propose that, on aarch64-linux-android, cpufeatures/Cargo.toml should use `cfg(all(...))` instead of full target name "aarch64-linux-android", just like the other target-specific deps on libc do.

Motivation for this change is building with a custom rustc target like "aarch64-foobar-linux-android". Cargo/Rustc (and consequently the #[cfg] check in src/aarch64.rs) correctly interpret that as target_arch="aarch64", target_os="android", but the current Cargo.toml fails to include the dependency on libc.