### PR TITLE
ci: tweak Clippy command

### DIFF
--- a/blobby/benches/mod.rs
+++ b/blobby/benches/mod.rs
@@ -1,4 +1,0 @@
-#![feature(test)]
-extern crate test;
-
-


### PR DESCRIPTION
Adds `--lib --bins --tests` to the Clippy command to apply it to tests and binaries. Additionally, removes `--exclude aarch64-dit` which is not necessary since `aarch64-dit` is no longer part of the workspace.