### PR TITLE
ctutils: constant-time selection and equality testing

### DIFF
--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -87,8 +87,17 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }}
 
+  # Test using `cargo careful`
+  test-careful:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cargo-careful
+      - run: cargo careful test --all-features
+
   # Cross-compiled tests
-  cross:
+  test-cross:
     strategy:
       matrix:
         include:

--- a/.github/workflows/ctutils.yml
+++ b/.github/workflows/ctutils.yml
@@ -1,0 +1,75 @@
+name: ctutils
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ctutils.yml"
+      - "ctutils/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: ctutils
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+# Cancels CI jobs when new commits are pushed to a PR branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.87.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v5
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }}
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      working-directory: ${{ github.workflow }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.87.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v5
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test
+
+  # Test using `cargo careful`
+  test-careful:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cargo-careful
+      - run: cargo careful test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.0.0"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "dbl"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "block-padding",
     "collectable",
     "cmov",
+    "ctutils",
     "cpufeatures",
     "dbl",
     "digest-io",
@@ -20,3 +21,6 @@ exclude = ["aarch64-dit"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+cmov = { path = "cmov" }

--- a/cmov/README.md
+++ b/cmov/README.md
@@ -83,7 +83,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/utils/actions/workflows/cmov.yml/badge.svg?branch=master
 [build-link]: https://github.com/RustCrypto/utils/actions/workflows/cmov.yml?query=branch:master
 
-[//]: # (general links)
+[//]: # (links)
 
 [RustCrypto]: https://github.com/RustCrypto
 [CMOV family]: https://www.jaist.ac.jp/iscenter-new/mpc/altix/altixdata/opt/intel/vtune/doc/users_guide/mergedProjects/analyzer_ec/mergedProjects/reference_olh/mergedProjects/instructions/instruct32_hh/vc35.htm

--- a/ctutils/CHANGELOG.md
+++ b/ctutils/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ctutils"
+description = """
+Constant-time utility library with selection and equality testing support targeting cryptographic
+applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides
+architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
+"""
+version = "0.0.0"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/RustCrypto/utils/tree/master/ctselect"
+repository = "https://github.com/RustCrypto/utils"
+categories = ["cryptography", "no-std"]
+keywords = ["crypto", "intrinsics"]
+readme = "README.md"
+edition = "2024"
+rust-version = "1.87"
+
+[dependencies]
+cmov = "0.4"

--- a/ctutils/LICENSE-APACHE
+++ b/ctutils/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ctutils/LICENSE-MIT
+++ b/ctutils/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ctutils/README.md
+++ b/ctutils/README.md
@@ -1,0 +1,67 @@
+# [RustCrypto]: Constant-Time Utilities
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache 2.0/MIT Licensed][license-image]
+![MSRV][msrv-image]
+
+Constant-time utility library with selection and equality testing support targeting cryptographic
+applications. Supports `const fn` where appropriate. Built on the [`cmov`] crate which provides
+architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
+
+## About
+
+This crate contains constant-time equivalents of the `bool` and `Option` types (`Choice` and
+`CtOption`), along with traits that can be used in combination with them.
+
+The `CtOption` type notably provides eagerly evaluated combinator methods (as opposed to the lazily
+evaluated combinators on `Option`) which make it possible to write constant-time code using
+an idiomatic Rust style.
+
+This is an experimental next-generation constant-time library inspired by `subtle`, but for now we
+recommend you continue to stick with `subtle`. We may attempt to get some of the changes in this
+library incorporated into `subtle` for a potential v3.0.
+
+## ⚠️ Security Warning
+
+The implementation contained in this crate has never been independently audited!
+
+USE AT YOUR OWN RISK!
+
+## Minimum Supported Rust Version (MSRV) Policy
+
+MSRV increases are not considered breaking changes and can happen in patch releases.
+
+The crate MSRV accounts for all supported targets and crate feature combinations.
+
+## License
+
+Licensed under either of:
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/ctutils.svg
+[crate-link]: https://crates.io/crates/ctutils
+[docs-image]: https://docs.rs/ctutils/badge.svg
+[docs-link]: https://docs.rs/ctutils/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.87+-blue.svg
+[build-image]: https://github.com/RustCrypto/utils/actions/workflows/ctutils.yml/badge.svg?branch=master
+[build-link]: https://github.com/RustCrypto/utils/actions/workflows/ctutils.yml?query=branch:master
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/RustCrypto
+[`cmov`]: https://docs.rs/cmov

--- a/ctutils/src/choice.rs
+++ b/ctutils/src/choice.rs
@@ -1,0 +1,238 @@
+use crate::{CtEq, CtSelect};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
+
+/// Constant-time analogue of `bool` providing a "best effort" optimization barrier.
+///
+/// Attempts to hint to the compiler and its codegen backends that optimizations should not be
+/// applied which depend on a value.
+///
+/// This is used as a "belt-and-suspenders" defense in addition to mechanisms like
+/// constant-time predication intrinsics provided by the `cmov` crate, and is never expected to be
+/// the only line of defense.
+#[derive(Copy, Clone, Debug)]
+pub struct Choice(u8);
+
+impl Choice {
+    /// The falsy value.
+    pub const FALSE: Self = Self(0);
+
+    /// The truthy value.
+    pub const TRUE: Self = Self(1);
+
+    /// Create a new [`Choice`] from the given `u8` value, which should be either `0` or `1`.
+    #[inline]
+    pub const fn new(value: u8) -> Self {
+        // Compare to what should be the non-secret upper bits of the value, which should always be
+        // zero, and thus avoid branching on the bit that carries a potential secret
+        debug_assert!(value & 0xFE == 0, "Choice::new accepts only 0 or 1");
+        Self(value)
+    }
+
+    /// Convert `Choice` into a `bool`.
+    ///
+    /// <div class = "warning">
+    /// <b>Security Warning</b>
+    ///
+    /// Using this function will introduce timing variability, since computing this at all currently
+    /// requires a branch.
+    ///
+    /// This is intended to be used as either the one and only branch at the end of a constant-time
+    /// operation to e.g. differentiate between success and failure, or in contexts where
+    /// constant-time doesn't matter, e.g. variable-time code that operates on "maybe secret" types
+    /// which aren't secrets in a particular context.
+    ///
+    /// If you are trying to use this in the context of a constant-time operation, be warned that
+    /// the small amount of timing variability it introduces can potentially be exploited. Whenever
+    /// possible, prefer fully constant-time approaches instead.
+    /// </div>
+    pub const fn to_bool(self) -> bool {
+        self.to_u8() != 0
+    }
+
+    /// Convert [`Choice`] to a `u8`, attempting to apply a "best effort" optimization barrier.
+    pub const fn to_u8(self) -> u8 {
+        // `black_box` is documented as working on a "best effort" basis. That's fine, this type is
+        // likewise documented as only working on a "best effort" basis itself. The only way we
+        // rely on `black_box` for correctness is it behaving as the identity function.
+        core::hint::black_box(self.0)
+    }
+
+    /// Apply an `and` conditional to the given [`Choice`]s.
+    #[inline]
+    pub const fn and(self, rhs: Choice) -> Choice {
+        Self(self.0 & rhs.0)
+    }
+
+    /// Apply an `or` conditional to the given [`Choice`]s.
+    #[inline]
+    pub const fn or(self, rhs: Choice) -> Choice {
+        Self(self.0 | rhs.0)
+    }
+
+    /// Apply an `xor` conditional to the given [`Choice`]s.
+    #[inline]
+    pub const fn xor(self, rhs: Choice) -> Choice {
+        Self(self.0 ^ rhs.0)
+    }
+
+    /// Compute the boolean inverse of `self`.
+    #[inline]
+    pub const fn not(self) -> Choice {
+        // NOTE: assumes self.0 is `0` or `1` as checked in constructor
+        Self(self.0 ^ 1)
+    }
+}
+
+impl BitAnd for Choice {
+    type Output = Choice;
+
+    #[inline]
+    fn bitand(self, rhs: Choice) -> Choice {
+        self.and(rhs)
+    }
+}
+
+impl BitAndAssign for Choice {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: Choice) {
+        *self = *self & rhs;
+    }
+}
+
+impl BitOr for Choice {
+    type Output = Choice;
+
+    #[inline]
+    fn bitor(self, rhs: Choice) -> Choice {
+        self.or(rhs)
+    }
+}
+
+impl BitOrAssign for Choice {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Choice) {
+        *self = *self | rhs;
+    }
+}
+
+impl BitXor for Choice {
+    type Output = Choice;
+
+    #[inline]
+    fn bitxor(self, rhs: Choice) -> Choice {
+        Choice(self.0 ^ rhs.0)
+    }
+}
+
+impl BitXorAssign for Choice {
+    #[inline]
+    fn bitxor_assign(&mut self, rhs: Choice) {
+        *self = *self ^ rhs;
+    }
+}
+
+impl CtEq for Choice {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Self {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+impl CtSelect for Choice {
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
+        Choice(self.0.ct_select(&other.0, choice))
+    }
+}
+
+impl From<Choice> for u8 {
+    fn from(choice: Choice) -> u8 {
+        choice.to_u8()
+    }
+}
+
+impl From<Choice> for bool {
+    fn from(choice: Choice) -> bool {
+        choice.to_bool()
+    }
+}
+
+impl Not for Choice {
+    type Output = Choice;
+
+    #[inline]
+    fn not(self) -> Choice {
+        self.not()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Choice;
+    use crate::{CtEq, CtSelect};
+
+    #[test]
+    fn ct_eq() {
+        let a = Choice::TRUE;
+        let b = Choice::TRUE;
+        let c = Choice::FALSE;
+
+        assert!(a.ct_eq(&b).to_bool());
+        assert!(!a.ct_eq(&c).to_bool());
+        assert!(!b.ct_eq(&c).to_bool());
+
+        assert!(!a.ct_ne(&b).to_bool());
+        assert!(a.ct_ne(&c).to_bool());
+        assert!(b.ct_ne(&c).to_bool());
+    }
+
+    #[test]
+    fn ct_select() {
+        let a = Choice::FALSE;
+        let b = Choice::TRUE;
+        assert_eq!(a.ct_select(&b, Choice::FALSE).to_bool(), a.to_bool());
+        assert_eq!(a.ct_select(&b, Choice::TRUE).to_bool(), b.to_bool());
+    }
+
+    #[test]
+    fn to_bool() {
+        assert_eq!(Choice::new(0).to_bool(), false);
+        assert_eq!(Choice::new(1).to_bool(), true);
+    }
+
+    #[test]
+    fn to_u8() {
+        assert_eq!(Choice::new(0).to_u8(), 0);
+        assert_eq!(Choice::new(1).to_u8(), 1);
+    }
+
+    #[test]
+    fn and() {
+        assert_eq!((Choice::new(0) & Choice::new(0)).to_u8(), 0);
+        assert_eq!((Choice::new(1) & Choice::new(0)).to_u8(), 0);
+        assert_eq!((Choice::new(0) & Choice::new(1)).to_u8(), 0);
+        assert_eq!((Choice::new(1) & Choice::new(1)).to_u8(), 1);
+    }
+
+    #[test]
+    fn or() {
+        assert_eq!((Choice::new(0) | Choice::new(0)).to_u8(), 0);
+        assert_eq!((Choice::new(1) | Choice::new(0)).to_u8(), 1);
+        assert_eq!((Choice::new(0) | Choice::new(1)).to_u8(), 1);
+        assert_eq!((Choice::new(1) | Choice::new(1)).to_u8(), 1);
+    }
+
+    #[test]
+    fn xor() {
+        assert_eq!((Choice::new(0) ^ Choice::new(0)).to_u8(), 0);
+        assert_eq!((Choice::new(1) ^ Choice::new(0)).to_u8(), 1);
+        assert_eq!((Choice::new(0) ^ Choice::new(1)).to_u8(), 1);
+        assert_eq!((Choice::new(1) ^ Choice::new(1)).to_u8(), 0);
+    }
+
+    #[test]
+    fn not() {
+        assert_eq!(Choice::new(0).not().to_u8(), 1);
+        assert_eq!(Choice::new(1).not().to_u8(), 0);
+    }
+}

--- a/ctutils/src/lib.rs
+++ b/ctutils/src/lib.rs
@@ -1,0 +1,73 @@
+#![no_std]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![deny(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications
+)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+
+//! # API Design
+//!
+//! ## [`Choice`]: constant-time analogue for [`bool`]
+//! Values of this type are one of either [`Choice::FALSE`] or [`Choice::TRUE`].
+//!
+//! To achieve constant-time operation, `Choice` is ultimately used in combination with special
+//! CPU-specific constant-time predication instructions implemented by the [`cmov`] crate
+//! (with a portable "best effort" fallback that cannot provide guarantees).
+//!
+//! It additionally uses various methods to hint to the compiler that it should avoid inserting
+//! branches based on its value where it otherwise would if `bool` were used instead, but cannot
+//! provide guarantees in this regard.
+//!
+//! ## [`CtOption`]: constant-time analogue for [`Option`]
+//! The core `Option` type is typically great for representing the conditional absence or presence
+//! of a value, and provides a number of handy combinators for operating on them.
+//!
+//! However, it has a rather fundamental flaw when constant-time is desirable: its combinators are
+//! lazily evaluated. To ensure constant-time operation, all combinators must be eagerly evaluated
+//! so they aren't conditionally executed based on the value's presence.
+//!
+//! `CtOption` instead carries a `Choice` along with a value, which makes it possible to do
+//! something it isn't with `Option`: evaluate combinators eagerly instead of lazily, running the
+//! same functions regardless of the value's effective presence or absence.
+//!
+//! ## [`CtEq`]: constant-time analogue for [`PartialEq`]/[`Eq`]
+//! Equality testing often short circuits for performance reasons, but when comparing values in
+//! constant-time such short-circuiting is forbidden.
+//!
+//! The `CtEq` trait is a replacement for these scenarios. It's impl'd for several core types
+//! including unsigned and signed integers as well as slices and arrays. It returns a `Choice`
+//! as opposed to a `bool`], following the standard practice in this crate.
+//!
+//! *NOTE: for `subtle` users, this is the equivalent of the `ConstantTimeEq` trait*
+//!
+//! ## [`CtSelect`]: constant-time [predication]
+//! Predication in computer architecture describes methods for conditionally modifying state
+//! using non-branch instructions which perform conditional modifications based on a *predicate*
+//! or boolean value, in the design of this library a `Choice`.
+//!
+//! The `CtSelect` trait provides methods for performing conditional moves, either conditionally
+//! modifying a value in-place, or selecting from two different inputs and returning a new one.
+//!
+//! *NOTE: for `subtle` users, this is the equivalent of the `ConditionallySelectable` trait*
+//!
+//! [predication]: https://en.wikipedia.org/wiki/Predication_(computer_architecture)
+
+mod choice;
+mod ct_option;
+mod traits;
+
+pub use choice::Choice;
+pub use ct_option::CtOption;
+pub use traits::{ct_eq::CtEq, ct_select::CtSelect};

--- a/ctutils/src/traits.rs
+++ b/ctutils/src/traits.rs
@@ -1,0 +1,7 @@
+//! Trait definitions.
+//!
+//! These are each in their own module so we can also define tests for the core types they're impl'd
+//! on in the same module.
+
+pub(crate) mod ct_eq;
+pub(crate) mod ct_select;

--- a/ctutils/src/traits/ct_eq.rs
+++ b/ctutils/src/traits/ct_eq.rs
@@ -1,0 +1,158 @@
+use crate::Choice;
+use cmov::CmovEq;
+use core::cmp;
+
+/// Constant-time equality: like `(Partial)Eq` with [`Choice`] instead of [`bool`].
+///
+/// Impl'd for: [`u8`], [`u16`], [`u32`], [`u64`], [`u128`], [`usize`], [`cmp::Ordering`],
+/// [`Choice`], and arrays/slices of any type which also impls [`CtEq`].
+pub trait CtEq<Rhs = Self>
+where
+    Rhs: ?Sized,
+{
+    /// Equality
+    fn ct_eq(&self, other: &Rhs) -> Choice;
+
+    /// Inequality
+    fn ct_ne(&self, other: &Rhs) -> Choice {
+        !self.ct_eq(other)
+    }
+}
+
+// Impl `CtEq` using the `cmov::CmovEq` trait
+macro_rules! impl_unsigned_ct_eq_with_cmov {
+    ( $($uint:ty),+ ) => {
+        $(
+            impl CtEq for $uint {
+                #[inline]
+                fn ct_eq(&self, other: &Self) -> Choice {
+                    let mut ret = 0;
+                    self.cmoveq(other, 1, &mut ret);
+                    Choice::new(ret)
+                }
+            }
+        )+
+    };
+}
+
+// Impl `CtEq` by first casting to unsigned then using the unsigned `CtEq` impls
+// TODO(tarcieri): add signed integer support to `cmov`
+macro_rules! impl_signed_ct_eq_with_cmov {
+    ( $($int:ty),+ ) => {
+        $(
+            impl CtEq for $int {
+                #[inline]
+                fn ct_eq(&self, other: &Self) -> Choice {
+                    self.cast_unsigned().ct_eq(&other.cast_unsigned())
+                }
+            }
+        )+
+    };
+}
+
+impl_unsigned_ct_eq_with_cmov!(u8, u16, u32, u64, u128);
+impl_signed_ct_eq_with_cmov!(i8, i16, i32, i64, i128);
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl CtEq for usize {
+    #[cfg(target_pointer_width = "32")]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        (*self as u32).ct_eq(&(*other as u32))
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        (*self as u64).ct_eq(&(*other as u64))
+    }
+}
+
+impl CtEq for cmp::Ordering {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        // `Ordering` is `repr(i8)`, which has a `CtEq` impl
+        (*self as i8).ct_eq(&(*other as i8))
+    }
+}
+
+impl<T: CtEq> CtEq for [T] {
+    #[inline]
+    fn ct_eq(&self, other: &[T]) -> Choice {
+        let mut ret = self.len().ct_eq(&other.len());
+        for (a, b) in self.iter().zip(other.iter()) {
+            ret &= a.ct_eq(b);
+        }
+        ret
+    }
+}
+
+impl<T: CtEq, const N: usize> CtEq for [T; N] {
+    #[inline]
+    fn ct_eq(&self, other: &[T; N]) -> Choice {
+        self.as_slice().ct_eq(other.as_slice())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CtEq;
+    use core::cmp::Ordering;
+
+    macro_rules! truth_table {
+        ($a:expr, $b:expr, $c:expr) => {
+            assert!($a.ct_eq(&$b).to_bool());
+            assert!(!$a.ct_eq(&$c).to_bool());
+            assert!(!$b.ct_eq(&$c).to_bool());
+
+            assert!(!$a.ct_ne(&$b).to_bool());
+            assert!($a.ct_ne(&$c).to_bool());
+            assert!($b.ct_ne(&$c).to_bool());
+        };
+    }
+
+    macro_rules! ct_eq_test {
+        ($ty:ty, $name:ident) => {
+            #[test]
+            fn $name() {
+                let a: $ty = 42;
+                let b: $ty = 42;
+                let c: $ty = 1;
+                truth_table!(a, b, c);
+            }
+        };
+    }
+
+    ct_eq_test!(u8, u8_ct_eq);
+    ct_eq_test!(u16, u16_ct_eq);
+    ct_eq_test!(u32, u32_ct_eq);
+    ct_eq_test!(u64, u64_ct_eq);
+    ct_eq_test!(u128, u128_ct_eq);
+    ct_eq_test!(usize, usize_ct_eq);
+
+    #[test]
+    fn array_ct_eq() {
+        let a = [1u64, 2, 3];
+        let b = [1u64, 2, 3];
+        let c = [1u64, 2, 4];
+        truth_table!(a, b, c);
+    }
+
+    #[test]
+    fn ordering_ct_eq() {
+        let a = Ordering::Greater;
+        let b = Ordering::Greater;
+        let c = Ordering::Less;
+        truth_table!(a, b, c);
+    }
+
+    #[test]
+    fn slice_ct_eq() {
+        let a: &[u64] = &[1, 2, 3];
+        let b: &[u64] = &[1, 2, 3];
+        let c: &[u64] = &[1, 2, 4];
+        truth_table!(a, b, c);
+
+        // Length mismatches
+        assert!(a.ct_ne(&[]).to_bool());
+        assert!(a.ct_ne(&[1, 2]).to_bool());
+    }
+}

--- a/ctutils/src/traits/ct_select.rs
+++ b/ctutils/src/traits/ct_select.rs
@@ -1,0 +1,146 @@
+use crate::Choice;
+use cmov::Cmov;
+use core::cmp;
+
+/// Constant-time selection: pick between two values based on a given [`Choice`].
+pub trait CtSelect: Sized {
+    /// Select between `self` and `other` based on `choice`, returning a copy of the value.
+    ///
+    /// # Returns
+    /// - `self` if `choice` is [`Choice::FALSE`].
+    /// - `other` if `choice` is [`Choice::TRUE`].
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self;
+
+    /// Conditionally assign `other` to `self` if `choice` is [`Choice::TRUE`].
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        *self = Self::ct_select(self, other, choice);
+    }
+
+    /// Conditionally swap `self` and `other` if `choice` is [`Choice::TRUE`].
+    fn ct_swap(&mut self, other: &mut Self, choice: Choice) {
+        let tmp = self.ct_select(other, choice);
+        *other = Self::ct_select(other, self, choice);
+        *self = tmp;
+    }
+}
+
+// Impl `CtSelect` using the `cmov::Cmov` trait
+macro_rules! impl_unsigned_ct_select_with_cmov {
+    ( $($uint:ty),+ ) => {
+        $(
+            impl CtSelect for $uint {
+                #[inline]
+                fn ct_select(&self, other: &Self, choice: Choice) -> Self {
+                    let mut ret = *self;
+                    ret.ct_assign(other, choice);
+                    ret
+                }
+
+                fn ct_assign(&mut self, other: &Self, choice: Choice) {
+                    self.cmovnz(other, choice.into());
+                }
+            }
+        )+
+    };
+}
+
+// Impl `CtSelect` by first casting to unsigned then using the unsigned `CtSelect` impls
+// TODO(tarcieri): add signed integer support to `cmov`
+macro_rules! impl_signed_ct_select_with_cmov {
+    ( $($int:ty),+ ) => {
+        $(
+            impl CtSelect for $int {
+                #[inline]
+                fn ct_select(&self, other: &Self, choice: Choice) -> Self {
+                    self.cast_unsigned().ct_select(&other.cast_unsigned(), choice).cast_signed()
+                }
+            }
+        )+
+    };
+}
+
+impl_unsigned_ct_select_with_cmov!(u8, u16, u32, u64, u128);
+impl_signed_ct_select_with_cmov!(i8, i16, i32, i64, i128);
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl CtSelect for usize {
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
+        (*self as u32).ct_select(&(*other as u32), choice) as usize
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
+        (*self as u64).ct_select(&(*other as u64), choice) as usize
+    }
+}
+
+impl CtSelect for cmp::Ordering {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
+        // `Ordering` is `#[repr(i8)]` where:
+        //
+        // - `Less` => -1
+        // - `Equal` => 0
+        // - `Greater` => 1
+        //
+        // Given this, it's possible to operate on orderings as if they're `i8`, which allows us to
+        // use the `CtSelect` impl on `i8` to select between them.
+        let ret = (*self as i8).ct_select(&(*other as i8), choice);
+
+        // SAFETY: `Ordering` is `#[repr(i8)]` and `ret` has been assigned to
+        // a value which was originally a valid `Ordering` then cast to `i8`
+        #[allow(trivial_casts, unsafe_code)]
+        unsafe {
+            *(&ret as *const i8).cast::<Self>()
+        }
+    }
+}
+
+impl<T, const N: usize> CtSelect for [T; N]
+where
+    T: CtSelect,
+{
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
+        core::array::from_fn(|i| T::ct_select(&self[i], &other[i], choice))
+    }
+
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        for (a, b) in self.iter_mut().zip(other) {
+            a.ct_assign(b, choice)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Choice, CtSelect, cmp};
+
+    macro_rules! ct_select_test {
+        ($ty:ty, $name:ident) => {
+            #[test]
+            fn $name() {
+                let a: $ty = 1;
+                let b: $ty = 2;
+                assert_eq!(a.ct_select(&b, Choice::FALSE), a);
+                assert_eq!(a.ct_select(&b, Choice::TRUE), b);
+            }
+        };
+    }
+
+    ct_select_test!(u8, u8_ct_select);
+    ct_select_test!(u16, u16_ct_select);
+    ct_select_test!(u32, u32_ct_select);
+    ct_select_test!(u64, u64_ct_select);
+    ct_select_test!(u128, u128_ct_select);
+
+    #[test]
+    fn ordering_ct_select() {
+        let a = cmp::Ordering::Less;
+        let b = cmp::Ordering::Greater;
+        assert_eq!(a.ct_select(&b, Choice::FALSE), a);
+        assert_eq!(a.ct_select(&b, Choice::TRUE), b);
+    }
+}


