### PR TITLE
zeroize: avoid double-zeroizing Vec's initialized elements

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -526,14 +526,17 @@ where
     /// Ensures the entire capacity of the `Vec` is zeroed. Cannot ensure that
     /// previous reallocations did not leave values on the heap.
     fn zeroize(&mut self) {
+        // Zero the spare (uninitialized) capacity first, i.e. everything
+        // beyond `len`. This must happen before `clear()` resets `len` to 0,
+        // otherwise `spare_capacity_mut()` would cover the whole allocation
+        // and re-zero the initialized elements a second time below.
+        self.spare_capacity_mut().zeroize();
+
         // Zeroize all the initialized elements.
         self.iter_mut().zeroize();
 
-        // Set the Vec's length to 0 and drop all the elements.
+        // Set the Vec's length to 0 and drop all the (already-zeroized) elements.
         self.clear();
-
-        // Zero the full capacity of `Vec`.
-        self.spare_capacity_mut().zeroize();
     }
 }
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -523,7 +523,7 @@ where
 {
     /// "Best effort" zeroization for `Vec`.
     ///
-    /// Ensures the entire capacity of the `Vec` is zeroed. Cannot ensure that
+    /// Call `Zeroize` on all `Vec` elements and spare capacity. Cannot ensure that
     /// previous reallocations did not leave values on the heap.
     fn zeroize(&mut self) {
         // Zero the spare (uninitialized) capacity first, i.e. everything


### PR DESCRIPTION
Fixes #1524.

`Vec<Z>::zeroize()` currently:
1. Zeroizes the initialized elements via `iter_mut()`
2. Calls `clear()`, which resets `len` to 0
3. Zeroizes `spare_capacity_mut()`

Since `spare_capacity_mut()` covers everything beyond `len`, and `len` is already 0 by step 3, it covers the *entire* allocation - re-zeroizing the elements that were already zeroized in step 1.

This PR reorders the operations so the spare (truly uninitialized) capacity is zeroed first, while `len` still reflects the real element count. The two zeroing passes then cover disjoint ranges instead of overlapping.

Behavior is unchanged - the full allocation is still zeroed - only the redundant work is removed. Verified locally with `cargo test --features alloc`: all existing tests pass, including `zeroize_vec_entire_capacity`, which specifically checks that no partially-zeroized or uninitialized data survives (this test's ordering-sensitive assertions still hold under the new order - traced through manually and confirmed via the test run).