### PR TITLE
block-padding: remove `unsafe` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ name = "block-buffer"
 version = "0.11.0-rc.5"
 dependencies = [
  "hex-literal 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hybrid-array 0.4.1",
+ "hybrid-array 0.4.3",
  "zeroize 1.8.1",
 ]
 
@@ -28,7 +28,7 @@ dependencies = [
 name = "block-padding"
 version = "0.4.0-rc.4"
 dependencies = [
- "hybrid-array 0.4.1",
+ "hybrid-array 0.4.3",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ dependencies = [
 name = "dbl"
 version = "0.5.0"
 dependencies = [
- "hybrid-array 0.4.1",
+ "hybrid-array 0.4.3",
 ]
 
 [[package]]
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7116c472cf19838450b1d421b4e842569f52b519d640aee9ace1ebcf5b21051"
+checksum = "ed7c10d9cd8b8e0733111482917f4f7e188cf6f57fc8eb0ff9b26a51db9fbd3c"
 dependencies = [
  "typenum",
 ]
@@ -142,7 +142,7 @@ name = "inout"
 version = "0.2.0-rc.6"
 dependencies = [
  "block-padding",
- "hybrid-array 0.4.1",
+ "hybrid-array 0.4.3",
 ]
 
 [[package]]

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["cryptography", "no-std"]
 readme = "README.md"
 
 [dependencies]
-hybrid-array = "0.4"
+hybrid-array = "0.4.3"

--- a/block-padding/src/lib.rs
+++ b/block-padding/src/lib.rs
@@ -8,6 +8,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
+#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 pub use hybrid_array as array;
@@ -78,11 +79,9 @@ pub trait Padding {
             (None, PadType::Ambiguous) => 0,
             (None, PadType::Reversible) => return Err(UnpadError),
         };
-        // SAFETY: `res_len` is always smaller or equal to `bs * blocks.len()`
-        Ok(unsafe {
-            let p = blocks.as_ptr() as *const u8;
-            core::slice::from_raw_parts(p, res_len)
-        })
+
+        // Note: `res_len` is always smaller or equal to `bs * blocks.len()`
+        Ok(&Array::slice_as_flattened(blocks)[..res_len])
     }
 }
 


### PR DESCRIPTION
Pushes the unsafety down to the `hybrid-array` level, using the newly added `Array::slice_as_flattened`.

Also adds `forbid(unsafe_code)`.