### PR TITLE
ctutils: `subtle` interop

### DIFF
--- a/.github/workflows/ctutils.yml
+++ b/.github/workflows/ctutils.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cargo test
+      - run: cargo test --all-features
+      - run: cargo test --all-features --release
 
   # Test using `cargo careful`
   test-careful:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ name = "ctutils"
 version = "0.0.0"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -261,6 +262,12 @@ dependencies = [
  "digest",
  "keccak",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -18,3 +18,6 @@ rust-version = "1.85"
 
 [dependencies]
 cmov = "0.4"
+
+# optional dependencies
+subtle = { version = "2", optional = true, default-features = false }

--- a/ctutils/src/choice.rs
+++ b/ctutils/src/choice.rs
@@ -159,6 +159,22 @@ impl From<Choice> for bool {
     }
 }
 
+#[cfg(feature = "subtle")]
+impl From<subtle::Choice> for Choice {
+    #[inline]
+    fn from(choice: subtle::Choice) -> Choice {
+        Choice(choice.unwrap_u8())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl From<Choice> for subtle::Choice {
+    #[inline]
+    fn from(choice: Choice) -> subtle::Choice {
+        subtle::Choice::from(choice.0)
+    }
+}
+
 impl Not for Choice {
     type Output = Choice;
 

--- a/ctutils/src/ct_option.rs
+++ b/ctutils/src/ct_option.rs
@@ -385,6 +385,31 @@ impl<T> From<CtOption<T>> for Option<T> {
     }
 }
 
+/// NOTE: in order to be able to unwrap the `subtle::CtOption` we rely on a `Default` bound in
+/// order to have a placeholder value, and `ConditionallySelectable` to be able to use `unwrap_or`.
+#[cfg(feature = "subtle")]
+impl<T> From<subtle::CtOption<T>> for CtOption<T>
+where
+    T: subtle::ConditionallySelectable + Default,
+{
+    #[inline]
+    fn from(src: subtle::CtOption<T>) -> CtOption<T> {
+        let is_some = src.is_some();
+        CtOption {
+            value: src.unwrap_or(Default::default()),
+            is_some: is_some.into(),
+        }
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> From<CtOption<T>> for subtle::CtOption<T> {
+    #[inline]
+    fn from(src: CtOption<T>) -> subtle::CtOption<T> {
+        subtle::CtOption::new(src.value, src.is_some.into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{Choice, CtEq, CtOption, CtSelect};


### PR DESCRIPTION
Adds bidirectional `From` conversions for the following:
- `ctutils::Choice` <=> `subtle::Choice`
- `ctutils::CtOption` <=> `subtle::CtOption`

Support is gated under an optional `subtle` feature.

This will simplify using `ctutils` in codebases that are already using `subtle` such as `crypto-bigint` (the main place it seems interesting to actually attempt to use it).