### PR TITLE
block-buffer: improve `split_blocks` implementations

### DIFF
--- a/block-buffer/src/sealed.rs
+++ b/block-buffer/src/sealed.rs
@@ -1,7 +1,7 @@
 use hybrid_array::sizes::{U0, U1};
 
 use super::{Array, ArraySize};
-use core::{mem::MaybeUninit, ptr, slice};
+use core::{mem::MaybeUninit, ptr};
 
 type Block<N> = MaybeUninit<Array<u8, N>>;
 
@@ -60,18 +60,7 @@ impl Sealed for super::Eager {
 
     #[inline(always)]
     fn split_blocks<N: ArraySize>(data: &[u8]) -> (&[Array<u8, N>], &[u8]) {
-        let nb = data.len() / N::USIZE;
-        let blocks_len = nb * N::USIZE;
-        let tail_len = data.len() - blocks_len;
-        // SAFETY: we guarantee that created slices do not point outside of `data`
-        unsafe {
-            let blocks_ptr = data.as_ptr() as *const Array<u8, N>;
-            let tail_ptr = data.as_ptr().add(blocks_len);
-            (
-                slice::from_raw_parts(blocks_ptr, nb),
-                slice::from_raw_parts(tail_ptr, tail_len),
-            )
-        }
+        Array::slice_as_chunks(data)
     }
 }
 
@@ -96,24 +85,12 @@ impl Sealed for super::Lazy {
 
     #[inline(always)]
     fn split_blocks<N: ArraySize>(data: &[u8]) -> (&[Array<u8, N>], &[u8]) {
-        if data.is_empty() {
-            return (&[], &[]);
-        }
-        let (nb, tail_len) = if data.len() % N::USIZE == 0 {
-            (data.len() / N::USIZE - 1, N::USIZE)
+        let (blocks, tail) = Array::slice_as_chunks(data);
+        if data.is_empty() || !tail.is_empty() {
+            (blocks, tail)
         } else {
-            let nb = data.len() / N::USIZE;
-            (nb, data.len() - nb * N::USIZE)
-        };
-        let blocks_len = nb * N::USIZE;
-        // SAFETY: we guarantee that created slices do not point outside of `data`
-        unsafe {
-            let blocks_ptr = data.as_ptr() as *const Array<u8, N>;
-            let tail_ptr = data.as_ptr().add(blocks_len);
-            (
-                slice::from_raw_parts(blocks_ptr, nb),
-                slice::from_raw_parts(tail_ptr, tail_len),
-            )
+            let (tail, blocks) = blocks.split_last().expect("`blocks` can not be empty");
+            (blocks, tail)
         }
     }
 }


### PR DESCRIPTION
This PR simplifies implementations and removes `unsafe` by leveraging `Array::slice_as_chunks`. The resulting code is still panic-free, as can be seen here: https://rust.godbolt.org/z/43xMT3ExP