### PR TITLE
zeroize_derive v1.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ on:
       'hex-literal-v*',
       'inout-v*',
       'sponge-cursor-v*',
-      'zeroize-v*'
+      'zeroize-v*',
+      'zeroize_derive-v*'
     ]
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.5.0-pre"
+version = "1.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -19,8 +19,8 @@ even WASM!
 """
 
 [dependencies]
-serde = { version = "1.0", default-features = false, optional = true }
-zeroize_derive = { version = "1.5.0-pre", optional = true }
+serde = { version = "1", default-features = false, optional = true }
+zeroize_derive = { version = "1.5", optional = true }
 
 [features]
 default = ["alloc"]

--- a/zeroize/LICENSE-MIT
+++ b/zeroize/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2025 The RustCrypto Project Developers
+Copyright (c) 2018-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/zeroize_derive/CHANGELOG.md
+++ b/zeroize_derive/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.5.0 (unreleased)
+## 1.5.0 (2026-06-12)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
 
+### Fixed
+- Unnecessary qualifications ([#1072])
+- Rust 1.92 warnings ([#1270])
+
 [#1149]: https://github.com/RustCrypto/utils/pull/1149
+[#1072]: https://github.com/RustCrypto/utils/pull/1072
+[#1270]: https://github.com/RustCrypto/utils/pull/1270
 
 ## 1.4.2 (2023-03-30)
 ### Changed

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroize_derive"
-version = "1.5.0-pre"
+version = "1.5.0"
 authors = ["The RustCrypto Project Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/zeroize_derive/LICENSE-MIT
+++ b/zeroize_derive/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2025 The RustCrypto Project Developers
+Copyright (c) 2019-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
## Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])

## Fixed
- Unnecessary qualifications ([#1072])
- Rust 1.92 warnings ([#1270])

[#1149]: https://github.com/RustCrypto/utils/pull/1149
[#1072]: https://github.com/RustCrypto/utils/pull/1072
[#1270]: https://github.com/RustCrypto/utils/pull/1270