### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ version = "0.4.0-pre.0"
 [[package]]
 name = "block-buffer"
 version = "0.11.0-rc.4"
-dependencies = [
- "hex-literal 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hybrid-array 0.4.0",
- "zeroize 1.8.1",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a229bfd78e4827c91b9b95784f69492c1b77c1ab75a45a8a037b139215086f94"
 dependencies = [
@@ -25,8 +16,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-rc.5"
+dependencies = [
+ "hex-literal 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hybrid-array 0.4.0",
+ "zeroize 1.8.1",
+]
+
+[[package]]
 name = "block-padding"
-version = "0.4.0-rc.3"
+version = "0.4.0-rc.4"
 dependencies = [
  "hybrid-array 0.4.0",
 ]
@@ -89,7 +89,7 @@ version = "0.11.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c478574b20020306f98d61c8ca3322d762e1ff08117422ac6106438605ea516"
 dependencies = [
- "block-buffer 0.11.0-rc.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.11.0-rc.4",
  "const-oid",
  "crypto-common",
 ]
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "block-padding",
  "hybrid-array 0.4.0",

--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-buffer"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Buffer type for block processing of data"

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.4.0-rc.3"
+version = "0.4.0-rc.4"
 description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 description = "Custom reference types for code generic over in-place and buffer-to-buffer modes of operation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ keywords = ["custom-reference"]
 readme = "README.md"
 
 [dependencies]
-block-padding = { version = "0.4.0-rc.3", path = "../block-padding", optional = true }
+block-padding = { version = "0.4.0-rc.4", path = "../block-padding", optional = true }
 hybrid-array = "0.4"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Releases the following:
- `block-buffer` v0.11.0-rc.5
- `block-padding` v0.4.0-rc.4
- `inout` v0.2.0-rc.6