### PR TITLE
zeroize_derive: fixup test suite [1.4]

### DIFF
--- a/zeroize/derive/src/lib.rs
+++ b/zeroize/derive/src/lib.rs
@@ -7,13 +7,13 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use syn::{
-    Attribute, Data, DeriveInput, Expr, ExprLit, Field, Fields, Lit, Meta, Result, Variant,
-    WherePredicate,
     parse::{Parse, ParseStream},
     parse_quote,
     punctuated::Punctuated,
     token::Comma,
     visit::Visit,
+    Attribute, Data, DeriveInput, Expr, ExprLit, Field, Fields, Lit, Meta, Result, Variant,
+    WherePredicate,
 };
 
 /// Name of zeroize-related attributes
@@ -454,7 +454,7 @@ mod tests {
                 impl ::zeroize::Zeroize for Z {
                     fn zeroize(&mut self) {
                         match self {
-                            #[allow(unused_variables)]
+                            #[allow(unused_variables, unused_assignments)]
                             Z { a, b, c } => {
                                 a.zeroize();
                                 b.zeroize();
@@ -484,7 +484,7 @@ mod tests {
                 impl ::zeroize::Zeroize for Z {
                     fn zeroize(&mut self) {
                         match self {
-                            #[allow(unused_variables)]
+                            #[allow(unused_variables, unused_assignments)]
                             Z { a, b, c } => {
                                 a.zeroize();
                                 b.zeroize();
@@ -520,7 +520,7 @@ mod tests {
                 impl ::zeroize::Zeroize for Z {
                     fn zeroize(&mut self) {
                         match self {
-                            #[allow(unused_variables)]
+                            #[allow(unused_variables, unused_assignments)]
                             Z { a, b, c } => {
                                 a.zeroize();
                                 b.zeroize()
@@ -545,7 +545,7 @@ mod tests {
                 impl<T> ::zeroize::Zeroize for Z<T> where T: MyTrait {
                     fn zeroize(&mut self) {
                         match self {
-                            #[allow(unused_variables)]
+                            #[allow(unused_variables, unused_assignments)]
                             Z(__zeroize_field_0) => {
                                 __zeroize_field_0.zeroize()
                             }
@@ -574,7 +574,7 @@ mod tests {
                         use ::zeroize::__internal::AssertZeroize;
                         use ::zeroize::__internal::AssertZeroizeOnDrop;
                         match self {
-                            #[allow(unused_variables)]
+                            #[allow(unused_variables, unused_assignments)]
                             Z { a, b, c } => {
                                 a.zeroize_or_on_drop();
                                 b.zeroize_or_on_drop();

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -318,6 +318,7 @@ fn derive_deref() {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[allow(dead_code)]
 fn derive_zeroize_on_drop_generic() {
     #[derive(ZeroizeOnDrop)]
     struct Y<T: Zeroize>(Box<T>);
@@ -327,6 +328,7 @@ fn derive_zeroize_on_drop_generic() {
 }
 
 #[test]
+#[allow(dead_code)]
 fn derive_zeroize_unused_param() {
     #[derive(Zeroize)]
     struct Z<T> {
@@ -337,6 +339,7 @@ fn derive_zeroize_unused_param() {
 }
 
 #[test]
+#[allow(dead_code)]
 // Issue #878
 fn derive_zeroize_with_marker() {
     #[derive(ZeroizeOnDrop, Zeroize)]
@@ -353,6 +356,7 @@ fn derive_zeroize_with_marker() {
 }
 
 #[test]
+#[allow(dead_code)]
 // Issue #878
 fn derive_zeroize_used_param() {
     #[derive(Zeroize)]


### PR DESCRIPTION
https://github.com/RustCrypto/utils/pull/1270 broke the tests for zeroize_derive, this fixes the expected output of the tests accordingly.

This is a backport of https://github.com/RustCrypto/utils/pull/1320

Fixes https://github.com/RustCrypto/utils/issues/1317