### PR TITLE
ctutils: deprecate `Choice::new`

### DIFF
--- a/ctutils/src/traits/ct_eq.rs
+++ b/ctutils/src/traits/ct_eq.rs
@@ -29,9 +29,9 @@ macro_rules! impl_ct_eq_with_cmov_eq {
             impl CtEq for $ty {
                 #[inline]
                 fn ct_eq(&self, other: &Self) -> Choice {
-                    let mut ret = 0;
-                    self.cmoveq(other, 1, &mut ret);
-                    Choice::new(ret)
+                    let mut ret = Choice::FALSE;
+                    self.cmoveq(other, 1, &mut ret.0);
+                    ret
                 }
             }
         )+

--- a/ctutils/src/traits/ct_gt.rs
+++ b/ctutils/src/traits/ct_gt.rs
@@ -15,7 +15,7 @@ macro_rules! impl_unsigned_ct_gt {
                 #[inline]
                 fn ct_gt(&self, other: &Self) -> Choice {
                     let (_, overflow) = other.overflowing_sub(*self);
-                    Choice::new(overflow.into())
+                    Choice(overflow.into())
                 }
             }
         )+

--- a/ctutils/src/traits/ct_lt.rs
+++ b/ctutils/src/traits/ct_lt.rs
@@ -15,7 +15,7 @@ macro_rules! impl_unsigned_ct_lt {
                 #[inline]
                 fn ct_lt(&self, other: &Self) -> Choice {
                     let (_, overflow) = self.overflowing_sub(*other);
-                    Choice::new(overflow.into())
+                    Choice(overflow.into())
                 }
             }
         )+


### PR DESCRIPTION
It panics if given a value which isn't `0` or `1`.

Instead we can use `Choice::from_u8_lsb` for clear, non-panicking semantics instead.