### PR TITLE
ctutils v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cmov",
  "subtle",

--- a/ctutils/CHANGELOG.md
+++ b/ctutils/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2025-12-26)
+### Added
+- Additional methods for `CtOption` ([#1274]):
+  - `some`
+  - `none`
+  - `into_option_copied`
+  - `filter_by`
+  - `as_inner_unchecked`
+  - `to_inner_unchecked`
+- `Default` impl for `CtOption` ([#1274])
+- `map!` and `unwrap_or!` macros ([#1274])
+- `u128` methods for `Choice` ([#1277]):
+  - `from_u128_le`
+  - `from_u128_lsb`
+  - `select_u128`
+
+[#1274]: https://github.com/RustCrypto/utils/pull/1274
+[#1277]: https://github.com/RustCrypto/utils/pull/1277
+
 ## 0.1.1 (2025-12-26)
 ### Added
 - Additional `const fn` constructor and predication methods for `Choice` ([#1266], [#1272])

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -5,7 +5,7 @@ Constant-time utility library with selection and equality testing support target
 applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides
 architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
 """
-version = "0.1.1"
+version = "0.1.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/utils/tree/master/ctselect"


### PR DESCRIPTION
### Added
- Additional methods for `CtOption` ([#1274]):
  - `some`
  - `none`
  - `into_option_copied`
  - `filter_by`
  - `as_inner_unchecked`
  - `to_inner_unchecked`
- `Default` impl for `CtOption` ([#1274])
- `map!` and `unwrap_or!` macros ([#1274])
- `u128` methods for `Choice` ([#1277]):
  - `from_u128_le`
  - `from_u128_lsb`
  - `select_u128`

[#1274]: https://github.com/RustCrypto/utils/pull/1274
[#1277]: https://github.com/RustCrypto/utils/pull/1277