### PR TITLE
ctutils v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cmov",
  "subtle",

--- a/ctutils/CHANGELOG.md
+++ b/ctutils/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 (2025-12-26)
+### Fixed
+- Rustdoc syntax for variable-time-related warning text ([#1278])
+
+[#1278]: https://github.com/RustCrypto/utils/pull/1278
+
 ## 0.1.2 (2025-12-26)
 ### Added
 - Additional methods for `CtOption` ([#1274]):

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -5,13 +5,13 @@ Constant-time utility library with selection and equality testing support target
 applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides
 architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
 """
-version = "0.1.2"
+version = "0.1.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/utils/tree/master/ctselect"
 repository = "https://github.com/RustCrypto/utils"
 categories = ["cryptography", "no-std"]
-keywords = ["crypto", "intrinsics"]
+keywords = ["constant-time", "crypto", "intrinsics"]
 readme = "README.md"
 edition = "2024"
 rust-version = "1.85"

--- a/ctutils/README.md
+++ b/ctutils/README.md
@@ -13,7 +13,7 @@ architecture-specific predication intrinsics. Heavily inspired by the [`subtle`]
 ## About
 
 This crate contains constant-time equivalents of the `bool` and `Option` types (`Choice` and
-`CtOption`), along with traits that can be used in combination with them.
+`CtOption` respectively), along with traits that can be used in combination with them.
 
 The `CtOption` type notably provides eagerly evaluated combinator methods (as opposed to the lazily
 evaluated combinators on `Option`) which make it possible to write constant-time code using


### PR DESCRIPTION
### Fixed
- Rustdoc syntax for variable-time-related warning text ([#1278])

[#1278]: https://github.com/RustCrypto/utils/pull/1278