### PR TITLE
cmov: test with miri on `powerpc-unknown-linux-gnu`

### DIFF
--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -130,8 +130,9 @@ jobs:
     strategy:
       matrix:
         target:
-          - x86_64-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
Trying to catch the same bug from #1295 with the existing test suite