### PR TITLE
block-padding: add `'static` bound to `Padding`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,15 +8,6 @@ version = "0.4.0"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.11.0"
 dependencies = [
  "hex-literal 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,8 +16,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "hybrid-array",
 ]
@@ -89,7 +89,7 @@ version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
- "block-buffer 0.11.0-rc.5",
+ "block-buffer 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "const-oid",
  "crypto-common",
 ]
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/block-padding/CHANGELOG.md
+++ b/block-padding/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.1 (2025-10-06)
+## 0.4.2 (2025-11-26)
+### Changed
+- Added `'static` bound to `Padding` trait ([#1248])
+
+[#1248]: https://github.com/RustCrypto/utils/pull/1248
+
+## 0.4.1 (2025-10-06) [YANKED]
 ### Added
 - `PaddedData` enum  ([#1227])
 

--- a/block-padding/Cargo.toml
+++ b/block-padding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-padding"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/block-padding/src/lib.rs
+++ b/block-padding/src/lib.rs
@@ -13,7 +13,7 @@ use core::fmt;
 use hybrid_array::{Array, ArraySize};
 
 /// Trait for message padding algorithms.
-pub trait Padding {
+pub trait Padding: 'static {
     /// Pads `block` filled with data up to `pos` (i.e the message length
     /// stored in `block` is equal to `pos`).
     ///


### PR DESCRIPTION
Needed for https://github.com/RustCrypto/traits/pull/2101