### PR TITLE
zeroize: replace derived Debug with opaque impl for Zeroizing

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -599,9 +599,15 @@ impl Zeroize for CString {
 ///
 /// `Zeroizing<T>` is defined with `repr(transparent)`, which means it is
 /// guaranteed to have the same physical representation as the underlying type.
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Default, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Zeroizing<Z: Zeroize + ?Sized>(Z);
+
+impl<Z: Zeroize + ?Sized> core::fmt::Debug for Zeroizing<Z> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Zeroizing").finish_non_exhaustive()
+    }
+}
 
 impl<Z> Zeroizing<Z>
 where


### PR DESCRIPTION
Closes #825

`Zeroizing<Z>` derives `Debug` right now, which just prints the inner value. Saw this while working on a secret vault project and it was a bit surprising — the whole point of the wrapper is to protect the data.

Going with @tarcieri's suggestion from the issue:

```rust
impl<Z: Zeroize + ?Sized> core::fmt::Debug for Zeroizing<Z> {
    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
        f.debug_struct("Zeroizing").finish_non_exhaustive()
    }
}
```

Now prints `Zeroizing { .. }`. Also relaxes the bound from `Z: Debug` to `Z: Zeroize + ?Sized` so it works for all wrappable types.

Reference project if curious: [MeissnerSeal](https://github.com/umudique/meissnerseal)