### PR TITLE
cpufeatures: gracefully degrade on targets without a detection backend

### DIFF
--- a/cpufeatures/src/fallback.rs
+++ b/cpufeatures/src/fallback.rs
@@ -1,0 +1,30 @@
+//! Fallback for targets without a runtime CPU feature detection backend.
+//!
+//! On architectures cpufeatures has no detection support for (e.g.
+//! `powerpc`/`powerpc64`), runtime detection is unavailable, so feature checks
+//! fall back to compile-time target features only.
+
+// Evaluate the given `$body` expression if any of the supplied target features
+// are not enabled at compile time. Otherwise returns true.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __unless_target_features {
+    ($($tf:tt),+ => $body:expr ) => {
+        {
+            #[cfg(not(all($(target_feature=$tf,)*)))]
+            $body
+
+            #[cfg(all($(target_feature=$tf,)*))]
+            true
+        }
+    };
+}
+
+// Runtime CPU feature detection is unavailable on these targets.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __detect_target_features {
+    ($($tf:tt),+) => {
+        false
+    };
+}

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -22,13 +22,14 @@ mod x86;
 #[cfg(miri)]
 mod miri;
 
+#[cfg(not(miri))]
 #[cfg(not(any(
     target_arch = "aarch64",
     target_arch = "loongarch64",
     target_arch = "x86",
     target_arch = "x86_64"
 )))]
-compile_error!("This crate works only on `aarch64`, `loongarch64`, `x86`, and `x86-64` targets.");
+mod fallback;
 
 /// Create module with CPU feature detection code.
 #[macro_export]


### PR DESCRIPTION
cpufeatures emitted a hard `compile_error!` on any target other than
aarch64/loongarch64/x86/x86_64. This breaks otherwise-portable crates that
depend on cpufeatures unconditionally but only invoke `cpufeatures::new!`
under arch-gated cfgs (e.g. `#[cfg(target_arch = "x86_64")]`), so the
detection macros are never actually expanded on other architectures
(powerpc, powerpc64, etc.) — the crate simply fails to compile.

Add a `fallback` module providing the `__unless_target_features!` and
`__detect_target_features!` macros for those targets. Runtime detection is
unavailable there, so feature checks rely solely on compile-time target
features and otherwise report features as absent — mirroring the existing
"other OS" fallback already used within the aarch64 backend.
