### PR TITLE
zeroize: add v1.8.2 changelog entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zeroize"
-version = "1.9.0"
+version = "1.9.0-pre"
 dependencies = [
  "serde",
  "zeroize_derive",

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1149]: https://github.com/RustCrypto/utils/pull/1149
 
+## 1.8.2 (2025-09-29)
+### Changed
+- Switch from `doc_auto_cfg` to `doc_cfg` ([#1228])
+
+[#1228]: https://github.com/RustCrypto/utils/pull/1228
+
 ## 1.8.1 (2024-05-25)
 ### Changed
 - Feature-gate AVX-512 support under `simd`; restores MSRV 1.60 ([#1073])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroize"
-version = "1.9.0"
+version = "1.9.0-pre"
 description = """
 Securely clear secrets from memory with a simple trait built on
 stable Rust primitives which guarantee memory is zeroed using an


### PR DESCRIPTION
v1.8.2. was released in #1229.

Also bumps the version down to `1.9.0-pre` to note that v1.9.0 has not yet been released.