### PR TITLE
zeroize: always enable AVX-512 support

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -29,7 +29,7 @@ std = ["alloc"]
 
 aarch64 = [] # NOTE: vestigial no-op feature; AArch64 support is always enabled now
 derive = ["zeroize_derive"]
-simd = [] # NOTE: MSRV 1.72
+simd = [] # NOTE: vestigial no-op feature; always enabled
 
 [lints]
 workspace = true

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -4,7 +4,6 @@ use crate::{Zeroize, optimization_barrier, volatile_write};
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
-
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
@@ -22,8 +21,6 @@ macro_rules! impl_zeroize_for_simd_register {
     };
 }
 
-impl_zeroize_for_simd_register!(__m128, __m128d, __m128i, __m256, __m256d, __m256i);
-
-// NOTE: MSRV 1.72
-#[cfg(feature = "simd")]
-impl_zeroize_for_simd_register!(__m512, __m512d, __m512i);
+impl_zeroize_for_simd_register!(
+    __m128, __m128d, __m128i, __m256, __m256d, __m256i, __m512, __m512d, __m512i
+);


### PR DESCRIPTION
It was previously gated under the `simd` feature due to MSRV 1.72.

Since we're now MSRV 1.85, it can always be enabled.