### PR TITLE
ctutils: add `CtGt` and `CtLt`

### DIFF
--- a/ctutils/src/lib.rs
+++ b/ctutils/src/lib.rs
@@ -70,4 +70,4 @@ mod traits;
 
 pub use choice::Choice;
 pub use ct_option::CtOption;
-pub use traits::{ct_eq::CtEq, ct_select::CtSelect};
+pub use traits::{ct_eq::CtEq, ct_gt::CtGt, ct_lt::CtLt, ct_select::CtSelect};

--- a/ctutils/src/traits.rs
+++ b/ctutils/src/traits.rs
@@ -4,4 +4,6 @@
 //! on in the same module.
 
 pub(crate) mod ct_eq;
+pub(crate) mod ct_gt;
+pub(crate) mod ct_lt;
 pub(crate) mod ct_select;

--- a/ctutils/src/traits/ct_gt.rs
+++ b/ctutils/src/traits/ct_gt.rs
@@ -1,0 +1,57 @@
+use crate::Choice;
+use core::cmp;
+
+/// Constant time greater than operation.
+pub trait CtGt {
+    /// Compute whether `self > other` in constant time.
+    fn ct_gt(&self, other: &Self) -> Choice;
+}
+
+// Impl `CtGt` using overflowing subtraction
+macro_rules! impl_unsigned_ct_gt {
+    ( $($uint:ty),+ ) => {
+        $(
+            impl CtGt for $uint {
+                #[inline]
+                fn ct_gt(&self, other: &Self) -> Choice {
+                    let (_, overflow) = other.overflowing_sub(*self);
+                    Choice::new(overflow.into())
+                }
+            }
+        )+
+    };
+}
+
+impl_unsigned_ct_gt!(u8, u16, u32, u64, u128);
+
+impl CtGt for cmp::Ordering {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> Choice {
+        // No impl of `CtGt` for `i8`, so use `u8`
+        let a = (*self as i8) + 1;
+        let b = (*other as i8) + 1;
+        (a as u8).ct_gt(&(b as u8))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CtGt;
+    use core::cmp::Ordering;
+
+    #[test]
+    fn ct_gt() {
+        let a = 42u64;
+        let b = 43u64;
+        assert!(!a.ct_gt(&a).to_bool());
+        assert!(!a.ct_gt(&b).to_bool());
+        assert!(b.ct_gt(&a).to_bool());
+    }
+
+    #[test]
+    fn ordering() {
+        assert!(!Ordering::Equal.ct_gt(&Ordering::Equal).to_bool());
+        assert!(!Ordering::Less.ct_gt(&Ordering::Greater).to_bool());
+        assert!(Ordering::Greater.ct_gt(&Ordering::Less).to_bool());
+    }
+}


### PR DESCRIPTION
Adds traits for computing greater than/less than in constant time.

Uses ~~borrowing~~ overflowing subtraction as the implementation strategy for unsigned integers.

Also adds impls for `cmp::Ordering`.