### PR TITLE
cmov v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cmov"
-version = "0.4.0-pre"
+version = "0.4.0"
 
 [[package]]
 name = "collectable"

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (unreleased)
+## 0.4.0 (2025-09-10)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
 

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -6,7 +6,7 @@ constant-time and not be rewritten as branches by the compiler.
 Provides wrappers for the CMOV family of instructions on x86/x86_64
 and CSEL on AArch64.
 """
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/utils/tree/master/cmov"


### PR DESCRIPTION
### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])

[#1149]: https://github.com/RustCrypto/utils/pull/1149