### PR TITLE
block-buffer: pin to `zeroize` v1.8

### DIFF
--- a/block-buffer/Cargo.toml
+++ b/block-buffer/Cargo.toml
@@ -14,7 +14,7 @@ description = "Buffer types for block processing of data"
 
 [dependencies]
 hybrid-array = "0.4"
-zeroize = { version = "1.4", optional = true, default-features = false }
+zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
Fixes the `minimal-versions` failure