### PR TITLE
cmov: use `black_box` in portable impl

### DIFF
--- a/cmov/src/portable.rs
+++ b/cmov/src/portable.rs
@@ -7,7 +7,7 @@
 // TODO(tarcieri): more optimized implementation for small integers
 
 use crate::{Cmov, CmovEq, Condition};
-use core::mem::size_of;
+use core::{hint::black_box, mem::size_of};
 
 impl Cmov for u16 {
     #[inline]
@@ -100,5 +100,5 @@ impl CmovEq for u64 {
 fn is_non_zero(condition: Condition) -> u64 {
     const SHIFT_BITS: usize = size_of::<u64>() - 1;
     let condition = condition as u64;
-    ((condition | (!condition).wrapping_add(1)) >> SHIFT_BITS) & 1
+    black_box(((condition | (!condition).wrapping_add(1)) >> SHIFT_BITS) & 1)
 }


### PR DESCRIPTION
The core predication function of the portable implementation is called `is_non_zero` and it returns a 1-bit mask value which is subsequently used to "select" between two values using bitwise masking.

In some previous real-world cases in the Rust compiler, it has been able to deduce, when using this sort of pattern in a loop, that the entire loop can be skipped when e.g. the condition is zero. [RUSTSEC-2024-0344](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) is one such example.

Adding a `black_box` in this position should hopefully help hint to the compiler that we do not want such an "optimization" performed.

Note that the only thing we're actually relying on from `black_box` for program correctness is that it behaves as an identity function, so this will not have deleterious effects. Whether it actually helps avoid problems like RUSTSEC-2024-0344 is something that can only be seen in practice, unfortunately, as we don't have any way to get actual guarantees out of the Rust compiler in cases where we can't use `asm!`.