### PR TITLE
CI: fix security audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.21.1
+          key: ${{ runner.os }}-cargo-audit-v0.22.0
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps the cache key for `cargo audit` since the old versions are no longer compatible with the database.