### PR TITLE
dbl v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "dbl"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "hybrid-array 0.4.0",
 ]

--- a/dbl/CHANGELOG.md
+++ b/dbl/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2025-09-02)
+### Changed
+- Bump `hybrid-array` to v0.4 ([#1208])
+
+[#1208]: https://github.com/RustCrypto/utils/pull/1208
+
 ## 0.4.0 (2025-08-06)
 ### Changed
 - Migrated from `generic-array` to `hybrid-array` ([#944])

--- a/dbl/Cargo.toml
+++ b/dbl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl"
-version = "0.5.0-pre"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/dbl"


### PR DESCRIPTION
### Changed
- Bump `hybrid-array` to v0.4 ([#1208])

[#1208]: https://github.com/RustCrypto/utils/pull/1208
