### PR TITLE
Release block-padding v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.4"
+version = "0.4.0"
 dependencies = [
  "hybrid-array",
 ]
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"

--- a/block-padding/CHANGELOG.md
+++ b/block-padding/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (unreleased)
+## 0.4.0 (2025-10-06)
 ### Added
 - `Padding::pad_detached` method ([#1225])
 

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.4.0-rc.4"
+version = "0.4.0"
 description = "Padding and unpadding of messages divided into blocks."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["custom-reference"]
 readme = "README.md"
 
 [dependencies]
-block-padding = { version = "0.4.0-rc.4", path = "../block-padding", optional = true }
+block-padding = { version = "0.4.0", path = "../block-padding", optional = true }
 hybrid-array = "0.4"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
### Added
- `Padding::pad_detached` method ([#1225])

### Changed
- Migrated from `generic-array` to `hybrid-array` ([#944])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
- Merged `RawPadding` and `Padding` traits ([#1217])
- Renamed `UnpadError` to `Error` ([#1225])

### Removed
- `Block` type alias ([#1217])
- `PadType` enum and associated type on the `Padding` trait ([#1225])

[#944]: https://github.com/RustCrypto/utils/pull/944
[#1149]: https://github.com/RustCrypto/utils/pull/1149
[#1217]: https://github.com/RustCrypto/utils/pull/1217
[#1225]: https://github.com/RustCrypto/utils/pull/1225