### PR TITLE
zeroize_derive: fix derive requiring Zeroize trait in scope

### DIFF
--- a/zeroize_derive/src/lib.rs
+++ b/zeroize_derive/src/lib.rs
@@ -46,7 +46,7 @@ fn derive_zeroize_impl(input: DeriveInput) -> TokenStream {
             .auto_params
             .iter()
             .map(|type_param| -> WherePredicate {
-                parse_quote! {#type_param: Zeroize}
+                parse_quote! {#type_param: ::zeroize::Zeroize}
             })
             .collect(),
     };
@@ -545,6 +545,32 @@ mod tests {
             },
             quote! {
                 impl<T> ::zeroize::Zeroize for Z<T> where T: MyTrait {
+                    fn zeroize(&mut self) {
+                        match self {
+                            #[allow(unused_variables, unused_assignments)]
+                            Z(__zeroize_field_0) => {
+                                __zeroize_field_0.zeroize()
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn zeroize_infers_fully_qualified_bound() {
+        // The auto-inferred `T: Zeroize` bound must reference the trait by its
+        // full `::zeroize::Zeroize` path, so deriving works at a call site that
+        // does not have the `Zeroize` trait imported into scope.
+        test_derive(
+            derive_zeroize_impl,
+            quote! {
+                struct Z<T>(T);
+            },
+            quote! {
+                impl<T> ::zeroize::Zeroize for Z<T> where T: ::zeroize::Zeroize {
                     fn zeroize(&mut self) {
                         match self {
                             #[allow(unused_variables, unused_assignments)]


### PR DESCRIPTION
Deriving `Zeroize` on a generic type failed unless the caller had `use zeroize::Zeroize;` in scope:
```
error[E0405]: cannot find trait `Zeroize` in this scope
```

The auto-generated `where T: Zeroize` bound used the bare trait name, which resolves at the call site. Everywhere else the derive writes the full `::zeroize::Zeroize` path — the bound was the one place that didn't.

Fix the bound to use the full path so deriving works without importing the trait.

Tries to address #1271