### PR TITLE
wycheproof2blb: fix blobby import

### DIFF
--- a/wycheproof2blb/Cargo.toml
+++ b/wycheproof2blb/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-blobby = { version = "0.4.0-pre", path = "../blobby" }
+blobby = { version = "0.4.0-pre", path = "../blobby", features = ["alloc"] }
 hex = "0.4"
 serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Fix error:

```
   Compiling wycheproof2blb v0.2.0-pre (/home/kpp/rustcrypto_utils/wycheproof2blb)
error[E0425]: cannot find function `encode_blobs` in crate `blobby`
   --> wycheproof2blb/src/main.rs:155:33
    |
155 |     let (blb_data, _) = blobby::encode_blobs(&blobs);
    |                                 ^^^^^^^^^^^^ not found in `blobby`
    |
note: found an item that was configured out
   --> /home/kpp/utils/blobby/src/lib.rs:20:7
    |
    = note: the item is gated behind the `alloc` feature
```

I don't know why your CI doesn't catch it :shrug: 