### PR TITLE
Bump `hybrid-array` to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ name = "block-buffer"
 version = "0.11.0-rc.4"
 dependencies = [
  "hex-literal 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hybrid-array",
+ "hybrid-array 0.4.0",
  "zeroize 1.8.1",
 ]
 
@@ -21,14 +21,14 @@ version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a229bfd78e4827c91b9b95784f69492c1b77c1ab75a45a8a037b139215086f94"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.3.1",
 ]
 
 [[package]]
 name = "block-padding"
 version = "0.4.0-rc.3"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.0",
 ]
 
 [[package]]
@@ -73,14 +73,14 @@ version = "0.2.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.3.1",
 ]
 
 [[package]]
 name = "dbl"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.0",
 ]
 
 [[package]]
@@ -139,11 +139,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe39a812f039072707ce38020acbab2f769087952eddd9e2b890f37654b2349"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "inout"
 version = "0.2.0-rc.5"
 dependencies = [
  "block-padding",
- "hybrid-array",
+ "hybrid-array 0.4.0",
 ]
 
 [[package]]

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hybrid-array = "0.3"
+hybrid-array = "0.4"
 zeroize = { version = "1.4", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["cryptography", "no-std"]
 readme = "README.md"
 
 [dependencies]
-hybrid-array = "0.3"
+hybrid-array = "0.4"

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl"
-version = "0.4.0"
+version = "0.5.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/dbl"
@@ -13,4 +13,4 @@ description = """Double operation in Galois Field `GF(2^128)` using the lexicogr
 polynomial among the irreducible degree `n` polynomials having a minimum number of coefficients."""
 
 [dependencies]
-hybrid-array = "0.3"
+hybrid-array = "0.4"

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 block-padding = { version = "0.4.0-rc.3", path = "../block-padding", optional = true }
-hybrid-array = "0.3"
+hybrid-array = "0.4"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
NOTE: when cutting releases the `inout` dependency on `block-padding` should also be bumped