### PR TITLE
Release inout v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.6"
+version = "0.2.0"
 dependencies = [
  "block-padding",
  "hybrid-array",

--- a/inout/CHANGELOG.md
+++ b/inout/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (unreleased)
+## 0.2.0 (2025-10-06)
 ### Changed
 - Migrated from `generic-array` to `hybrid-array` ([#944])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])

--- a/inout/CHANGELOG.md
+++ b/inout/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#944]: https://github.com/RustCrypto/utils/pull/944
 [#1132]: https://github.com/RustCrypto/utils/pull/1132
-[#1132]: https://github.com/RustCrypto/utils/pull/1132
+[#1133]: https://github.com/RustCrypto/utils/pull/1133
 [#1149]: https://github.com/RustCrypto/utils/pull/1149
 [#1169]: https://github.com/RustCrypto/utils/pull/1169
 

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.2.0-rc.6"
+version = "0.2.0"
 description = "Custom reference types for code generic over in-place and buffer-to-buffer modes of operation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ keywords = ["custom-reference"]
 readme = "README.md"
 
 [dependencies]
-block-padding = { version = "0.4.0", path = "../block-padding", optional = true }
 hybrid-array = "0.4"
+block-padding = { version = "0.4", path = "../block-padding", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
### Changed
- Migrated from `generic-array` to `hybrid-array` ([#944])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])

### Added
- `InOut::into_out` and `InOutBufReserved::into_out` methods ([#1132])
- `InOutBufReserved::split_reserved` method ([#1133])
- `InOut::into_out_with_copied_in` and `InOutBuf::into_out_with_copied_in` methods ([#1169])

[#944]: https://github.com/RustCrypto/utils/pull/944
[#1132]: https://github.com/RustCrypto/utils/pull/1132
[#1133]: https://github.com/RustCrypto/utils/pull/1133
[#1149]: https://github.com/RustCrypto/utils/pull/1149
[#1169]: https://github.com/RustCrypto/utils/pull/1169
