### PR TITLE
cmov: fix truncation bug in portable implementation

### DIFF
--- a/cmov/tests/proptests.rs
+++ b/cmov/tests/proptests.rs
@@ -1,6 +1,3 @@
-// TODO(tarcieri): known to be broken on PPC32. See RustCrypto/utils#1298
-#![cfg(not(target_arch = "powerpc"))]
-
 /// Write the proptests for an integer type.
 macro_rules! int_proptests {
     ( $($int:ident),+ ) => {

--- a/cmov/tests/regression.rs
+++ b/cmov/tests/regression.rs
@@ -1,8 +1,5 @@
 //! Tests for previous bugs in the implementation.
 
-// TODO(tarcieri): known to be broken on PPC32. See RustCrypto/utils#1298
-#![cfg(not(target_arch = "powerpc"))]
-
 use cmov::CmovEq;
 
 #[test]


### PR DESCRIPTION
Closes #1298

The previous portable implementation truncated integers when comparing them in the `u64` implemenation of `CmovEq`.

This adds a macro adapted from `ctutils` and uses it everywhere 64-bit integers are being compared in the portable implementation.