### PR TITLE
ctutils v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cmov",
  "subtle",

--- a/ctutils/CHANGELOG.md
+++ b/ctutils/CHANGELOG.md
@@ -4,5 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2025-12-26)
+### Added
+- Additional `const fn` constructor and predication methods for `Choice` ([#1266], [#1272])
+
+[#1266]: https://github.com/RustCrypto/utils/pull/1266
+[#1272]: https://github.com/RustCrypto/utils/pull/1272
+
 ## 0.1.0 (2025-12-19)
 - Initial release

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -5,7 +5,7 @@ Constant-time utility library with selection and equality testing support target
 applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides
 architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
 """
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/utils/tree/master/ctselect"


### PR DESCRIPTION
### Added
- Additional `const fn` constructor and predication methods for `Choice` ([#1266], [#1272])

[#1266]: https://github.com/RustCrypto/utils/pull/1266
[#1272]: https://github.com/RustCrypto/utils/pull/1272