### PR DESCRIPTION
(for lack of a better name)

~~This is woefully incomplete but I'm pushing it up anyway since several people have asked about `const fn` support for `subtle`~~

This is effectively a rewrite of `subtle` using the `cmov` crate for both constant-time selection/predication as well as equality comparisons. The `cmov` crate uses architecture-specific predication instructions on x86(_64) and ARM, with a portable "best effort" fallback.

It uses `core::hint::black_box` on-access as an optimization barrier, however this is a belt-and-suspenders defense paired with the use of intrinsics where available. This is a bit different than `subtle` which uses a similar black box optimization barrier at initialization time. There are a couple problems with this approach:

1. The optimizer can assume the value is unchanged after repeat accesses to the same `Choice`, which means it could potentially insert a branch to e.g. shortcut-on-zero
2. `black_box` is (rather annoyingly) only `const fn` in Rust 1.86. ~~This is targeting an initial MSRV of 1.85~~ This PR is MSRV 1.87 but we'll have a revertable downgrade to 1.85, as well as supporting `const fn` constructors for `Choice` which are a big missing piece in `subtle` right now

I'm not intending to replace our usages of `subtle` with this yet (I'd much rather ship everything), but would like to have a testbed for using `cmov` for constant-time operations which can perhaps inform a potential `subtle` v3.0 (if I can make that happen).

~~To be useful, this still needs an equivalent of `CtOption` (ideally with much more `const fn` support), which I was hoping to implement before pushing this up.~~ Added!

One thing we could consider is trying to get this complete enough to use in `crypto-bigint` to replace `ConstChoice`/`ConstCtOption`, though it would likely need all of the methods on `Choice` to be `const fn`, which would probably involve shipping `Choice` without `black_box` (i.e. what `crypto-bigint` is already doing), and then adding a `subtle` integration for converting `ctutil::Choice` -> `subtle::Choice` and a prospective `ctutil::CtOption` -> `subtle::CtOption`.

cc @andrewwhitehead @fjarri @ycscaly