### PR TITLE
cmov: enable additional lints

### DIFF
--- a/cmov/src/aarch64.rs
+++ b/cmov/src/aarch64.rs
@@ -37,7 +37,10 @@ macro_rules! cseleq {
             };
         };
 
-        *$dst = tmp as u8;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            *$dst = tmp as u8;
+        }
     };
 }
 

--- a/cmov/src/lib.rs
+++ b/cmov/src/lib.rs
@@ -4,7 +4,18 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![warn(missing_docs, unused_qualifications)]
+#![warn(
+    clippy::cast_possible_truncation,
+    clippy::integer_division_remainder_used,
+    clippy::mod_module_files,
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications
+)]
 
 #[cfg(not(miri))]
 #[cfg(target_arch = "aarch64")]
@@ -59,6 +70,8 @@ pub trait CmovEq {
     }
 }
 
+// TODO(tarcieri): address truncation lint
+#[allow(clippy::cast_possible_truncation)]
 impl Cmov for u8 {
     #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
@@ -87,6 +100,8 @@ impl CmovEq for u8 {
     }
 }
 
+// TODO(tarcieri): address truncation lint
+#[allow(clippy::cast_possible_truncation)]
 impl Cmov for u128 {
     #[inline]
     fn cmovnz(&mut self, value: &Self, condition: Condition) {
@@ -111,6 +126,8 @@ impl Cmov for u128 {
     }
 }
 
+// TODO(tarcieri): address truncation lint
+#[allow(clippy::cast_possible_truncation)]
 impl CmovEq for u128 {
     #[inline]
     fn cmovne(&self, rhs: &Self, input: Condition, output: &mut Condition) {

--- a/cmov/src/x86.rs
+++ b/cmov/src/x86.rs
@@ -39,7 +39,11 @@ macro_rules! cmov_eq {
                 options(pure, nomem, nostack),
             };
         }
-        *$dst = tmp as u8;
+
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            *$dst = tmp as u8;
+        }
     };
 }
 


### PR DESCRIPTION
Issues like #1300 could ideally be caught via more fastidious linting.

This adds several additional lints and TODOs to address the ones which are currently failing.