### PR TITLE
zeroize: remove internal use of `optimization_barrier`

### DIFF
--- a/zeroize/src/aarch64.rs
+++ b/zeroize/src/aarch64.rs
@@ -1,6 +1,6 @@
 //! [`Zeroize`] impls for ARM64 SIMD registers.
 
-use crate::{Zeroize, optimization_barrier, volatile_write};
+use crate::{Zeroize, volatile_write};
 
 use core::arch::aarch64::*;
 
@@ -11,7 +11,6 @@ macro_rules! impl_zeroize_for_simd_register {
                 #[inline]
                 fn zeroize(&mut self) {
                     volatile_write(self, unsafe { core::mem::zeroed() });
-                    optimization_barrier(self);
                 }
             }
         )+

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -273,7 +273,6 @@ where
 {
     fn zeroize(&mut self) {
         volatile_write(self, Z::default());
-        optimization_barrier(self);
     }
 }
 
@@ -307,7 +306,6 @@ macro_rules! impl_zeroize_for_non_zero {
                         None => unreachable!(),
                     };
                     volatile_write(self, ONE);
-                    optimization_barrier(self);
                 }
             }
         )+
@@ -401,8 +399,6 @@ where
         // already done semantically. Any value which needed to be dropped will have been
         // done so by take().
         unsafe { ptr::write_volatile(self, None) }
-
-        optimization_barrier(self);
     }
 }
 
@@ -415,10 +411,8 @@ impl<Z> ZeroizeOnDrop for Option<Z> where Z: ZeroizeOnDrop {}
 /// [`MaybeUninit`] removes all invariants.
 impl<Z> Zeroize for MaybeUninit<Z> {
     fn zeroize(&mut self) {
-        // Safety:
-        // `MaybeUninit` is valid for any byte pattern, including zeros.
+        // SAFETY: `MaybeUninit` is valid for any byte pattern, including zeros.
         unsafe { ptr::write_volatile(self, MaybeUninit::zeroed()) }
-        optimization_barrier(self);
     }
 }
 
@@ -444,7 +438,6 @@ impl<Z> Zeroize for [MaybeUninit<Z>] {
         // and 0 is a valid value for `MaybeUninit<Z>`
         // The memory of the slice should not wrap around the address space.
         unsafe { volatile_set(ptr, MaybeUninit::zeroed(), size) }
-        optimization_barrier(self);
     }
 }
 
@@ -470,7 +463,6 @@ where
         // `self.len()` is also not larger than an `isize`, because of the assertion above.
         // The memory of the slice should not wrap around the address space.
         unsafe { volatile_set(self.as_mut_ptr(), Z::default(), self.len()) };
-        optimization_barrier(self);
     }
 }
 
@@ -826,7 +818,6 @@ pub unsafe fn zeroize_flat_type<F: Sized>(data: *mut F) {
     unsafe {
         volatile_set(data.cast::<u8>(), 0, size);
     }
-    optimization_barrier(&data);
 }
 
 /// Internal module used as support for `AssertZeroizeOnDrop`.

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -1,6 +1,6 @@
 //! [`Zeroize`] impls for x86 SIMD registers
 
-use crate::{Zeroize, optimization_barrier, volatile_write};
+use crate::{Zeroize, volatile_write};
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
@@ -14,7 +14,6 @@ macro_rules! impl_zeroize_for_simd_register {
                 #[inline]
                 fn zeroize(&mut self) {
                     volatile_write(self, unsafe { core::mem::zeroed() });
-                    optimization_barrier(self);
                 }
             }
         )*


### PR DESCRIPTION
We replaced our previous use of compiler fences with `optimization_barrier` under the assumption it would be a zero-cost abstraction, but per #1504 that is not the case as it caused a performance regression.

The use of either of these was effectively redundant and a belt-and-suspenders defense as volatile writes alone are already sufficient to guarantee zeroization will not be removed by the compiler.

This removes the use of `optimization_barrier` to restore the previous performance.

Closes #1504.