### PR TITLE
ctutils: bump `subtle` version requirement to v2.6

### DIFF
--- a/ctutils/Cargo.toml
+++ b/ctutils/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 cmov = "0.5.3"
 
 # optional dependencies
-subtle = { version = "2", optional = true, default-features = false }
+subtle = { version = "2.6", optional = true, default-features = false }
 
 [dev-dependencies]
 proptest = "1.11"


### PR DESCRIPTION
We're failing `minimal-versions` because `subtle` v2.0.0 didn't have `CtOption`, so this pins to the latest minor release.

https://github.com/RustCrypto/utils/actions/runs/25933364627/job/76232484200?pr=1481