### PR TITLE
cmov: add `asm!` optimized `masknz32` for ARM32

### DIFF
--- a/.github/workflows/cmov.yml
+++ b/.github/workflows/cmov.yml
@@ -135,7 +135,6 @@ jobs:
     strategy:
       matrix:
         target:
-          - armv7-unknown-linux-gnueabi
           - powerpc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
           - x86_64-unknown-linux-gnu


### PR DESCRIPTION
In #1332 we ran into LLVM inserting branches in this routine for `thumbv6m-none-eabi` targets. It was "fixed" by fiddling around with `black_box` but that seems brittle.

In #1334 we attempted a simple portable `asm!` optimization barrier approach but it did not work as expected.

This instead opts to implement one of the fiddliest bits, mask generation, using ARM assembly instead. The resulting assembly is actually more efficient than what rustc/LLVM outputs and avoids touching the stack pointer.

It's a simple enough function to implement in assembly on other platforms with stable `asm!` too, but this is a start.