### PR TITLE
zeroize v1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zeroize"
-version = "1.9.0-pre"
+version = "1.9.0"
 dependencies = [
  "serde",
  "zeroize_derive",

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,17 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.9.0 (unreleased)
+## 1.9.0 (2026-06-12)
 ### Added
+- `Zeroizing` is now `repr(transparent)` ([#1253])
 - `optimization_barrier` function ([#1261])
+- `Zeroizing` now supports `?Sized` ([#1318])
 - `zeroize_stack` function ([#1331])
 
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
+- Replace `atomic_fence` with `optimization_barrier` ([#1252])
+- Bump `zeroize_derive` to v1.5 ([#1492])
+- Always enable AVX-512 support ([#1493])
 
 [#1149]: https://github.com/RustCrypto/utils/pull/1149
+[#1252]: https://github.com/RustCrypto/utils/pull/1252
+[#1253]: https://github.com/RustCrypto/utils/pull/1253
 [#1261]: https://github.com/RustCrypto/utils/pull/1261
+[#1318]: https://github.com/RustCrypto/utils/pull/1318
 [#1331]: https://github.com/RustCrypto/utils/pull/1331
+[#1492]: https://github.com/RustCrypto/utils/pull/1492
+[#1493]: https://github.com/RustCrypto/utils/pull/1493
 
 ## 1.8.2 (2025-09-29)
 ### Changed

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeroize"
-version = "1.9.0-pre"
+version = "1.9.0"
 authors = ["The RustCrypto Project Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
## Added
- `Zeroizing` is now `repr(transparent)` ([#1253])
- `optimization_barrier` function ([#1261])
- `Zeroizing` now supports `?Sized` ([#1318])
- `zeroize_stack` function ([#1331])

## Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1149])
- Replace `atomic_fence` with `optimization_barrier` ([#1252])
- Bump `zeroize_derive` to v1.5 ([#1492])
- Always enable AVX-512 support ([#1493])

[#1149]: https://github.com/RustCrypto/utils/pull/1149
[#1252]: https://github.com/RustCrypto/utils/pull/1252
[#1253]: https://github.com/RustCrypto/utils/pull/1253
[#1261]: https://github.com/RustCrypto/utils/pull/1261
[#1318]: https://github.com/RustCrypto/utils/pull/1318
[#1331]: https://github.com/RustCrypto/utils/pull/1331
[#1492]: https://github.com/RustCrypto/utils/pull/1492
[#1493]: https://github.com/RustCrypto/utils/pull/1493