### PR TITLE
cpufeatures: Enable compile time target features under Miri

### DIFF
--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detection of the `avx` target feature ([#1511])
 - Use `::MAX` constant instead of deprecated `::max_value()` associated method ([#1515])
 
+### Changed
+- Use compile-time target feature detection under Miri ([#1513])
+
 [#1511]: https://github.com/RustCrypto/utils/pull/1511
 [#1515]: https://github.com/RustCrypto/utils/pull/1515
+[#1513]: https://github.com/RustCrypto/utils/pull/1513
 
 ## 0.3.0 (2026-02-05)
 ### Added

--- a/cpufeatures/src/miri.rs
+++ b/cpufeatures/src/miri.rs
@@ -7,7 +7,7 @@
 #[doc(hidden)]
 macro_rules! __unless_target_features {
     ($($tf:tt),+ => $body:expr ) => {
-        false
+        cfg!(all($(target_feature = $tf,)*))
     };
 }
 


### PR DESCRIPTION
Miri already supports a lot of intrinsics: https://github.com/rust-lang/miri/tree/master/src/intrinsics so I think it make sense to return `true` for compile time enabled features, so if someone runs `RUSTFLAGS=+avx2 cargo miri run` it will actually enable those features, as the user explicitly asked for them

Also added tests to show that it works outside and inside of miri

tested everything locally too(including loongarch64 via qemu)