### PR TITLE
ctutils: remove `Choice::new`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.3"
+version = "0.3.0-pre"
 dependencies = [
  "cmov",
  "subtle",

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -5,7 +5,7 @@ Constant-time utility library with selection and equality testing support target
 applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides
 architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate.
 """
-version = "0.2.3"
+version = "0.3.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/utils/tree/master/ctselect"

--- a/ctutils/src/choice.rs
+++ b/ctutils/src/choice.rs
@@ -45,13 +45,6 @@ impl Choice {
     /// Equivalent of [`true`].
     pub const TRUE: Self = Self(1);
 
-    /// DEPRECATED: legacy alias for [`Choice::from_u8_lsb`].
-    #[deprecated(since = "0.2.3", note = "use `Choice::from_u8_lsb` instead")]
-    #[inline]
-    pub const fn new(value: u8) -> Self {
-        Self::from_u8_lsb(value)
-    }
-
     /// Convert `Choice` into a `bool`.
     ///
     /// <div class = "warning">


### PR DESCRIPTION
It had weird semantics: panicking in debug mode if given a `u8` other than `0` or `1`.

Instead `Choice::from_u8_lsb` provides an equivalent constructor which never panicks or incorrectly initializes a `Choice`.