### PR TITLE
cmov v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cmov"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "proptest",
 ]

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.3 (2025-12-27)
+### Fixed
+- `aarch64` ASM bug ([#1299])
+- Truncation bug in portable implementation ([#1300])
+
+[#1299]: https://github.com/RustCrypto/utils/pull/1299
+[#1300]: https://github.com/RustCrypto/utils/pull/1300
+
 ## 0.4.2 (2025-12-26)
 ### Added
 - Signed integer support ([#1280])

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmov"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Fixed
- `aarch64` ASM bug ([#1299])
- Truncation bug in portable implementation ([#1300])

[#1299]: https://github.com/RustCrypto/utils/pull/1299
[#1300]: https://github.com/RustCrypto/utils/pull/1300