### PR TITLE
zeroize v1.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "serde",
  "zeroize_derive",

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.8.2 (2025-09-29)
+### Changed
+- Switch from `doc_auto_cfg` to `doc_cfg` ([#1228])
+
+[#1228]: https://github.com/RustCrypto/utils/pull/1228
+
 ## 1.8.1 (2024-05-25)
 ### Changed
 - Feature-gate AVX-512 support under `simd`; restores MSRV 1.60 ([#1073])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 description = """
 Securely clear secrets from memory with a simple trait built on
 stable Rust primitives which guarantee memory is zeroed using an

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"


### PR DESCRIPTION
Note: this is a backport release which doesn't include the bump to MSRV 1.85 / 2024 edition. I'd like to give that one a little more time to bake, as last time we tried to bump `zeroize` MSRV many people complained.

### Changed
- Switch from `doc_auto_cfg` to `doc_cfg` ([#1228])

[#1228]: https://github.com/RustCrypto/utils/pull/1228