### PR TITLE
blobby: add number of entries to the file header

### DIFF
--- a/blobby/src/lib.rs
+++ b/blobby/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 pub(crate) mod decode;
 #[cfg(feature = "alloc")]
 pub use decode::parse_into_vec;
-pub use decode::{parse_dedup_len, parse_into_array, parse_items_len};
+pub use decode::{Header, parse_into_array};
 
 #[cfg(feature = "alloc")]
 mod encode;

--- a/blobby/tests/mod.rs
+++ b/blobby/tests/mod.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "alloc")]
+
+const TEST_BLOBS: &[&[u8]] = &[
+    b"1",
+    b"12",
+    b"1",
+    b"1",
+    b"123",
+    &[42; 100_000],
+    &[42; 100_000],
+    &[13; 70_000],
+];
+
+#[test]
+fn blobby_rondtrip_test() -> Result<(), blobby::Error> {
+    let (blobby_data, dedup_len) = blobby::encode_blobs(TEST_BLOBS);
+    assert_eq!(dedup_len, 2);
+    assert_eq!(blobby_data.len(), 170_022);
+
+    let decoded_blobs = blobby::parse_into_array::<8, 2>(&blobby_data)?;
+    assert_eq!(decoded_blobs, TEST_BLOBS);
+
+    let decoded_blobs = blobby::parse_into_vec(&blobby_data)?;
+    assert_eq!(decoded_blobs, TEST_BLOBS);
+
+    Ok(())
+}


### PR DESCRIPTION
This change allows to simplify decoding and use one-pass approach. Previously, we had to perform a separate pass to find number of entries in the file, which could make compilation for large blb files noticeably slower.