### PR TITLE
Release blobby v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "blobby"
-version = "0.4.0-pre.1"
+version = "0.4.0"
 
 [[package]]
 name = "block-buffer"

--- a/blobby/CHANGELOG.md
+++ b/blobby/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (unreleased)
+## 0.4.0 (2025-10-08)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
 - Replaced iterators with `const fn` parsing ([#1187])

--- a/blobby/Cargo.toml
+++ b/blobby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blobby"
-version = "0.4.0-pre.1"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/blobby/README.md
+++ b/blobby/README.md
@@ -11,7 +11,7 @@ An encoding and decoding library for the Blobby (`blb`) file format, which serve
 deduplicated storage format for a sequence of binary blobs.
 
 ## Examples
-```
+```rust
 // We recommend to save blobby data into separate files and
 // use the `include_bytes!` macro
 static BLOBBY_DATA: &[u8; 27] = b"\x08\x02\x05hello\x06world!\x01\x02 \x00\x03\x06:::\x03\x01\x00";


### PR DESCRIPTION
### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
- Replaced iterators with `const fn` parsing ([#1187])
- Format of the file. File header now contains total number of stored blobs. ([#1207])

[#1149]: https://github.com/RustCrypto/utils/pull/1149
[#1187]: https://github.com/RustCrypto/utils/pull/1187
[#1207]: https://github.com/RustCrypto/utils/pull/1207