### PR TITLE
cmov v0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "proptest",
 ]

--- a/cmov/CHANGELOG.md
+++ b/cmov/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.4 (2026-05-28)
+### Security
+- Fix [GHSA-3rjw-m598-pq24]: `Cmov`/`CmovEq` on `aarch64` can produce wrong results if high-bits of registers are set ([dba6c355])
+
+[GHSA-3rjw-m598-pq24]: https://github.com/RustCrypto/utils/security/advisories/GHSA-3rjw-m598-pq24
+[dba6c355]: https://github.com/RustCrypto/utils/commit/dba6c355c9f241e3726d5ec2a68f9f3b519f6063
+
 ## 0.5.3 (2026-04-02)
 ### Added
 - Impl `Cmov`/`CmovEq` for `NonZeroUsize`/`NonZeroIsize` ([#1415])

--- a/cmov/Cargo.toml
+++ b/cmov/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/cmov/README.md
+++ b/cmov/README.md
@@ -73,6 +73,7 @@ USE AT YOUR OWN RISK!
 Below are security issues this crate has experienced in the past:
 
 - [RUSTSEC-2026-0003]: Non-constant-time code generation on ARM32 targets
+- [GHSA-3rjw-m598-pq24]: `Cmov`/`CmovEq` on ARM64 can produce wrong results if high-bits of registers are set
 
 ## Minimum Supported Rust Version (MSRV) Policy
 
@@ -120,3 +121,4 @@ dual licensed as above, without any additional terms or conditions.
 [`ctutils`]: https://docs.rs/ctutils
 [open an issue]: https://github.com/RustCrypto/utils/issues
 [RUSTSEC-2026-0003]: https://rustsec.org/advisories/RUSTSEC-2026-0003.html
+[GHSA-3rjw-m598-pq24]: https://github.com/RustCrypto/utils/security/advisories/GHSA-3rjw-m598-pq24


### PR DESCRIPTION
## Security
- Fix [GHSA-3rjw-m598-pq24]: `Cmov`/`CmovEq` on `aarch64` can produce wrong results if high-bits of registers are set ([dba6c355])

[GHSA-3rjw-m598-pq24]: https://github.com/RustCrypto/utils/security/advisories/GHSA-3rjw-m598-pq24
[dba6c355]: https://github.com/RustCrypto/utils/commit/dba6c355c9f241e3726d5ec2a68f9f3b519f6063