### PR TITLE
cpubits v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "cpubits"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "cpufeatures"

--- a/cpubits/CHANGELOG.md
+++ b/cpubits/CHANGELOG.md
@@ -5,5 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2026-04-28)
+### Fixed
+- Output for 16-bit targets ([#1470])
+
+[#1470]: https://github.com/RustCrypto/utils/pull/1470
+
 ## 0.1.0 (2026-02-22)
 Initial release

--- a/cpubits/Cargo.toml
+++ b/cpubits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpubits"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/cpubits"


### PR DESCRIPTION
## Fixed
- Output for 16-bit targets ([#1470])

[#1470]: https://github.com/RustCrypto/utils/pull/1470