### PR TITLE
ctutils v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cmov",
  "subtle",

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -5,7 +5,7 @@ Constant-time utility library with selection and equality testing support target
 applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides
 architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
 """
-version = "0.2.0"
+version = "0.2.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/utils/tree/master/ctselect"


### PR DESCRIPTION
Includes pin to `cmov` v0.4.3 with important security fixes, see #1304