### PR TITLE
inout: require `block-padding` v0.4.2

### DIFF
--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -14,7 +14,7 @@ description = "Custom reference types for code generic over in-place and buffer-
 
 [dependencies]
 hybrid-array = "0.4"
-block-padding = { version = "0.4", path = "../block-padding", optional = true }
+block-padding = { version = "0.4.2", path = "../block-padding", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The other versions are yanked, but nothing is forcing an upgrade if people already have older versions in their Cargo.lock.

The problematic crates are ones like `cipher` that are using it vicariously, so we need to pin it here to force an upgrade.