### PR TITLE
Use `::MAX` constant instead of deprecated `::max_value()` associated method

### DIFF
--- a/cpufeatures/CHANGELOG.md
+++ b/cpufeatures/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.3.1 (UNRELEASED)
 ### Fixed
 - Detection of the `avx` target feature ([#1511])
+- Use `::MAX` constant instead of deprecated `::max_value()` associated method ([#1515])
 
 [#1511]: https://github.com/RustCrypto/utils/pull/1511
+[#1515]: https://github.com/RustCrypto/utils/pull/1515
 
 ## 0.3.0 (2026-02-05)
 ### Added

--- a/cpufeatures/src/lib.rs
+++ b/cpufeatures/src/lib.rs
@@ -37,7 +37,7 @@ macro_rules! new {
         mod $mod_name {
             use core::sync::atomic::{AtomicU8, Ordering::Relaxed};
 
-            const UNINIT: u8 = u8::max_value();
+            const UNINIT: u8 = u8::MAX;
             static STORAGE: AtomicU8 = AtomicU8::new(UNINIT);
 
             /// Initialization token


### PR DESCRIPTION
Fixes https://github.com/RustCrypto/utils/issues/1514