### PR TITLE
cpufeatures: fix `avx` detection

### DIFF
--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (UNRELEASED)
+### Fixed
+- Detection of the `avx` target feature ([#1511])
+
+[#1511]: https://github.com/RustCrypto/utils/pull/1511
+
 ## 0.3.0 (2026-02-05)
 ### Added
 - `x86` support for: `sha512`, `sm3`, `sm4` ([#1181])

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -113,7 +113,7 @@ __expand_check_macro! {
     ("sse4.2", "", 0, ecx, 20),
     ("popcnt", "", 0, ecx, 23),
     ("aes", "", 0, ecx, 25),
-    ("avx", "xmm", 0, ecx, 28),
+    ("avx", "ymm", 0, ecx, 28),
     ("rdrand", "", 0, ecx, 30),
 
     ("mmx", "", 0, edx, 23),


### PR DESCRIPTION
Check YMM register support instead of XMM.

Reported in #1510