### PR TITLE
inout v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "block-padding",
  "hybrid-array",

--- a/inout/CHANGELOG.md
+++ b/inout/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2025-12-27)
+### Changed
+- Require `block-padding` v0.4.2 ([#1291])
+
+[#1291]: https://github.com/RustCrypto/utils/pull/1291
+
 ## 0.2.1 (2025-10-06)
 ### Changed
 - Migrate to fixed `Padding::pad_detached` from `block-padding` v0.4.1 ([#1227])

--- a/inout/Cargo.toml
+++ b/inout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inout"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Changed
- Require `block-padding` v0.4.2 ([#1291])

[#1291]: https://github.com/RustCrypto/utils/pull/1291