### PR TITLE
ctutils: initial proptests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ name = "ctutils"
 version = "0.3.1"
 dependencies = [
  "cmov",
+ "proptest",
  "subtle",
 ]
 

--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -22,5 +22,8 @@ cmov = "0.4.3"
 # optional dependencies
 subtle = { version = "2", optional = true, default-features = false }
 
+[dev-dependencies]
+proptest = "1.9"
+
 [package.metadata.docs.rs]
 all-features = true

--- a/ctutils/tests/proptests.rs
+++ b/ctutils/tests/proptests.rs
@@ -1,0 +1,56 @@
+/// Write the proptests for an integer type.
+macro_rules! int_proptests {
+    ( $($int:ident),+ ) => {
+        $(
+            mod $int {
+                use ctutils::{CtSelect, CtEq, Choice};
+                use proptest::prelude::*;
+
+                proptest! {
+                    #[test]
+                    fn ct_assign(a in any::<$int>(), b in any::<$int>(), byte in any::<u8>()) {
+                        let choice = Choice::from_u8_lsb(byte);
+                        let mut actual = a;
+                        actual.ct_assign(&b, choice);
+
+                        let expected = if byte & 1 == 1 {
+                            b
+                        } else {
+                            a
+                        };
+
+                        prop_assert_eq!(expected, actual);
+                    }
+
+                    #[test]
+                     fn ct_eq(a in any::<$int>(), b in any::<$int>()) {
+                        let actual = a.ct_eq(&b);
+                        prop_assert_eq!(a == b, actual.to_bool());
+                     }
+
+                     #[test]
+                     fn ct_ne(a in any::<$int>(), b in any::<$int>()) {
+                        let actual = a.ct_ne(&b);
+                        prop_assert_eq!(a != b, actual.to_bool());
+                     }
+
+                    #[test]
+                    fn ct_select(a in any::<$int>(), b in any::<$int>(), byte in any::<u8>()) {
+                        let choice = Choice::from_u8_lsb(byte);
+                        let actual = a.ct_select(&b, choice);
+
+                        let expected = if byte & 1 == 1 {
+                            b
+                        } else {
+                            a
+                        };
+
+                        prop_assert_eq!(expected, actual);
+                    }
+                }
+            }
+        )+
+    };
+}
+
+int_proptests!(i8, i16, i32, i64, i128, u8, u16, u32, u64, u128);


### PR DESCRIPTION
Adds initial proptests for `CtEq::ct_eq` and `CtSelect::ct_select` for all core signed and unsigned integer types