### PR TITLE
CI: actually test `zeroize_derive`

### DIFF
--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -99,6 +99,26 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }}
 
+  # Custom derive tests
+  test-derive:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: zeroize_derive
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v6
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test
+      - run: cargo test --release
+
   # Cross-compiled tests
   cross:
     strategy:


### PR DESCRIPTION
It seems there wasn't actually any CI for `zeroize_derive` after it was extracted from `zeroize/derive` into a toplevel `zeroize_derive` directory, other than the vicarious tests that are in `zeroize` itself.

This runs a separate job just for the custom derive tests.

NOTE: they presently seem to be failing!