### PR TITLE
Fix output for 16-bit targets

### DIFF
--- a/cpubits/src/lib.rs
+++ b/cpubits/src/lib.rs
@@ -259,7 +259,7 @@ macro_rules! cpubits {
                 // WASM
                 target_arch = "wasm32",
             ))]
-            16 => { $( $tokens32 )* }
+            16 => { $( $tokens16 )* }
             32 => { $( $tokens32 )* }
             64 => { $( $tokens64 )* }
         }


### PR DESCRIPTION
`tokens32` being used for both 16 and 32 bits appears to be an artifact from copying the prior block and modifying it (as reasonable for such development), but itself unsound.

---

I used the web UI for this, just to fire this off quickly as an exceptionally minor change, but that does mean it's completely untested.