### PR TITLE
blobby: 0.4.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "blobby"
-version = "0.4.0-pre.0"
+version = "0.4.0-pre.1"
 
 [[package]]
 name = "block-buffer"

--- a/blobby/Cargo.toml
+++ b/blobby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blobby"
-version = "0.4.0-pre.0"
+version = "0.4.0-pre.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Iterator over simple binary blob storage"


### PR DESCRIPTION
This includes the binary file format changes included in #1207

This release is to remove the various `[patch.crates-io]` we have to support the new format.