### PR TITLE
ctutils v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "cmov",
  "subtle",

--- a/ctutils/CHANGELOG.md
+++ b/ctutils/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2025-12-27)
+### Added
+- Additional `Choice::from_u128*` constructors ([#1285])
+- `CtNeg` trait ([#1286])
+
+### Changed
+- Renamed `Choice::from_*_nonzero` => `from_*_nz` ([#1287])
+
+[#1285]: https://github.com/RustCrypto/utils/pull/1285
+[#1286]: https://github.com/RustCrypto/utils/pull/1286
+[#1287]: https://github.com/RustCrypto/utils/pull/1287
+
 ## 0.1.4 (2025-12-26)
 ### Added
 - Impl `CtEq`/`CtSelect` for `isize` ([#1283])

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -5,7 +5,7 @@ Constant-time utility library with selection and equality testing support target
 applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides
 architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
 """
-version = "0.2.0-pre"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/utils/tree/master/ctselect"


### PR DESCRIPTION
### Added
- Additional `Choice::from_u128*` constructors ([#1285])
- `CtNeg` trait ([#1286])

### Changed
- Renamed `Choice::from_*_nonzero` => `from_*_nz` ([#1287])

[#1285]: https://github.com/RustCrypto/utils/pull/1285
[#1286]: https://github.com/RustCrypto/utils/pull/1286
[#1287]: https://github.com/RustCrypto/utils/pull/1287