### PR TITLE
zeroize: fixup rust 1.92 warnings

### DIFF
--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -125,7 +125,6 @@ impl Drop for ZeroizeNoDropEnum {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(unused_assignments)]
 fn derive_struct_skip() {
     #[derive(Zeroize, ZeroizeOnDrop)]
     struct Z {
@@ -156,7 +155,6 @@ fn derive_struct_skip() {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(unused_assignments)]
 fn derive_enum_skip() {
     #[derive(Zeroize, ZeroizeOnDrop)]
     enum Z {

--- a/zeroize_derive/src/lib.rs
+++ b/zeroize_derive/src/lib.rs
@@ -374,7 +374,7 @@ fn generate_fields(input: &DeriveInput, method: TokenStream) -> TokenStream {
         };
 
         quote! {
-            #[allow(unused_variables)]
+            #[allow(unused_variables, unused_assignments)]
             #binding => {
                 #(#method_field);*
             }


### PR DESCRIPTION
`#[derive(ZeroizeOnDrop)]` was throwing warnings like:
```
warning: value assigned to `curve` is never read
  --> src/crypto/ecdsa.rs:43:9
   |
43 |         curve: ECCCurve,
   |         ^^^^^
   |
   = help: maybe it is overwritten before being read?
   = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by de
```

This changes the tests to highlight the new warnings.