### PR TITLE
ctutils: add `CtNeg` trait

### DIFF
--- a/ctutils/src/lib.rs
+++ b/ctutils/src/lib.rs
@@ -81,4 +81,4 @@ mod traits;
 
 pub use choice::Choice;
 pub use ct_option::CtOption;
-pub use traits::{ct_eq::CtEq, ct_gt::CtGt, ct_lt::CtLt, ct_select::CtSelect};
+pub use traits::{ct_eq::CtEq, ct_gt::CtGt, ct_lt::CtLt, ct_neg::CtNeg, ct_select::CtSelect};

--- a/ctutils/src/traits.rs
+++ b/ctutils/src/traits.rs
@@ -6,4 +6,5 @@
 pub(crate) mod ct_eq;
 pub(crate) mod ct_gt;
 pub(crate) mod ct_lt;
+pub(crate) mod ct_neg;
 pub(crate) mod ct_select;

--- a/ctutils/src/traits/ct_neg.rs
+++ b/ctutils/src/traits/ct_neg.rs
@@ -1,0 +1,59 @@
+use crate::{Choice, CtSelect};
+
+/// Constant-time conditional negation: negates a value when `choice` is [`Choice::TRUE`].
+pub trait CtNeg: Sized {
+    /// Conditionally negate `self`, returning `-self` if `choice` is [`Choice::TRUE`], or `self`
+    /// otherwise.
+    fn ct_neg(&self, choice: Choice) -> Self;
+
+    /// Conditionally negate `self` in-place, replacing it with `-self` if `choice` is
+    /// [`Choice::TRUE`].
+    fn ct_neg_assign(&mut self, choice: Choice) {
+        *self = self.ct_neg(choice);
+    }
+}
+
+// Impl `CtNeg` for an integer type which impls `CtSelect`
+macro_rules! impl_ct_neg {
+    ( $($ty:ty),+ ) => {
+        $(
+            impl CtNeg for $ty {
+                #[inline]
+                fn ct_neg(&self, choice: Choice) -> Self {
+                    let neg = -*self;
+                    self.ct_select(&neg, choice)
+                }
+
+                #[inline]
+                fn ct_neg_assign(&mut self, choice: Choice) {
+                    let neg = -*self;
+                    self.ct_assign(&neg, choice)
+                }
+            }
+        )+
+    };
+}
+
+impl_ct_neg!(i8, i16, i32, i64, i128);
+
+// TODO(tarcieri): test all signed integer types
+#[cfg(test)]
+mod tests {
+    use super::{Choice, CtNeg};
+
+    #[test]
+    fn i64_ct_neg() {
+        assert_eq!(42, 42.ct_neg(Choice::FALSE));
+        assert_eq!(-42, 42.ct_neg(Choice::TRUE));
+    }
+
+    #[test]
+    fn i64_ct_neg_assign() {
+        let mut n = 42;
+        n.ct_neg_assign(Choice::FALSE);
+        assert_eq!(42, n);
+
+        n.ct_neg_assign(Choice::TRUE);
+        assert_eq!(-42, n);
+    }
+}


### PR DESCRIPTION
For full feature parity with `subtle`, this adds a conditional negation trait called `CtNeg`.

It uses a slightly different design from `subtle`, supporting both in-place operation ala `subtle` with `ct_neg_assign`, while also supporting `core::ops::Neg`-like usage with `ct_neg`.

Using one trait with two methods permits a default implementation of `ct_neg_assign` while still letting it be overridden, which is useful for e.g. heap-allocated types. It could arguably be split into `CtNeg` and `CtNegAssign` but we would lose that default impl (and the same argument could be made for splitting up e.g. `CtSelect`, with the same drawbacks)

By default impls are written for the signed integer (`i*`) types: `i8`, `i16`, `i32`, `i64`, `i128`.