### PR TITLE
cmov v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cmov"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "proptest",
 ]

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 (2026-01-14)
+### Security
+- Fix non-constant-time assembly being emitted from portable backend on `thumbv6m-none-eabi` ([#1332])
+
+[#1332]: https://github.com/RustCrypto/utils/pull/1332
+
 ## 0.4.3 (2025-12-27)
 ### Fixed
 - `aarch64` ASM bug ([#1299])

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmov"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/cmov/LICENSE-MIT
+++ b/cmov/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2025 The RustCrypto Project Developers
+Copyright (c) 2022-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Security
- Fix non-constant-time assembly being emitted from portable backend on `thumbv6m-none-eabi` ([#1332])

[#1332]: https://github.com/RustCrypto/utils/pull/1332