### PR TITLE
ctutils: enhanced `subtle` interop

### DIFF
--- a/.github/workflows/ctutils.yml
+++ b/.github/workflows/ctutils.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cargo test
+      - run: cargo test --features subtle
       - run: cargo test --all-features
       - run: cargo test --all-features --release
 

--- a/ctutils/src/choice.rs
+++ b/ctutils/src/choice.rs
@@ -410,6 +410,15 @@ impl From<Choice> for bool {
     }
 }
 
+impl Not for Choice {
+    type Output = Choice;
+
+    #[inline]
+    fn not(self) -> Choice {
+        self.not()
+    }
+}
+
 #[cfg(feature = "subtle")]
 impl From<subtle::Choice> for Choice {
     #[inline]
@@ -426,12 +435,19 @@ impl From<Choice> for subtle::Choice {
     }
 }
 
-impl Not for Choice {
-    type Output = Choice;
-
+#[cfg(feature = "subtle")]
+impl subtle::ConditionallySelectable for Choice {
     #[inline]
-    fn not(self) -> Choice {
-        self.not()
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        CtSelect::ct_select(a, b, choice.into())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeEq for Choice {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
     }
 }
 

--- a/ctutils/src/ct_option.rs
+++ b/ctutils/src/ct_option.rs
@@ -576,6 +576,29 @@ impl<T> From<CtOption<T>> for subtle::CtOption<T> {
     }
 }
 
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConditionallySelectable for CtOption<T>
+where
+    T: Copy, // `ConditionallySelectable` supertrait bound
+    Self: CtSelect,
+{
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        CtSelect::ct_select(a, b, choice.into())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConstantTimeEq for CtOption<T>
+where
+    Self: CtEq,
+{
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{Choice, CtEq, CtOption, CtSelect};

--- a/ctutils/src/traits/ct_eq.rs
+++ b/ctutils/src/traits/ct_eq.rs
@@ -2,6 +2,9 @@ use crate::Choice;
 use cmov::CmovEq;
 use core::cmp;
 
+#[cfg(feature = "subtle")]
+use crate::CtOption;
+
 /// Constant-time equality: like `(Partial)Eq` with [`Choice`] instead of [`bool`].
 ///
 /// Impl'd for: [`u8`], [`u16`], [`u32`], [`u64`], [`u128`], [`usize`], [`cmp::Ordering`],
@@ -86,6 +89,25 @@ impl<T: CtEq, const N: usize> CtEq for [T; N] {
     #[inline]
     fn ct_eq(&self, other: &[T; N]) -> Choice {
         self.as_slice().ct_eq(other.as_slice())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl CtEq for subtle::Choice {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.unwrap_u8().ct_eq(&other.unwrap_u8())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> CtEq for subtle::CtOption<T>
+where
+    T: CtEq + Default + subtle::ConditionallySelectable,
+{
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        CtOption::from(*self).ct_eq(&CtOption::from(*other))
     }
 }
 


### PR DESCRIPTION
Impls each crate's eq/select traits for the other's choice/option:

- `ctutils::Choice`: `subtle::{ConditionallySelectable, ConstantTimeEq}`
- `ctutils::CtOption`: `subtle::{ConditionallySelectable, ConstantTimeEq}`
- `subtle::Choice`: `ctutils::{CtEq, CtSelect}`
- `subtle::CtOption`: `ctutils::{CtEq, CtSelect}`