### PR TITLE
cmov v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cmov"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "collectable"

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2025-12-19)
+### Changed
+- Use `black_box` in portable impl ([#1255])
+
+[#1255]: https://github.com/RustCrypto/utils/pull/1255
+
 ## 0.4.0 (2025-09-10)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmov"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Changed
- Use `black_box` in portable impl ([#1255])

[#1255]: https://github.com/RustCrypto/utils/pull/1255