### PR TITLE
zeroize_derive v1.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/derive/CHANGELOG.md
+++ b/zeroize/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.3 (2025-12-29)
+### Fixed
+- Rust 1.92 warnings ([#1270])
+
+[#1270]: https://github.com/RustCrypto/utils/pull/1270
+
 ## 1.4.2 (2023-03-30)
 ### Changed
 - Inject where clauses; skip unused ([#882])

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/utils/tree/master/zeroize/derive"
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = {version = "2", features = ["full", "extra-traits", "visit"]}
+syn = { version = "2", features = ["full", "extra-traits", "visit"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--document-private-items"]

--- a/zeroize/derive/src/lib.rs
+++ b/zeroize/derive/src/lib.rs
@@ -7,13 +7,13 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use syn::{
+    Attribute, Data, DeriveInput, Expr, ExprLit, Field, Fields, Lit, Meta, Result, Variant,
+    WherePredicate,
     parse::{Parse, ParseStream},
     parse_quote,
     punctuated::Punctuated,
     token::Comma,
     visit::Visit,
-    Attribute, Data, DeriveInput, Expr, ExprLit, Field, Fields, Lit, Meta, Result, Variant,
-    WherePredicate,
 };
 
 /// Name of zeroize-related attributes
@@ -176,7 +176,7 @@ impl ZeroizeAttrs {
         }
 
         match &input.data {
-            syn::Data::Enum(enum_) => {
+            Data::Enum(enum_) => {
                 for variant in &enum_.variants {
                     for attr in &variant.attrs {
                         result.parse_attr(attr, Some(variant), None);
@@ -191,7 +191,7 @@ impl ZeroizeAttrs {
                     }
                 }
             }
-            syn::Data::Struct(struct_) => {
+            Data::Struct(struct_) => {
                 for field in &struct_.fields {
                     for attr in &field.attrs {
                         result.parse_attr(attr, None, Some(field));
@@ -201,7 +201,7 @@ impl ZeroizeAttrs {
                     }
                 }
             }
-            syn::Data::Union(union_) => panic!("Unsupported untagged union {:?}", union_),
+            Data::Union(union_) => panic!("Unsupported untagged union {:?}", union_),
         }
 
         result.auto_params = bound_accumulator.params;
@@ -374,7 +374,7 @@ fn generate_fields(input: &DeriveInput, method: TokenStream) -> TokenStream {
         };
 
         quote! {
-            #[allow(unused_variables)]
+            #[allow(unused_variables, unused_assignments)]
             #binding => {
                 #(#method_field);*
             }


### PR DESCRIPTION
NOTE: not for merge, this is just to document what is being released

### Fixed
- Rust 1.92 warnings ([#1270])

[#1270]: https://github.com/RustCrypto/utils/pull/1270